### PR TITLE
Add infrastructure assembly, API module, and server entry point

### DIFF
--- a/.claude/context/guides/.archive/7-infrastructure-api-server.md
+++ b/.claude/context/guides/.archive/7-infrastructure-api-server.md
@@ -1,0 +1,482 @@
+# 7 - Infrastructure Assembly, API Module, and Server Entry Point
+
+## Problem Context
+
+Issues #4, #5, and #6 established Herald's foundational packages — lifecycle coordination, database toolkit, storage abstraction, middleware, module/routing, handlers, and configuration. These are all disconnected pieces. This issue wires them together into the Infrastructure assembly, API module shell, and server entry point so Herald becomes a running Go web service with health/readiness probes and graceful shutdown.
+
+## Architecture Approach
+
+All patterns adapted from agent-lab's Layered Composition Architecture:
+
+- **Infrastructure** assembles shared subsystems (lifecycle, logger, database, storage) in a single struct. `New()` is cold start (creates subsystems, no connections). `Start()` is hot start (registers lifecycle hooks that establish connections).
+- **API Module** follows three-step initialization: Runtime (infrastructure + API config) → Domain (empty placeholder) → Module (mux + middleware). Returns a `*module.Module` for the router.
+- **Server** coordinates the full lifecycle: config load → infrastructure create → modules create → router build → HTTP server create (cold start) → infrastructure start → HTTP start → wait for readiness → block on signal → shutdown.
+
+## Implementation
+
+### Step 1: Add Pagination Config to APIConfig
+
+**`internal/config/api.go`** — add pagination env var mapping, field, and wiring:
+
+```go
+// Add import
+"github.com/JaimeStill/herald/pkg/pagination"
+
+// Add env var mapping (alongside corsEnv and openAPIEnv)
+var paginationEnv = &pagination.ConfigEnv{
+	DefaultPageSize: "HERALD_PAGINATION_DEFAULT_PAGE_SIZE",
+	MaxPageSize:     "HERALD_PAGINATION_MAX_PAGE_SIZE",
+}
+
+// Add Pagination field to APIConfig
+type APIConfig struct {
+	BasePath   string                `toml:"base_path"`
+	CORS       middleware.CORSConfig `toml:"cors"`
+	OpenAPI    openapi.Config        `toml:"openapi"`
+	Pagination pagination.Config     `toml:"pagination"`
+}
+```
+
+Update `Finalize` — add after the OpenAPI finalize call:
+
+```go
+if err := c.Pagination.Finalize(paginationEnv); err != nil {
+	return fmt.Errorf("pagination: %w", err)
+}
+```
+
+Update `Merge` — add at the end:
+
+```go
+c.Pagination.Merge(&overlay.Pagination)
+```
+
+No changes needed to `loadDefaults` or `loadEnv` — pagination defaults are handled by `pagination.Config.Finalize`.
+
+**`config.toml`** — add at the end of the `[api]` section (before any non-api sections):
+
+```toml
+[api.pagination]
+default_page_size = 20
+max_page_size = 100
+```
+
+### Step 2: Infrastructure Assembly
+
+**Delete** `internal/infrastructure/doc.go`
+
+**Create `internal/infrastructure/infrastructure.go`:**
+
+```go
+package infrastructure
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/database"
+	"github.com/JaimeStill/herald/pkg/lifecycle"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type Infrastructure struct {
+	Lifecycle *lifecycle.Coordinator
+	Logger    *slog.Logger
+	Database  database.System
+	Storage   storage.System
+}
+
+func New(cfg *config.Config) (*Infrastructure, error) {
+	lc := lifecycle.New()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	db, err := database.New(&cfg.Database, logger)
+	if err != nil {
+		return nil, fmt.Errorf("database init failed: %w", err)
+	}
+
+	store, err := storage.New(&cfg.Storage, logger)
+	if err != nil {
+		return nil, fmt.Errorf("storage init failed: %w", err)
+	}
+
+	return &Infrastructure{
+		Lifecycle: lc,
+		Logger:    logger,
+		Database:  db,
+		Storage:   store,
+	}, nil
+}
+
+func (i *Infrastructure) Start() error {
+	if err := i.Database.Start(i.Lifecycle); err != nil {
+		return fmt.Errorf("database start failed: %w", err)
+	}
+	if err := i.Storage.Start(i.Lifecycle); err != nil {
+		return fmt.Errorf("storage start failed: %w", err)
+	}
+	return nil
+}
+```
+
+### Step 3: API Module
+
+**Delete** `internal/api/doc.go`
+
+**Create `internal/api/runtime.go`:**
+
+```go
+package api
+
+import (
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/pagination"
+)
+
+type Runtime struct {
+	*infrastructure.Infrastructure
+	Pagination pagination.Config
+}
+
+func NewRuntime(cfg *config.Config, infra *infrastructure.Infrastructure) *Runtime {
+	return &Runtime{
+		Infrastructure: &infrastructure.Infrastructure{
+			Lifecycle: infra.Lifecycle,
+			Logger:    infra.Logger.With("module", "api"),
+			Database:  infra.Database,
+			Storage:   infra.Storage,
+		},
+		Pagination: cfg.API.Pagination,
+	}
+}
+```
+
+**Create `internal/api/domain.go`:**
+
+```go
+package api
+
+type Domain struct{}
+
+func NewDomain(runtime *Runtime) *Domain {
+	return &Domain{}
+}
+```
+
+**Create `internal/api/routes.go`:**
+
+```go
+package api
+
+import (
+	"net/http"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/openapi"
+)
+
+func registerRoutes(
+	mux *http.ServeMux,
+	spec *openapi.Spec,
+	domain *Domain,
+	cfg *config.Config,
+) {
+	// Domain route groups registered here as systems are implemented.
+}
+```
+
+**Create `internal/api/api.go`:**
+
+```go
+package api
+
+import (
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/middleware"
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/pkg/openapi"
+	"net/http"
+)
+
+func NewModule(cfg *config.Config, infra *infrastructure.Infrastructure) (*module.Module, error) {
+	runtime := NewRuntime(cfg, infra)
+	domain := NewDomain(runtime)
+
+	spec := openapi.NewSpec(cfg.API.OpenAPI.Title, cfg.Version)
+	spec.SetDescription(cfg.API.OpenAPI.Description)
+
+	mux := http.NewServeMux()
+	registerRoutes(mux, spec, domain, cfg)
+
+	specBytes, err := openapi.MarshalJSON(spec)
+	if err != nil {
+		return nil, err
+	}
+	mux.HandleFunc("GET /openapi.json", openapi.ServeSpec(specBytes))
+
+	m := module.New(cfg.API.BasePath, mux)
+	m.Use(middleware.CORS(&cfg.API.CORS))
+	m.Use(middleware.Logger(runtime.Infrastructure.Logger))
+
+	return m, nil
+}
+```
+
+### Step 4: Server Entry Point
+
+**Create `cmd/server/http.go`:**
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/lifecycle"
+)
+
+type httpServer struct {
+	http            *http.Server
+	logger          *slog.Logger
+	shutdownTimeout time.Duration
+}
+
+func newHTTPServer(cfg *config.ServerConfig, handler http.Handler, logger *slog.Logger) *httpServer {
+	return &httpServer{
+		http: &http.Server{
+			Addr:         cfg.Addr(),
+			Handler:      handler,
+			ReadTimeout:  cfg.ReadTimeoutDuration(),
+			WriteTimeout: cfg.WriteTimeoutDuration(),
+		},
+		logger:          logger.With("system", "http"),
+		shutdownTimeout: cfg.ShutdownTimeoutDuration(),
+	}
+}
+
+func (s *httpServer) Start(lc *lifecycle.Coordinator) error {
+	go func() {
+		s.logger.Info("server listening", "addr", s.http.Addr)
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("server error", "error", err)
+		}
+	}()
+
+	lc.OnShutdown(func() {
+		<-lc.Context().Done()
+		s.logger.Info("shutting down server")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+
+		if err := s.http.Shutdown(shutdownCtx); err != nil {
+			s.logger.Error("server shutdown error", "error", err)
+		} else {
+			s.logger.Info("server shutdown complete")
+		}
+	})
+
+	return nil
+}
+```
+
+**Create `cmd/server/modules.go`:**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/JaimeStill/herald/internal/api"
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/middleware"
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/web/scalar"
+)
+
+type Modules struct {
+	API    *module.Module
+	Scalar *module.Module
+}
+
+func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modules, error) {
+	apiModule, err := api.NewModule(cfg, infra)
+	if err != nil {
+		return nil, err
+	}
+
+	scalarModule := scalar.NewModule("/scalar")
+	scalarModule.Use(middleware.Logger(infra.Logger))
+
+	return &Modules{
+		API:    apiModule,
+		Scalar: scalarModule,
+	}, nil
+}
+
+func (m *Modules) Mount(router *module.Router) {
+	router.Mount(m.API)
+	router.Mount(m.Scalar)
+}
+
+func buildRouter(infra *infrastructure.Infrastructure) *module.Router {
+	router := module.NewRouter()
+
+	router.HandleNative("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	router.HandleNative("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !infra.Lifecycle.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	})
+
+	return router
+}
+```
+
+**Create `cmd/server/server.go`:**
+
+```go
+package main
+
+import (
+	"time"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+)
+
+type Server struct {
+	infra   *infrastructure.Infrastructure
+	modules *Modules
+	http    *httpServer
+}
+
+func NewServer(cfg *config.Config) (*Server, error) {
+	infra, err := infrastructure.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	modules, err := NewModules(infra, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	router := buildRouter(infra)
+	modules.Mount(router)
+
+	infra.Logger.Info(
+		"server initialized",
+		"addr", cfg.Server.Addr(),
+		"version", cfg.Version,
+	)
+
+	return &Server{
+		infra:   infra,
+		modules: modules,
+		http:    newHTTPServer(&cfg.Server, router, infra.Logger),
+	}, nil
+}
+
+func (s *Server) Start() error {
+	s.infra.Logger.Info("starting service")
+
+	if err := s.infra.Start(); err != nil {
+		return err
+	}
+
+	if err := s.http.Start(s.infra.Lifecycle); err != nil {
+		return err
+	}
+
+	go func() {
+		s.infra.Lifecycle.WaitForStartup()
+		s.infra.Logger.Info("all subsystems ready")
+	}()
+
+	return nil
+}
+
+func (s *Server) Shutdown(timeout time.Duration) error {
+	s.infra.Logger.Info("initiating shutdown")
+	return s.infra.Lifecycle.Shutdown(timeout)
+}
+```
+
+**Replace `cmd/server/main.go`:**
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/JaimeStill/herald/internal/config"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal("config load failed:", err)
+	}
+
+	srv, err := NewServer(cfg)
+	if err != nil {
+		log.Fatal("service init failed:", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		log.Fatal("service start failed:", err)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	<-sigChan
+
+	if err := srv.Shutdown(cfg.ShutdownTimeoutDuration()); err != nil {
+		log.Fatal("shutdown failed:", err)
+	}
+
+	log.Println("service stopped gracefully")
+}
+```
+
+## Validation Criteria
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `go mod tidy` produces no changes
+- [ ] `docker compose up -d` starts PostgreSQL and Azurite
+- [ ] `mise run dev` starts the server successfully
+- [ ] Server connects to PostgreSQL on startup (log: "database connection established")
+- [ ] Server initializes storage container on startup (log: "storage container ready")
+- [ ] `GET /healthz` returns 200 with `{"status":"ok"}`
+- [ ] `GET /readyz` returns 200 with `{"status":"ready"}` after startup
+- [ ] `GET /api/openapi.json` returns the OpenAPI spec
+- [ ] `GET /scalar` serves the Scalar API reference UI
+- [ ] SIGINT triggers graceful shutdown with ordered teardown logs

--- a/.claude/context/sessions/7-infrastructure-api-server.md
+++ b/.claude/context/sessions/7-infrastructure-api-server.md
@@ -1,0 +1,51 @@
+# 7 - Infrastructure Assembly, API Module, and Server Entry Point
+
+## Summary
+
+Wired all foundational packages (lifecycle, database, storage, middleware, module/routing, config) into the Infrastructure assembly, API module shell, and server entry point. Herald is now a running Go web service with health/readiness probes, OpenAPI spec endpoint, Scalar API reference UI, and graceful shutdown following the Layered Composition Architecture from agent-lab.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Server struct location | `cmd/server/server.go` | Matches agent-lab encapsulation; keeps `main.go` minimal |
+| Logger creation | Inline in `infrastructure.New()` | No logging config needed yet; avoids unnecessary package |
+| Domain struct | Empty placeholder | Domain systems added in Objectives #2 and #3 |
+| Health response format | JSON `{"status":"ok"}` | Matches acceptance criteria; consistent with API responses |
+| Scalar module | Wired in `cmd/server/modules.go` | Already implemented in `web/scalar/`; provides API documentation UI |
+| Pagination config | Added to `APIConfig` | Required by API Runtime for domain system construction |
+
+## Files Modified
+
+- `internal/config/api.go` — added pagination config field, env mapping, finalize/merge wiring
+- `config.toml` — added `[api.pagination]` section
+- `internal/infrastructure/infrastructure.go` — new (replaced `doc.go` stub)
+- `internal/api/api.go` — new (replaced `doc.go` stub)
+- `internal/api/runtime.go` — new
+- `internal/api/domain.go` — new
+- `internal/api/routes.go` — new
+- `cmd/server/main.go` — replaced stub with minimal entry point
+- `cmd/server/server.go` — new (Server struct with lifecycle coordination)
+- `cmd/server/http.go` — new (HTTP server wrapper with shutdown hook)
+- `cmd/server/modules.go` — new (module assembly, health/readiness endpoints)
+- `tests/infrastructure/infrastructure_test.go` — new
+- `tests/api/api_test.go` — new
+- `tests/config/config_test.go` — added pagination tests
+
+## Patterns Established
+
+- **Infrastructure assembly**: `New()` for cold start (no connections), `Start()` for hot start (lifecycle hooks)
+- **API module composition**: Runtime → Domain → Module with middleware
+- **Server lifecycle**: `NewServer()` → `Start()` → signal wait → `Shutdown()` in separate files (`server.go`, `http.go`, `modules.go`, `main.go`)
+- **Health/readiness probes**: native router handlers, JSON responses, readiness gated by `lifecycle.Ready()`
+
+## Validation Results
+
+- `go build ./...` — pass
+- `go vet ./...` — pass
+- `go mod tidy` — no changes
+- `go test ./tests/...` — 14 packages, all pass
+- `mise run dev` — server starts, connects to PostgreSQL and Azurite, all subsystems ready
+- `GET /healthz` — 200 `{"status":"ok"}`
+- `GET /readyz` — 200 `{"status":"ready"}`
+- SIGINT — graceful shutdown with ordered teardown

--- a/.claude/plans/immutable-swinging-star.md
+++ b/.claude/plans/immutable-swinging-star.md
@@ -1,0 +1,117 @@
+# Issue #7 — Infrastructure Assembly, API Module, and Server Entry Point
+
+## Context
+
+This is the final sub-issue of Objective #1 (Project Scaffolding, Configuration, and Service Skeleton). Issues #4, #5, and #6 established the foundational packages — lifecycle coordination, database toolkit, storage abstraction, middleware, module/routing, handlers, and configuration. This issue wires everything together into a running Go web service with health/readiness probes and graceful shutdown.
+
+All patterns are adapted from `~/code/agent-lab` (infrastructure, API module, server lifecycle).
+
+## Implementation
+
+### Step 1: Add Pagination to APIConfig
+
+**File: `internal/config/api.go`** (modify)
+
+Add pagination config to `APIConfig` so the API Runtime can pass it to domain systems. Add the `paginationEnv` var, `Pagination pagination.Config` field, and wire it through `Finalize`, `Merge`, and `loadDefaults`.
+
+**File: `config.toml`** (modify)
+
+Add `[api.pagination]` section with `default_page_size = 20` and `max_page_size = 100`.
+
+### Step 2: Infrastructure Assembly
+
+**File: `internal/infrastructure/infrastructure.go`** (new, replaces `doc.go`)
+
+Adapts `agent-lab/internal/infrastructure/infrastructure.go`:
+
+- `Infrastructure` struct: `Lifecycle *lifecycle.Coordinator`, `Logger *slog.Logger`, `Database database.System`, `Storage storage.System`
+- `New(cfg *config.Config) (*Infrastructure, error)` — creates lifecycle coordinator, logger (`slog.TextHandler` to stderr), database system, storage system. Cold start only (no connections).
+- `Start() error` — calls `Database.Start(lc)` then `Storage.Start(lc)`. Hot start (registers lifecycle hooks).
+
+Delete `internal/infrastructure/doc.go` stub.
+
+### Step 3: API Module
+
+Four files in `internal/api/`, replacing the `doc.go` stub:
+
+**File: `internal/api/runtime.go`** (new)
+
+- `Runtime` struct embedding `*infrastructure.Infrastructure` + `Pagination pagination.Config`
+- `NewRuntime(cfg *config.Config, infra *Infrastructure) *Runtime` — creates module-scoped logger with `infra.Logger.With("module", "api")`
+
+**File: `internal/api/domain.go`** (new)
+
+- `Domain` struct — empty for now (domain systems added in Objectives #2 and #3)
+- `NewDomain(runtime *Runtime) *Domain` — returns empty Domain
+
+**File: `internal/api/routes.go`** (new)
+
+- `registerRoutes(mux *http.ServeMux, spec *openapi.Spec, domain *Domain, cfg *config.Config)` — no-op for now (domain handlers registered when domains are implemented)
+
+**File: `internal/api/api.go`** (new)
+
+Adapts `agent-lab/internal/api/api.go`:
+
+- `NewModule(cfg *config.Config, infra *Infrastructure) (*module.Module, error)` — creates Runtime, Domain, OpenAPI spec, mux, registers routes, marshals OpenAPI JSON, serves `/openapi.json`, creates module with middleware (CORS then Logger)
+
+Delete `internal/api/doc.go` stub.
+
+### Step 4: Server Entry Point
+
+Three files in `cmd/server/`:
+
+**File: `cmd/server/http.go`** (new)
+
+Adapts `agent-lab/cmd/server/http.go`:
+
+- `httpServer` struct wrapping `*http.Server` with logger and shutdown timeout
+- `newHTTPServer(cfg *ServerConfig, handler http.Handler, logger *slog.Logger) *httpServer`
+- `Start(lc *lifecycle.Coordinator) error` — ListenAndServe in goroutine, registers shutdown hook that blocks on `<-lc.Context().Done()` then calls `http.Server.Shutdown(ctx)`
+
+**File: `cmd/server/modules.go`** (new)
+
+Adapts `agent-lab/cmd/server/modules.go`:
+
+- `Modules` struct with `API *module.Module`
+- `NewModules(infra *Infrastructure, cfg *Config) (*Modules, error)` — creates API module
+- `Mount(router *module.Router)` — mounts API module
+- `buildRouter(infra *Infrastructure) *module.Router` — creates router, registers native health/readiness handlers:
+  - `GET /healthz` → 200 JSON `{"status":"ok"}` (always)
+  - `GET /readyz` → 200 JSON `{"status":"ready"}` when `infra.Lifecycle.Ready()` is true, 503 JSON `{"status":"not ready"}` otherwise
+
+**File: `cmd/server/main.go`** (modify — replace current stub)
+
+Adapts `agent-lab/cmd/server/main.go` + `server.go`:
+
+- `Server` struct with infra, modules, http fields
+- `NewServer(cfg) (*Server, error)` — cold start: create infrastructure, modules, router, HTTP server
+- `Start() error` — hot start: `infra.Start()`, `http.Start(lc)`, async `WaitForStartup` logging
+- `Shutdown(timeout) error` — delegates to lifecycle coordinator
+- `main()` — Load config → NewServer → Start → wait for SIGINT/SIGTERM → Shutdown
+
+## Files Summary
+
+| File | Action | Reference |
+|------|--------|-----------|
+| `internal/config/api.go` | Modify | Add pagination config |
+| `config.toml` | Modify | Add `[api.pagination]` section |
+| `internal/infrastructure/doc.go` | Delete | Replaced by implementation |
+| `internal/infrastructure/infrastructure.go` | Create | `agent-lab/internal/infrastructure/infrastructure.go` |
+| `internal/api/doc.go` | Delete | Replaced by implementation |
+| `internal/api/runtime.go` | Create | `agent-lab/internal/api/runtime.go` |
+| `internal/api/domain.go` | Create | `agent-lab/internal/api/domain.go` |
+| `internal/api/routes.go` | Create | `agent-lab/internal/api/routes.go` |
+| `internal/api/api.go` | Create | `agent-lab/internal/api/api.go` |
+| `cmd/server/http.go` | Create | `agent-lab/cmd/server/http.go` |
+| `cmd/server/modules.go` | Create | `agent-lab/cmd/server/modules.go` |
+| `cmd/server/main.go` | Replace | `agent-lab/cmd/server/main.go` + `server.go` |
+
+## Validation
+
+- `go build ./...` and `go vet ./...` pass
+- `go mod tidy` produces no changes
+- `docker compose up -d` starts PostgreSQL and Azurite
+- `mise run dev` starts the server, connects to PostgreSQL and Blob Storage
+- `GET /healthz` returns 200 with `{"status":"ok"}`
+- `GET /readyz` returns 200 with `{"status":"ready"}` after startup complete
+- SIGINT triggers graceful shutdown with ordered teardown log output

--- a/.claude/plans/spicy-stargazing-beacon.md
+++ b/.claude/plans/spicy-stargazing-beacon.md
@@ -1,0 +1,50 @@
+# Plan: Draft Management Update Email
+
+## Context
+
+Jaime was given a directive this week to deliver the document classification service as soon as possible. He has a hard deadline of **March 19** (~4 weeks). He's already coordinated with customer-site partners and will be exclusively focused on Herald delivery with zero bandwidth for external engagements. The email explains this pivot to management.
+
+## Approach
+
+Write the email as a **progress-category** post following the style profile conventions.
+
+### Voice Calibration
+- **Tone**: Professional, confident, conversational warmth over technical substance
+- **Register**: Formal enough for leadership, informal enough to feel like a person talking
+- **Cadence**: Short grounding statement → longer explanatory → medium impact
+- **Vocabulary**: Favor "foundational, proven, focused, established, accelerate" — avoid "utilize, synergy, paradigm, simply"
+- **Audience**: Management — lean toward impact framing with enough technical grounding to convey credibility
+
+### Structure (Progress Post Pattern)
+
+1. **Opening** — Set context: the pivot to deliver document classification as the immediate priority, with a March 19 delivery target
+
+2. **Section: R&D Foundation** — Brief arc establishing that this isn't starting from scratch:
+   - **classify-docs** came first — the experiment that proved sequential page-by-page classification with GPT vision works (96.3% accuracy). This predated both go-agents-orchestration and agent-lab.
+   - **agent-lab** — the full research platform that explored dynamic workflows, observability, profiles, and multi-stage pipelines. Valuable R&D, but built for experimentation, not focused delivery.
+   - **TAU kernel** — the universal agent runtime effort. Still a relevant project worth pursuing *after* Herald ships.
+
+3. **Section: Herald — Focused Delivery** — Frame Herald as a web service built exclusively for agentic document classification. Not a stripped-down agent-lab — a purpose-built service that eliminates the extraneous dynamic workflow concerns (observer infrastructure, multi-workflow registries, profile-based A/B testing, checkpoint persistence) in favor of a single, proven classification workflow targeting ~1M DoD PDF documents.
+
+4. **Section: Current Status & Trajectory** — Phase 1 (Service Foundation) in progress. Completed: scaffolding, configuration system, lifecycle coordination, HTTP infrastructure, database toolkit, storage abstraction (6 merged PRs). Next: infrastructure assembly and API module integration, then Phase 2 (Classification Engine). 4 phases total targeting v0.4.0.
+
+5. **Section: Delivery Commitment** — March 19 deadline. Already coordinated with customer-site partners. Exclusively focused — zero bandwidth for external engagements.
+
+6. **Closing** — Forward-looking confidence statement
+
+### Key Narrative Points
+- The R&D journey validated *what works* — Herald applies those findings to a focused delivery
+- classify-docs proved the classification approach before agent-lab or go-agents-orchestration existed
+- Herald is purpose-built for document classification, not a general-purpose workflow platform
+- TAU kernel remains a relevant future effort, sequenced after Herald delivery
+- Concrete progress and clear 4-week trajectory
+
+## Output
+- File: `_project/email.md`
+- Format: Markdown, no frontmatter (email draft, not blog post)
+- Length: ~400-600 words — concise enough to scan, detailed enough to inform
+
+## Verification
+- Read against style profile: tone, cadence, vocabulary, structure
+- Ensure no hedging language, no corporate buzzwords, no hyperbole
+- Confirm narrative: context → R&D foundation → focused delivery → status → commitment → forward look

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.0-dev.1.7
+
+- Add infrastructure assembly, API module shell, and server entry point with health/readiness probes, OpenAPI endpoint, Scalar UI, and graceful shutdown lifecycle (#7)
+
 ## v0.1.0-dev.1.6
 
 - Add storage abstraction with Azure Blob Storage implementation, streaming blob operations, and lifecycle-coordinated container initialization (#6)

--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/lifecycle"
+)
+
+type httpServer struct {
+	http            *http.Server
+	logger          *slog.Logger
+	shutdownTimeout time.Duration
+}
+
+func newHTTPServer(cfg *config.ServerConfig, handler http.Handler, logger *slog.Logger) *httpServer {
+	return &httpServer{
+		http: &http.Server{
+			Addr:         cfg.Addr(),
+			Handler:      handler,
+			ReadTimeout:  cfg.ReadTimeoutDuration(),
+			WriteTimeout: cfg.WriteTimeoutDuration(),
+		},
+		logger:          logger.With("system", "http"),
+		shutdownTimeout: cfg.ShutdownTimeoutDuration(),
+	}
+}
+
+func (s *httpServer) Start(lc *lifecycle.Coordinator) error {
+	go func() {
+		s.logger.Info("server listening", "addr", s.http.Addr)
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("server error", "error", err)
+		}
+	}()
+
+	lc.OnShutdown(func() {
+		<-lc.Context().Done()
+		s.logger.Info("shutting down server")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+
+		if err := s.http.Shutdown(shutdownCtx); err != nil {
+			s.logger.Error("server shutdown error", "error", err)
+		} else {
+			s.logger.Info("server shutdown complete")
+		}
+	})
+
+	return nil
+}

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/JaimeStill/herald/internal/api"
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/middleware"
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/web/scalar"
+)
+
+type Modules struct {
+	API    *module.Module
+	Scalar *module.Module
+}
+
+func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modules, error) {
+	apiModule, err := api.NewModule(cfg, infra)
+	if err != nil {
+		return nil, err
+	}
+
+	scalarModule := scalar.NewModule("/scalar")
+	scalarModule.Use(middleware.Logger(infra.Logger))
+
+	return &Modules{
+		API:    apiModule,
+		Scalar: scalarModule,
+	}, nil
+}
+
+func (m *Modules) Mount(router *module.Router) {
+	router.Mount(m.API)
+	router.Mount(m.Scalar)
+}
+
+func buildRouter(infra *infrastructure.Infrastructure) *module.Router {
+	router := module.NewRouter()
+
+	router.HandleNative("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	router.HandleNative("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !infra.Lifecycle.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	})
+
+	return router
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"time"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+)
+
+type Server struct {
+	infra   *infrastructure.Infrastructure
+	modules *Modules
+	http    *httpServer
+}
+
+func NewServer(cfg *config.Config) (*Server, error) {
+	infra, err := infrastructure.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	modules, err := NewModules(infra, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	router := buildRouter(infra)
+	modules.Mount(router)
+
+	infra.Logger.Info(
+		"server initialized",
+		"addr", cfg.Server.Addr(),
+		"version", cfg.Version,
+	)
+
+	return &Server{
+		infra:   infra,
+		modules: modules,
+		http:    newHTTPServer(&cfg.Server, router, infra.Logger),
+	}, nil
+}
+
+func (s *Server) Start() error {
+	s.infra.Logger.Info("starting service")
+
+	if err := s.infra.Start(); err != nil {
+		return err
+	}
+
+	if err := s.http.Start(s.infra.Lifecycle); err != nil {
+		return err
+	}
+
+	go func() {
+		s.infra.Lifecycle.WaitForStartup()
+		s.infra.Logger.Info("all subsystems ready")
+	}()
+
+	return nil
+}
+
+func (s *Server) Shutdown(timeout time.Duration) error {
+	s.infra.Logger.Info("initiating shutdown")
+	return s.infra.Lifecycle.Shutdown(timeout)
+}

--- a/config.toml
+++ b/config.toml
@@ -38,3 +38,7 @@ max_age = 3600
 [api.openapi]
 title = "Herald API"
 description = "Security marking classification service for DoD PDF documents."
+
+[api.pagination]
+default_page_size = 20
+max_page_size = 100

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,36 @@
+// Package api assembles the API module with all domain systems and route registration.
+package api
+
+import (
+	"net/http"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/middleware"
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/pkg/openapi"
+)
+
+// NewModule creates the API module with all domain handlers and middleware.
+func NewModule(cfg *config.Config, infra *infrastructure.Infrastructure) (*module.Module, error) {
+	runtime := NewRuntime(cfg, infra)
+	domain := NewDomain(runtime)
+
+	spec := openapi.NewSpec(cfg.API.OpenAPI.Title, cfg.Version)
+	spec.SetDescription(cfg.API.OpenAPI.Description)
+
+	mux := http.NewServeMux()
+	registerRoutes(mux, spec, domain, cfg)
+
+	specBytes, err := openapi.MarshalJSON(spec)
+	if err != nil {
+		return nil, err
+	}
+	mux.HandleFunc("GET /openapi.json", openapi.ServeSpec(specBytes))
+
+	m := module.New(cfg.API.BasePath, mux)
+	m.Use(middleware.CORS(&cfg.API.CORS))
+	m.Use(middleware.Logger(runtime.Infrastructure.Logger))
+
+	return m, nil
+}

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,1 +1,0 @@
-package api

--- a/internal/api/domain.go
+++ b/internal/api/domain.go
@@ -1,0 +1,9 @@
+package api
+
+// Domain holds all domain systems that comprise the API.
+type Domain struct{}
+
+// NewDomain creates all domain systems from the API runtime.
+func NewDomain(runtime *Runtime) *Domain {
+	return &Domain{}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/openapi"
+)
+
+func registerRoutes(
+	mux *http.ServeMux,
+	spec *openapi.Spec,
+	domain *Domain,
+	cfg *config.Config,
+) {
+}

--- a/internal/api/runtime.go
+++ b/internal/api/runtime.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/pagination"
+)
+
+// Runtime extends Infrastructure with API-specific configuration.
+type Runtime struct {
+	*infrastructure.Infrastructure
+	Pagination pagination.Config
+}
+
+// NewRuntime creates an API runtime with a module-scoped logger.
+func NewRuntime(cfg *config.Config, infra *infrastructure.Infrastructure) *Runtime {
+	return &Runtime{
+		Infrastructure: &infrastructure.Infrastructure{
+			Lifecycle: infra.Lifecycle,
+			Logger:    infra.Logger.With("module", "api"),
+			Database:  infra.Database,
+			Storage:   infra.Storage,
+		},
+		Pagination: cfg.API.Pagination,
+	}
+}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JaimeStill/herald/pkg/middleware"
 	"github.com/JaimeStill/herald/pkg/openapi"
+	"github.com/JaimeStill/herald/pkg/pagination"
 )
 
 var corsEnv = &middleware.CORSEnv{
@@ -22,11 +23,17 @@ var openAPIEnv = &openapi.ConfigEnv{
 	Description: "HERALD_OPENAPI_DESCRIPTION",
 }
 
+var paginationEnv = &pagination.ConfigEnv{
+	DefaultPageSize: "HERALD_PAGINATION_DEFAULT_PAGE_SIZE",
+	MaxPageSize:     "HERALD_PAGINATION_MAX_PAGE_SIZE",
+}
+
 // APIConfig holds API routing, CORS, and OpenAPI settings.
 type APIConfig struct {
-	BasePath string                `toml:"base_path"`
-	CORS     middleware.CORSConfig `toml:"cors"`
-	OpenAPI  openapi.Config        `toml:"openapi"`
+	BasePath   string                `toml:"base_path"`
+	CORS       middleware.CORSConfig `toml:"cors"`
+	OpenAPI    openapi.Config        `toml:"openapi"`
+	Pagination pagination.Config     `toml:"pagination"`
 }
 
 // Finalize applies defaults, environment variable overrides, and validation
@@ -41,6 +48,9 @@ func (c *APIConfig) Finalize() error {
 	if err := c.OpenAPI.Finalize(openAPIEnv); err != nil {
 		return fmt.Errorf("openapi: %w", err)
 	}
+	if err := c.Pagination.Finalize(paginationEnv); err != nil {
+		return fmt.Errorf("pagination: %w", err)
+	}
 	return nil
 }
 
@@ -51,6 +61,7 @@ func (c *APIConfig) Merge(overlay *APIConfig) {
 	}
 	c.CORS.Merge(&overlay.CORS)
 	c.OpenAPI.Merge(&overlay.OpenAPI)
+	c.Pagination.Merge(&overlay.Pagination)
 }
 
 func (c *APIConfig) loadDefaults() {

--- a/internal/infrastructure/doc.go
+++ b/internal/infrastructure/doc.go
@@ -1,1 +1,0 @@
-package infrastructure

--- a/internal/infrastructure/infrastructure.go
+++ b/internal/infrastructure/infrastructure.go
@@ -1,0 +1,60 @@
+// Package infrastructure provides core service initialization for application startup.
+// It assembles common dependencies (logging, database, storage) that domain systems require.
+package infrastructure
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/pkg/database"
+	"github.com/JaimeStill/herald/pkg/lifecycle"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+// Infrastructure holds the core systems required by all domain modules.
+// It provides a single point of initialization for lifecycle coordination,
+// logging, database access, and file storage.
+type Infrastructure struct {
+	Lifecycle *lifecycle.Coordinator
+	Logger    *slog.Logger
+	Database  database.System
+	Storage   storage.System
+}
+
+// New creates an Infrastructure from the application configuration.
+// It initializes all systems but does not start them; call Start separately.
+func New(cfg *config.Config) (*Infrastructure, error) {
+	lc := lifecycle.New()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	db, err := database.New(&cfg.Database, logger)
+	if err != nil {
+		return nil, fmt.Errorf("database init failed: %w", err)
+	}
+
+	store, err := storage.New(&cfg.Storage, logger)
+	if err != nil {
+		return nil, fmt.Errorf("storage init failed: %w", err)
+	}
+
+	return &Infrastructure{
+		Lifecycle: lc,
+		Logger:    logger,
+		Database:  db,
+		Storage:   store,
+	}, nil
+}
+
+// Start registers all infrastructure systems with the lifecycle coordinator.
+// Database and storage hooks are registered for startup and shutdown coordination.
+func (i *Infrastructure) Start() error {
+	if err := i.Database.Start(i.Lifecycle); err != nil {
+		return fmt.Errorf("database start failed: %w", err)
+	}
+	if err := i.Storage.Start(i.Lifecycle); err != nil {
+		return fmt.Errorf("storage start failed: %w", err)
+	}
+	return nil
+}

--- a/tests/infrastructure/infrastructure_test.go
+++ b/tests/infrastructure/infrastructure_test.go
@@ -1,0 +1,77 @@
+package infrastructure_test
+
+import (
+	"testing"
+
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/database"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+const azuriteConnString = "DefaultEndpointsProtocol=http;AccountName=heraldstore;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/heraldstore;"
+
+func validConfig() *config.Config {
+	return &config.Config{
+		Database: database.Config{
+			Host:            "localhost",
+			Port:            5432,
+			Name:            "herald",
+			User:            "herald",
+			Password:        "herald",
+			SSLMode:         "disable",
+			MaxOpenConns:    25,
+			MaxIdleConns:    5,
+			ConnMaxLifetime: "15m",
+			ConnTimeout:     "5s",
+		},
+		Storage: storage.Config{
+			ContainerName:    "documents",
+			ConnectionString: azuriteConnString,
+		},
+		Version: "0.1.0",
+	}
+}
+
+func TestNew(t *testing.T) {
+	infra, err := infrastructure.New(validConfig())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if infra.Lifecycle == nil {
+		t.Error("Lifecycle is nil")
+	}
+	if infra.Logger == nil {
+		t.Error("Logger is nil")
+	}
+	if infra.Database == nil {
+		t.Error("Database is nil")
+	}
+	if infra.Storage == nil {
+		t.Error("Storage is nil")
+	}
+}
+
+func TestNewDatabaseConnection(t *testing.T) {
+	infra, err := infrastructure.New(validConfig())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	conn := infra.Database.Connection()
+	if conn == nil {
+		t.Fatal("Database.Connection() returned nil")
+	}
+	conn.Close()
+}
+
+func TestNewInvalidStorageConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.Storage.ConnectionString = "not-a-connection-string"
+
+	_, err := infrastructure.New(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid storage connection string")
+	}
+}


### PR DESCRIPTION
## Summary

Wire all foundational packages into a running Go web service with health/readiness probes and graceful shutdown, completing Objective #1 (Project Scaffolding, Configuration, and Service Skeleton).

Closes #7

## Changes

- **Infrastructure assembly** (`internal/infrastructure/`) — `Infrastructure` struct composing lifecycle coordinator, logger, database system, and storage system with cold start / hot start separation
- **API module** (`internal/api/`) — Runtime (infrastructure + pagination config), Domain (empty placeholder), route registration, OpenAPI spec endpoint, CORS and logging middleware
- **Server entry point** (`cmd/server/`) — `Server` struct with full lifecycle coordination, HTTP server wrapper with graceful shutdown hook, module assembly with health/readiness probes and Scalar API docs
- **Pagination config** — added to `APIConfig` with env var overrides (`HERALD_PAGINATION_*`)
- **Tests** — infrastructure and API module black-box tests, pagination config tests