### PR TITLE
Add release pipeline with container image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+bin/
+node_modules/
+.claude/
+.github/
+.git/
+tests/
+coverage*
+*.test
+*.out
+config.*.toml
+docker-compose.yml
+compose/
+CHANGELOG.md
+_project/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: taiki-e/create-gh-release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          changelog: CHANGELOG.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM oven/bun:1 AS web
+WORKDIR /src/web
+COPY web/package.json web/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY web/ .
+RUN bun run build
+
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=web /src/web/scalar/scalar.js /src/web/scalar/scalar.js
+COPY --from=web /src/web/scalar/scalar.css /src/web/scalar/scalar.css
+RUN CGO_ENABLED=0 go build -o /herald ./cmd/server
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=build /herald /usr/local/bin/herald
+EXPOSE 8080
+ENTRYPOINT ["herald"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,11 +61,18 @@ func (c *Config) ShutdownTimeoutDuration() time.Duration {
 	return d
 }
 
-// Load reads the base config, applies any environment overlay, and finalizes all values.
+// Load reads the base config (if present), applies any environment overlay,
+// and finalizes all values. If no config.toml exists, defaults and environment
+// variables provide all configuration.
 func Load() (*Config, error) {
-	cfg, err := load(BaseConfigFile)
-	if err != nil {
-		return nil, err
+	cfg := &Config{}
+
+	if _, err := os.Stat(BaseConfigFile); err == nil {
+		loaded, err := load(BaseConfigFile)
+		if err != nil {
+			return nil, err
+		}
+		cfg = loaded
 	}
 
 	if path := overlayPath(); path != "" {

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -144,13 +144,27 @@ func TestLoadEnvVarOverrides(t *testing.T) {
 	}
 }
 
-func TestLoadMissingConfigFile(t *testing.T) {
+func TestLoadNoConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	_, err := config.Load()
-	if err == nil {
-		t.Fatal("expected error for missing config file")
+	t.Setenv("HERALD_DB_NAME", "testdb")
+	t.Setenv("HERALD_DB_USER", "testuser")
+	t.Setenv("HERALD_STORAGE_CONNECTION_STRING", "conn")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load without config.toml failed: %v", err)
+	}
+
+	if cfg.Server.Port != 8080 {
+		t.Errorf("server port default: got %d, want 8080", cfg.Server.Port)
+	}
+	if cfg.Database.Name != "testdb" {
+		t.Errorf("db name from env: got %s, want testdb", cfg.Database.Name)
+	}
+	if cfg.Storage.ConnectionString != "conn" {
+		t.Errorf("storage conn from env: got %s, want conn", cfg.Storage.ConnectionString)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the release infrastructure for Herald as a containerized web service.

## Changes

- **Dockerfile**: Multi-stage build (Bun/Vite web assets → Go binary → Alpine runtime)
- **`.github/workflows/release.yml`**: Triggers on `v*` tag push — builds and pushes image to `ghcr.io/JaimeStill/herald`, creates GitHub Release from CHANGELOG
- **`.dockerignore`**: Keeps build context lean
- **Config loading**: `config.toml` now optional — containers configure entirely via `HERALD_*` env vars, defaults fill the rest
- **Test update**: `TestLoadNoConfigFile` verifies env-var-only configuration

Image tag scheme:
- Dev releases: `ghcr.io/JaimeStill/herald:v0.1.0-dev.1.4`
- Phase releases: `ghcr.io/JaimeStill/herald:v0.1.0` + `:latest`