### PR TITLE
Add document domain core — types, mapping, repository, and system

### DIFF
--- a/.claude/context/guides/.archive/16-document-domain-core.md
+++ b/.claude/context/guides/.archive/16-document-domain-core.md
@@ -1,0 +1,433 @@
+# 16 - Document Domain Core
+
+## Problem Context
+
+Herald needs a document domain foundation layer — types, data access, and business logic — before HTTP handlers can be built (issue #17). This establishes the complete `internal/documents/` package following the System/Repository/Mapping/Errors pattern adapted from agent-lab.
+
+## Architecture Approach
+
+The repository holds `*sql.DB`, `storage.System`, `*slog.Logger`, and `pagination.Config`. All queries go through `pkg/query.Builder` with a `ProjectionMap`. Blob+DB atomicity uses upload-first with compensating delete on DB failure. No HTTP handler concerns — that's issue #17. No `Search` method on the repository — the GET list vs POST search distinction is a handler concern; both will call `List`.
+
+## Implementation
+
+### Step 1: Add uuid dependency
+
+```bash
+go get github.com/google/uuid
+```
+
+### Step 2: Create `internal/documents/document.go`
+
+Replace the existing `doc.go` stub with this file.
+
+```go
+package documents
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Document struct {
+	ID               uuid.UUID `json:"id"`
+	ExternalID       int       `json:"external_id"`
+	ExternalPlatform string    `json:"external_platform"`
+	Filename         string    `json:"filename"`
+	ContentType      string    `json:"content_type"`
+	SizeBytes        int64     `json:"size_bytes"`
+	PageCount        *int      `json:"page_count"`
+	StorageKey       string    `json:"storage_key"`
+	Status           string    `json:"status"`
+	UploadedAt       time.Time `json:"uploaded_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type CreateCommand struct {
+	Data             []byte
+	Filename         string
+	ContentType      string
+	ExternalID       int
+	ExternalPlatform string
+	PageCount        *int
+}
+
+type BatchResult struct {
+	Document *Document `json:"document,omitempty"`
+	Filename string    `json:"filename"`
+	Error    string    `json:"error,omitempty"`
+}
+```
+
+### Step 3: Create `internal/documents/errors.go`
+
+```go
+package documents
+
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	ErrNotFound    = errors.New("document not found")
+	ErrDuplicate   = errors.New("document already exists")
+	ErrFileTooLarge = errors.New("file exceeds maximum upload size")
+	ErrInvalidFile = errors.New("invalid file")
+)
+
+func MapHTTPStatus(err error) int {
+	if errors.Is(err, ErrNotFound) {
+		return http.StatusNotFound
+	}
+	if errors.Is(err, ErrDuplicate) {
+		return http.StatusConflict
+	}
+	if errors.Is(err, ErrFileTooLarge) {
+		return http.StatusRequestEntityTooLarge
+	}
+	if errors.Is(err, ErrInvalidFile) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+```
+
+### Step 4: Create `internal/documents/mapping.go`
+
+```go
+package documents
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/JaimeStill/herald/pkg/query"
+	"github.com/JaimeStill/herald/pkg/repository"
+)
+
+var projection = query.
+	NewProjectionMap("public", "documents", "d").
+	Project("id", "ID").
+	Project("external_id", "ExternalID").
+	Project("external_platform", "ExternalPlatform").
+	Project("filename", "Filename").
+	Project("content_type", "ContentType").
+	Project("size_bytes", "SizeBytes").
+	Project("page_count", "PageCount").
+	Project("storage_key", "StorageKey").
+	Project("status", "Status").
+	Project("uploaded_at", "UploadedAt").
+	Project("updated_at", "UpdatedAt")
+
+var defaultSort = query.SortField{Field: "UploadedAt", Descending: true}
+
+func scanDocument(s repository.Scanner) (Document, error) {
+	var d Document
+	err := s.Scan(
+		&d.ID,
+		&d.ExternalID,
+		&d.ExternalPlatform,
+		&d.Filename,
+		&d.ContentType,
+		&d.SizeBytes,
+		&d.PageCount,
+		&d.StorageKey,
+		&d.Status,
+		&d.UploadedAt,
+		&d.UpdatedAt,
+	)
+	return d, err
+}
+
+type Filters struct {
+	Status           *string `json:"status,omitempty"`
+	Filename         *string `json:"filename,omitempty"`
+	ExternalID       *int    `json:"external_id,omitempty"`
+	ExternalPlatform *string `json:"external_platform,omitempty"`
+	ContentType      *string `json:"content_type,omitempty"`
+	StorageKey       *string `json:"storage_key,omitempty"`
+}
+
+func FiltersFromQuery(values url.Values) Filters {
+	var f Filters
+
+	if s := values.Get("status"); s != "" {
+		f.Status = &s
+	}
+
+	if fn := values.Get("filename"); fn != "" {
+		f.Filename = &fn
+	}
+
+	if eid := values.Get("external_id"); eid != "" {
+		if v, err := strconv.Atoi(eid); err == nil {
+			f.ExternalID = &v
+		}
+	}
+
+	if ep := values.Get("external_platform"); ep != "" {
+		f.ExternalPlatform = &ep
+	}
+
+	if ct := values.Get("content_type"); ct != "" {
+		f.ContentType = &ct
+	}
+
+	if sk := values.Get("storage_key"); sk != "" {
+		f.StorageKey = &sk
+	}
+
+	return f
+}
+
+func (f Filters) Apply(b *query.Builder) *query.Builder {
+	return b.
+		WhereEquals("Status", f.Status).
+		WhereContains("Filename", f.Filename).
+		WhereEquals("ExternalID", f.ExternalID).
+		WhereEquals("ExternalPlatform", f.ExternalPlatform).
+		WhereEquals("ContentType", f.ContentType).
+		WhereContains("StorageKey", f.StorageKey)
+}
+```
+
+### Step 5: Create `internal/documents/system.go`
+
+```go
+package documents
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/pkg/pagination"
+)
+
+type System interface {
+	List(ctx context.Context, page pagination.PageRequest, filters Filters) (*pagination.PageResult[Document], error)
+	Find(ctx context.Context, id uuid.UUID) (*Document, error)
+	Create(ctx context.Context, cmd CreateCommand) (*Document, error)
+	CreateBatch(ctx context.Context, cmds []CreateCommand) []BatchResult
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+```
+
+### Step 6: Create `internal/documents/repository.go`
+
+```go
+package documents
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"path/filepath"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/pkg/pagination"
+	"github.com/JaimeStill/herald/pkg/query"
+	"github.com/JaimeStill/herald/pkg/repository"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type repo struct {
+	db         *sql.DB
+	storage    storage.System
+	logger     *slog.Logger
+	pagination pagination.Config
+}
+
+func New(db *sql.DB, store storage.System, logger *slog.Logger, pagination pagination.Config) System {
+	return &repo{
+		db:         db,
+		storage:    store,
+		logger:     logger.With("system", "documents"),
+		pagination: pagination,
+	}
+}
+
+func (r *repo) List(ctx context.Context, page pagination.PageRequest, filters Filters) (*pagination.PageResult[Document], error) {
+	page.Normalize(r.pagination)
+
+	qb := query.
+		NewBuilder(projection, defaultSort).
+		WhereSearch(page.Search, "Filename", "ExternalPlatform")
+
+	filters.Apply(qb)
+
+	if len(page.Sort) > 0 {
+		qb.OrderByFields(page.Sort)
+	}
+
+	countSQL, countArgs := qb.BuildCount()
+	var total int
+	if err := r.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count documents: %w", err)
+	}
+
+	pageSQL, pageArgs := qb.BuildPage(page.Page, page.PageSize)
+	docs, err := repository.QueryMany(ctx, r.db, pageSQL, pageArgs, scanDocument)
+	if err != nil {
+		return nil, fmt.Errorf("query documents: %w", err)
+	}
+
+	result := pagination.NewPageResult(docs, total, page.Page, page.PageSize)
+	return &result, nil
+}
+
+func (r *repo) Find(ctx context.Context, id uuid.UUID) (*Document, error) {
+	q, args := query.NewBuilder(projection).BuildSingle("ID", id)
+
+	d, err := repository.QueryOne(ctx, r.db, q, args, scanDocument)
+	if err != nil {
+		return nil, repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+	return &d, nil
+}
+
+func (r *repo) Create(ctx context.Context, cmd CreateCommand) (*Document, error) {
+	id := uuid.New()
+	key := buildStorageKey(id, sanitizeFilename(cmd.Filename))
+
+	if err := r.storage.Upload(ctx, key, bytes.NewReader(cmd.Data), cmd.ContentType); err != nil {
+		return nil, fmt.Errorf("upload document blob: %w", err)
+	}
+
+	q := `
+		INSERT INTO documents (id, external_id, external_platform, filename, content_type, size_bytes, page_count, storage_key)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, external_id, external_platform, filename, content_type, size_bytes, page_count, storage_key, status, uploaded_at, updated_at`
+
+	insertArgs := []any{
+		id,
+		cmd.ExternalID,
+		cmd.ExternalPlatform,
+		cmd.Filename,
+		cmd.ContentType,
+		int64(len(cmd.Data)),
+		cmd.PageCount,
+		key,
+	}
+
+	d, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Document, error) {
+		return repository.QueryOne(ctx, tx, q, insertArgs, scanDocument)
+	})
+
+	if err != nil {
+		// compensating blob delete — log but tolerate failure
+		if delErr := r.storage.Delete(ctx, key); delErr != nil {
+			r.logger.Warn("compensating blob delete failed", "key", key, "error", delErr)
+		}
+		return nil, repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+
+	r.logger.Info("document created", "id", d.ID, "filename", d.Filename)
+	return &d, nil
+}
+
+func (r *repo) CreateBatch(ctx context.Context, cmds []CreateCommand) []BatchResult {
+	results := make([]BatchResult, len(cmds))
+
+	for i, cmd := range cmds {
+		doc, err := r.Create(ctx, cmd)
+		if err != nil {
+			results[i] = BatchResult{
+				Filename: cmd.Filename,
+				Error:    err.Error(),
+			}
+		} else {
+			results[i] = BatchResult{
+				Document: doc,
+				Filename: cmd.Filename,
+			}
+		}
+	}
+
+	return results
+}
+
+func (r *repo) Delete(ctx context.Context, id uuid.UUID) error {
+	doc, err := r.Find(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = repository.WithTx(ctx, r.db, func(tx *sql.Tx) (struct{}, error) {
+		if err := repository.ExecExpectOne(ctx, tx, "DELETE FROM documents WHERE id = $1", id); err != nil {
+			return struct{}{}, err
+		}
+		return struct{}{}, nil
+	})
+
+	if err != nil {
+		return repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+
+	if delErr := r.storage.Delete(ctx, doc.StorageKey); delErr != nil {
+		r.logger.Warn("blob delete failed after DB delete", "key", doc.StorageKey, "error", delErr)
+	}
+
+	r.logger.Info("document deleted", "id", id)
+	return nil
+}
+
+func buildStorageKey(id uuid.UUID, filename string) string {
+	return fmt.Sprintf("documents/%s/%s", id, filename)
+}
+
+func sanitizeFilename(name string) string {
+	name = filepath.Base(name)
+	if name == "." || name == "" {
+		name = "document"
+	}
+	return url.PathEscape(name)
+}
+```
+
+### Step 7: Delete `internal/documents/doc.go`
+
+Remove the stub file now that the package has real source files.
+
+```bash
+rm internal/documents/doc.go
+```
+
+### Step 8: Wire domain into `internal/api/domain.go`
+
+Add the `Documents` field and wire the constructor:
+
+```go
+package api
+
+import "github.com/JaimeStill/herald/internal/documents"
+
+type Domain struct {
+	Documents documents.System
+}
+
+func NewDomain(runtime *Runtime) *Domain {
+	return &Domain{
+		Documents: documents.New(
+			runtime.Database.Connection(),
+			runtime.Storage,
+			runtime.Logger,
+			runtime.Pagination,
+		),
+	}
+}
+```
+
+## Validation Criteria
+
+- [ ] `go get github.com/google/uuid` succeeds
+- [ ] All domain types match the documents DB schema (migration 000001)
+- [ ] ProjectionMap columns match migration 000001 column order
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` compiles cleanly
+- [ ] `internal/documents/doc.go` is removed

--- a/.claude/context/sessions/16-document-domain-core.md
+++ b/.claude/context/sessions/16-document-domain-core.md
@@ -1,0 +1,43 @@
+# 16 - Document Domain Core
+
+## Summary
+
+Established the complete document domain foundation layer in `internal/documents/` — types, data access, business logic, and domain errors — with no HTTP concerns. The domain follows the System/Repository/Mapping/Errors pattern adapted from agent-lab. The repository holds `*sql.DB`, `storage.System`, and `*slog.Logger`, using the existing query builder, repository helpers, and pagination infrastructure. The domain is wired into the API module via `internal/api/domain.go`.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| No Search method on repository | Single `List` method serves both GET list and POST search | The GET vs POST distinction is an HTTP handler concern; both use the same Filters struct |
+| No Handler on System interface | Deferred to issue #17 | Handler type doesn't exist yet; added when the HTTP layer is built |
+| Filename sanitization | `filepath.Base` + `url.PathEscape` | Standard library functions handle path stripping and URL encoding without manual string manipulation |
+| Additional filters | Added ExternalID, ContentType, StorageKey beyond original spec | ExternalID for targeted lookups, ContentType for future doc type expansion, StorageKey for debugging |
+| PageCount on CreateCommand | Optional `*int` provided by caller | Extraction via pdfcpu is a handler concern (issue #17); repository stores whatever value is given |
+
+## Files Modified
+
+- `internal/documents/document.go` — Document, CreateCommand, BatchResult types (replaced doc.go stub)
+- `internal/documents/errors.go` — ErrNotFound, ErrDuplicate, ErrFileTooLarge, ErrInvalidFile, MapHTTPStatus
+- `internal/documents/mapping.go` — ProjectionMap, scanDocument, Filters, FiltersFromQuery, Apply
+- `internal/documents/system.go` — System interface (List, Find, Create, CreateBatch, Delete)
+- `internal/documents/repository.go` — repo struct, New constructor, all System methods, buildStorageKey, sanitizeFilename
+- `internal/api/domain.go` — Added Documents field and wired constructor
+- `go.mod` / `go.sum` — Added google/uuid as direct dependency
+- `tests/documents/documents_test.go` — Tests for MapHTTPStatus, FiltersFromQuery, Filters.Apply
+
+## Patterns Established
+
+- Domain package structure: document.go (types), errors.go, mapping.go, system.go, repository.go
+- Repository constructor: `New(db, storage, logger, pagination) System`
+- Blob+DB atomicity: upload blob first, INSERT in WithTx, compensating delete on failure
+- Filters with `Apply(*query.Builder)` method and `FiltersFromQuery(url.Values)` constructor
+- `sanitizeFilename` using `filepath.Base` + `url.PathEscape`
+
+## Validation Results
+
+- `go vet ./...` passes
+- `go build ./...` compiles cleanly
+- `go mod tidy` clean (promoted google/uuid to direct dependency)
+- 18 new tests pass (MapHTTPStatus: 7, FiltersFromQuery: 4, FiltersApply: 7)
+- Full test suite: 15 packages pass
+- All 11 Document struct fields match migration 000001 column types and order

--- a/.claude/plans/imperative-floating-moon.md
+++ b/.claude/plans/imperative-floating-moon.md
@@ -1,0 +1,134 @@
+# Plan: Issue #16 — Document Domain Core
+
+## Context
+
+Issue #16 establishes the document domain's foundation layer in `internal/documents/` — all types, data access, and business logic with no HTTP concerns. This is sub-issue 1 of Objective #3 (Document Domain). Sub-issue #17 builds the HTTP handler layer on top of this work.
+
+The domain follows the System/Repository/Mapping/Errors pattern from agent-lab, adapted for Herald. The repository holds `*sql.DB` (from `database.System.Connection()`), `storage.System`, and `*slog.Logger`, using the existing `pkg/query`, `pkg/repository`, and `pkg/pagination` infrastructure.
+
+## New Files
+
+All files created in `internal/documents/` (replacing the existing `doc.go` stub).
+
+### 1. `document.go` — Domain types
+
+- **`Document`** struct matching the DB schema from migration 000001:
+  - `ID uuid.UUID`, `ExternalID int`, `ExternalPlatform string`, `Filename string`, `ContentType string`, `SizeBytes int64`, `PageCount *int`, `StorageKey string`, `Status string`, `UploadedAt time.Time`, `UpdatedAt time.Time`
+  - JSON tags on all fields for API serialization
+
+- **`CreateCommand`** struct — input for creating a document:
+  - `Data []byte`, `Filename string`, `ContentType string`, `ExternalID int`, `ExternalPlatform string`, `PageCount *int`
+  - `Data` is the raw file bytes (used for blob upload and size calculation)
+  - `PageCount` is optional — extracted by the handler (issue #17) via pdfcpu; nil on failure
+
+- **`BatchResult`** struct — per-file result from batch create:
+  - `Document *Document`, `Filename string`, `Error string`
+
+### 2. `errors.go` — Domain errors and HTTP status mapping
+
+- Sentinel errors: `ErrNotFound`, `ErrDuplicate`, `ErrFileTooLarge`, `ErrInvalidFile`
+- `MapHTTPStatus(error) int` — maps domain errors to HTTP status codes:
+  - `ErrNotFound` → 404, `ErrDuplicate` → 409, `ErrFileTooLarge` → 413, `ErrInvalidFile` → 400
+  - Default → 500
+
+### 3. `mapping.go` — Query projections, scanning, and filters
+
+- **`projection`** — `query.NewProjectionMap("public", "documents", "d")` with all 11 columns mapped in migration order:
+  - `id→ID`, `external_id→ExternalID`, `external_platform→ExternalPlatform`, `filename→Filename`, `content_type→ContentType`, `size_bytes→SizeBytes`, `page_count→PageCount`, `storage_key→StorageKey`, `status→Status`, `uploaded_at→UploadedAt`, `updated_at→UpdatedAt`
+
+- **`defaultSort`** — `query.SortField{Field: "UploadedAt", Descending: true}` (newest first)
+
+- **`scanDocument`** — `repository.ScanFunc[Document]` scanning all 11 columns in projection order
+
+- **`Filters`** struct:
+  - `Status *string` — exact match (`WhereEquals`)
+  - `Filename *string` — contains match (`WhereContains`)
+  - `ExternalPlatform *string` — exact match (`WhereEquals`)
+
+- **`FiltersFromQuery(url.Values) Filters`** — parses query params to Filters
+- **`(Filters).Apply(*query.Builder) *query.Builder`** — adds filter conditions
+
+### 4. `repository.go` — Data access implementation
+
+- **`repo`** struct: `db *sql.DB`, `storage storage.System`, `logger *slog.Logger`, `pagination pagination.Config`
+- **`New(db, storage, logger, pagination) System`** constructor — returns the System interface
+
+**Methods:**
+
+- **`List(ctx, PageRequest, Filters) (*PageResult[Document], error)`**
+  Normalize page → NewBuilder with projection/defaultSort → WhereSearch on Filename, ExternalPlatform → filters.Apply → BuildCount + BuildPage → return PageResult
+
+- **`Find(ctx, uuid.UUID) (*Document, error)`**
+  BuildSingle by ID → QueryOne → MapError
+
+- **`Create(ctx, CreateCommand) (*Document, error)`**
+  1. Generate `id := uuid.New()`
+  2. Sanitize filename, build storage key: `documents/{id}/{sanitized}`
+  3. Upload blob: `r.storage.Upload(ctx, key, bytes.NewReader(cmd.Data), cmd.ContentType)`
+  4. INSERT in WithTx with RETURNING (all columns)
+  5. On DB failure: compensating `r.storage.Delete` (log warning on delete failure)
+  6. Return the created Document
+
+- **`CreateBatch(ctx, []CreateCommand) []BatchResult`**
+  Process each command independently via `r.Create()`. Collect BatchResult per file — success with Document, or error with message. Partial success semantics.
+
+- **`Delete(ctx, uuid.UUID) error`**
+  1. Find document (need storage_key)
+  2. Delete DB record via ExecExpectOne in WithTx
+  3. Delete blob (log warning if blob delete fails — orphan is acceptable)
+  4. MapError on DB errors
+
+No `Search` method — the GET list vs POST search distinction is an HTTP handler concern (issue #17). Both call the same `List` method with different filter sources.
+
+**Helpers (unexported):**
+
+- **`buildStorageKey(id uuid.UUID, filename string) string`** — `fmt.Sprintf("documents/%s/%s", id, filename)`
+- **`sanitizeFilename(string) string`** — strips path separators, ".." sequences, leading dots; preserves extension
+
+### 5. `system.go` — System interface
+
+Defines the public contract:
+- `List(ctx, PageRequest, Filters) (*PageResult[Document], error)`
+- `Find(ctx, uuid.UUID) (*Document, error)`
+- `Create(ctx, CreateCommand) (*Document, error)`
+- `CreateBatch(ctx, []CreateCommand) []BatchResult`
+- `Delete(ctx, uuid.UUID) error`
+
+No `Handler()` or `Search()` — Handler is added in #17, and the GET/POST search distinction is a handler concern (both call `List`).
+
+## Modified Files
+
+### `internal/api/domain.go`
+
+Add `Documents documents.System` field to Domain struct. Wire in NewDomain:
+```go
+Documents: documents.New(
+    runtime.Database.Connection(),
+    runtime.Storage,
+    runtime.Logger,
+    runtime.Pagination,
+),
+```
+
+### `go.mod` / `go.sum`
+
+Add `github.com/google/uuid` dependency (needed for `uuid.UUID` type in Document struct and `uuid.New()` in Create).
+
+## Dependencies Reused
+
+| Package | Used For |
+|---------|----------|
+| `pkg/query` | ProjectionMap, Builder, SortField, WhereEquals/WhereContains/WhereSearch |
+| `pkg/repository` | WithTx, QueryOne, QueryMany, ExecExpectOne, MapError, Scanner, ScanFunc |
+| `pkg/pagination` | PageRequest, PageResult, NewPageResult, Config |
+| `pkg/storage` | System interface (Upload, Delete) |
+| `pkg/database` | System.Connection() for *sql.DB |
+
+## Validation
+
+- `go vet ./...` passes
+- `go build ./...` compiles cleanly
+- All domain types match documents DB schema (migration 000001)
+- ProjectionMap columns match migration column order
+- Repository methods compile against `*sql.DB` and `storage.System`
+- Filters support status (equals), filename (contains), external_platform (equals)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.0-dev.3.16
+
+- Add document domain core: types, mapping, repository, and system interface with blob+DB atomicity and paginated filtered queries (#16)
+
 ## v0.1.0-dev.2.13
 
 - Add migration CLI with embedded SQL and initial documents schema (#13)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 )

--- a/internal/api/domain.go
+++ b/internal/api/domain.go
@@ -1,9 +1,22 @@
 package api
 
+import "github.com/JaimeStill/herald/internal/documents"
+
 // Domain holds all domain systems that comprise the API.
-type Domain struct{}
+type Domain struct {
+	Documents documents.System
+}
 
 // NewDomain creates all domain systems from the API runtime.
 func NewDomain(runtime *Runtime) *Domain {
-	return &Domain{}
+	docsSystem := documents.New(
+		runtime.Database.Connection(),
+		runtime.Storage,
+		runtime.Logger,
+		runtime.Pagination,
+	)
+
+	return &Domain{
+		Documents: docsSystem,
+	}
 }

--- a/internal/documents/doc.go
+++ b/internal/documents/doc.go
@@ -1,1 +1,0 @@
-package documents

--- a/internal/documents/document.go
+++ b/internal/documents/document.go
@@ -1,0 +1,46 @@
+// Package documents implements the document domain for Herald.
+// It provides types, data access, and business logic for document
+// upload, registration, metadata management, and blob storage integration.
+package documents
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Document represents a registered document with its metadata and blob storage reference.
+type Document struct {
+	ID               uuid.UUID `json:"id"`
+	ExternalID       int       `json:"external_id"`
+	ExternalPlatform string    `json:"external_platform"`
+	Filename         string    `json:"filename"`
+	ContentType      string    `json:"content_type"`
+	SizeBytes        int64     `json:"size_bytes"`
+	PageCount        *int      `json:"page_count"`
+	StorageKey       string    `json:"storage_key"`
+	Status           string    `json:"status"`
+	UploadedAt       time.Time `json:"uploaded_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// CreateCommand carries the data needed to upload and register a new document.
+// Data holds the raw file bytes. PageCount is optional and may be extracted
+// by the caller via pdfcpu; nil values are stored as NULL.
+type CreateCommand struct {
+	Data             []byte
+	Filename         string
+	ContentType      string
+	ExternalID       int
+	ExternalPlatform string
+	PageCount        *int
+}
+
+// BatchResult reports the outcome of a single file within a batch upload.
+// On success, Document is populated and Error is empty.
+// On failure, Error describes the problem and Document is nil.
+type BatchResult struct {
+	Document *Document `json:"document,omitempty"`
+	Filename string    `json:"filename"`
+	Error    string    `json:"error,omitempty"`
+}

--- a/internal/documents/errors.go
+++ b/internal/documents/errors.go
@@ -1,0 +1,31 @@
+package documents
+
+import (
+	"errors"
+	"net/http"
+)
+
+// Domain errors for document operations.
+var (
+	ErrNotFound     = errors.New("document not found")
+	ErrDuplicate    = errors.New("document already exists")
+	ErrFileTooLarge = errors.New("file exceeds maximum upload size")
+	ErrInvalidFile  = errors.New("invalid file")
+)
+
+// MapHTTPStatus maps document domain errors to appropriate HTTP status codes.
+func MapHTTPStatus(err error) int {
+	if errors.Is(err, ErrNotFound) {
+		return http.StatusNotFound
+	}
+	if errors.Is(err, ErrDuplicate) {
+		return http.StatusConflict
+	}
+	if errors.Is(err, ErrFileTooLarge) {
+		return http.StatusRequestEntityTooLarge
+	}
+	if errors.Is(err, ErrInvalidFile) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}

--- a/internal/documents/mapping.go
+++ b/internal/documents/mapping.go
@@ -1,0 +1,102 @@
+package documents
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/JaimeStill/herald/pkg/query"
+	"github.com/JaimeStill/herald/pkg/repository"
+)
+
+var projection = query.
+	NewProjectionMap("public", "documents", "d").
+	Project("id", "ID").
+	Project("external_id", "ExternalID").
+	Project("external_platform", "ExternalPlatform").
+	Project("filename", "Filename").
+	Project("content_type", "ContentType").
+	Project("size_bytes", "SizeBytes").
+	Project("page_count", "PageCount").
+	Project("storage_key", "StorageKey").
+	Project("status", "Status").
+	Project("uploaded_at", "UploadedAt").
+	Project("updated_at", "UpdatedAt")
+
+var defaultSort = query.SortField{
+	Field:      "UploadedAt",
+	Descending: true,
+}
+
+// Filters contains optional filtering criteria for document queries.
+// Nil fields are ignored. Status, ExternalID, ExternalPlatform, and ContentType
+// use exact matching. Filename and StorageKey use case-insensitive contains matching.
+type Filters struct {
+	Status           *string `json:"status,omitempty"`
+	Filename         *string `json:"filename,omitempty"`
+	ExternalID       *int    `json:"external_id,omitempty"`
+	ExternalPlatform *string `json:"external_platform,omitempty"`
+	ContentType      *string `json:"content_type,omitempty"`
+	StorageKey       *string `json:"storage_key,omitempty"`
+}
+
+// Apply adds filter conditions to a query builder.
+func (f Filters) Apply(b *query.Builder) *query.Builder {
+	return b.
+		WhereEquals("Status", f.Status).
+		WhereContains("Filename", f.Filename).
+		WhereEquals("ExternalID", f.ExternalID).
+		WhereEquals("ExternalPlatform", f.ExternalPlatform).
+		WhereEquals("ContentType", f.ContentType).
+		WhereContains("StorageKey", f.StorageKey)
+}
+
+// FiltersFromQuery extracts filter values from URL query parameters.
+func FiltersFromQuery(values url.Values) Filters {
+	var f Filters
+
+	if s := values.Get("status"); s != "" {
+		f.Status = &s
+	}
+
+	if fn := values.Get("filename"); fn != "" {
+		f.Filename = &fn
+	}
+
+	if eid := values.Get("external_id"); eid != "" {
+		if v, err := strconv.Atoi(eid); err == nil {
+			f.ExternalID = &v
+		}
+	}
+
+	if ep := values.Get("external_platform"); ep != "" {
+		f.ExternalPlatform = &ep
+	}
+
+	if ct := values.Get("content_type"); ct != "" {
+		f.ContentType = &ct
+	}
+
+	if sk := values.Get("storage_key"); sk != "" {
+		f.StorageKey = &sk
+	}
+
+	return f
+}
+
+func scanDocument(s repository.Scanner) (Document, error) {
+	var d Document
+	err := s.Scan(
+		&d.ID,
+		&d.ExternalID,
+		&d.ExternalPlatform,
+		&d.Filename,
+		&d.ContentType,
+		&d.SizeBytes,
+		&d.PageCount,
+		&d.StorageKey,
+		&d.Status,
+		&d.UploadedAt,
+		&d.UpdatedAt,
+	)
+	return d, err
+}

--- a/internal/documents/repository.go
+++ b/internal/documents/repository.go
@@ -1,0 +1,188 @@
+package documents
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"path/filepath"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/pkg/pagination"
+	"github.com/JaimeStill/herald/pkg/query"
+	"github.com/JaimeStill/herald/pkg/repository"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type repo struct {
+	db         *sql.DB
+	storage    storage.System
+	logger     *slog.Logger
+	pagination pagination.Config
+}
+
+// New creates a document repository implementing the System interface.
+func New(
+	db *sql.DB,
+	store storage.System,
+	logger *slog.Logger,
+	pagination pagination.Config,
+) System {
+	return &repo{
+		db:         db,
+		storage:    store,
+		logger:     logger.With("system", "documents"),
+		pagination: pagination,
+	}
+}
+
+func (r *repo) List(
+	ctx context.Context,
+	page pagination.PageRequest,
+	filters Filters,
+) (*pagination.PageResult[Document], error) {
+	page.Normalize(r.pagination)
+
+	qb := query.
+		NewBuilder(projection, defaultSort).
+		WhereSearch(page.Search, "Filename", "ExternalPlatform")
+
+	filters.Apply(qb)
+
+	if len(page.Sort) > 0 {
+		qb.OrderByFields(page.Sort)
+	}
+
+	countSQL, countArgs := qb.BuildCount()
+	var total int
+	if err := r.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count documents: %w", err)
+	}
+
+	pageSQL, pageArgs := qb.BuildPage(page.Page, page.PageSize)
+	docs, err := repository.QueryMany(ctx, r.db, pageSQL, pageArgs, scanDocument)
+	if err != nil {
+		return nil, fmt.Errorf("query documents: %w", err)
+	}
+
+	result := pagination.NewPageResult(docs, total, page.Page, page.PageSize)
+	return &result, nil
+}
+
+func (r repo) Find(ctx context.Context, id uuid.UUID) (*Document, error) {
+	q, args := query.NewBuilder(projection).BuildSingle("ID", id)
+
+	d, err := repository.QueryOne(ctx, r.db, q, args, scanDocument)
+	if err != nil {
+		return nil, repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+	return &d, nil
+}
+
+func (r *repo) Create(ctx context.Context, cmd CreateCommand) (*Document, error) {
+	id := uuid.New()
+	key := buildStorageKey(id, sanitizeFilename(cmd.Filename))
+
+	if err := r.storage.Upload(ctx, key, bytes.NewReader(cmd.Data), cmd.ContentType); err != nil {
+		return nil, fmt.Errorf("upload document blob: %w", err)
+	}
+
+	q := `
+		INSERT INTO documents(id, external_id, external_platform, filename, content_type, size_bytes, page_count, storage_key)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, external_id, external_platform, filename, content_type, size_bytes, page_count, storage_key, status, uploaded_at, updated_at`
+
+	insertArgs := []any{
+		id,
+		cmd.ExternalID,
+		cmd.ExternalPlatform,
+		cmd.Filename,
+		cmd.ContentType,
+		int64(len(cmd.Data)),
+		cmd.PageCount,
+		key,
+	}
+
+	d, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Document, error) {
+		return repository.QueryOne(ctx, tx, q, insertArgs, scanDocument)
+	})
+
+	if err != nil {
+		if delErr := r.storage.Delete(ctx, key); delErr != nil {
+			r.logger.Warn("compensating blob delete failed", "key", key, "error", delErr)
+		}
+		return nil, repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+
+	r.logger.Info("document created", "id", d.ID, "filename", d.Filename)
+	return &d, nil
+}
+
+func (r *repo) CreateBatch(ctx context.Context, cmds []CreateCommand) []BatchResult {
+	results := make([]BatchResult, len(cmds))
+
+	for i, cmd := range cmds {
+		doc, err := r.Create(ctx, cmd)
+		if err != nil {
+			results[i] = BatchResult{
+				Filename: cmd.Filename,
+				Error:    err.Error(),
+			}
+		} else {
+			results[i] = BatchResult{
+				Document: doc,
+				Filename: cmd.Filename,
+			}
+		}
+	}
+
+	return results
+}
+
+func (r *repo) Delete(ctx context.Context, id uuid.UUID) error {
+	doc, err := r.Find(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = repository.WithTx(ctx, r.db, func(tx *sql.Tx) (struct{}, error) {
+		if err := repository.ExecExpectOne(
+			ctx, tx,
+			"DELETE FROM documents WHERE id = $1",
+			id,
+		); err != nil {
+			return struct{}{}, err
+		}
+		return struct{}{}, nil
+	})
+
+	if err != nil {
+		return repository.MapError(err, ErrNotFound, ErrDuplicate)
+	}
+
+	if delErr := r.storage.Delete(ctx, doc.StorageKey); delErr != nil {
+		r.logger.Warn(
+			"blob delete failed after DB delete",
+			"key", doc.StorageKey,
+			"error", delErr,
+		)
+	}
+
+	r.logger.Info("document deleted", "id", id)
+	return nil
+}
+
+func buildStorageKey(id uuid.UUID, filename string) string {
+	return fmt.Sprintf("documents/%s/%s", id, filename)
+}
+
+func sanitizeFilename(name string) string {
+	name = filepath.Base(name)
+	if name == "." || name == "" {
+		name = "document"
+	}
+	return url.PathEscape(name)
+}

--- a/internal/documents/system.go
+++ b/internal/documents/system.go
@@ -1,0 +1,23 @@
+package documents
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/pkg/pagination"
+)
+
+// System defines the public contract for document domain operations.
+type System interface {
+	List(
+		ctx context.Context,
+		page pagination.PageRequest,
+		filters Filters,
+	) (*pagination.PageResult[Document], error)
+
+	Find(ctx context.Context, id uuid.UUID) (*Document, error)
+	Create(ctx context.Context, cmd CreateCommand) (*Document, error)
+	CreateBatch(ctx context.Context, cmds []CreateCommand) []BatchResult
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/tests/documents/documents_test.go
+++ b/tests/documents/documents_test.go
@@ -1,0 +1,229 @@
+package documents_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/JaimeStill/herald/internal/documents"
+	"github.com/JaimeStill/herald/pkg/query"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestMapHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		want   int
+	}{
+		{"not found", documents.ErrNotFound, http.StatusNotFound},
+		{"duplicate", documents.ErrDuplicate, http.StatusConflict},
+		{"file too large", documents.ErrFileTooLarge, http.StatusRequestEntityTooLarge},
+		{"invalid file", documents.ErrInvalidFile, http.StatusBadRequest},
+		{"unknown error", errors.New("something else"), http.StatusInternalServerError},
+		{"wrapped not found", fmt.Errorf("find failed: %w", documents.ErrNotFound), http.StatusNotFound},
+		{"wrapped duplicate", fmt.Errorf("insert failed: %w", documents.ErrDuplicate), http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := documents.MapHTTPStatus(tt.err)
+			if got != tt.want {
+				t.Errorf("MapHTTPStatus(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFiltersFromQuery(t *testing.T) {
+	t.Run("all params present", func(t *testing.T) {
+		values := url.Values{
+			"status":            {"pending"},
+			"filename":          {"report"},
+			"external_id":       {"42"},
+			"external_platform": {"sharepoint"},
+			"content_type":      {"application/pdf"},
+			"storage_key":       {"documents/abc"},
+		}
+
+		f := documents.FiltersFromQuery(values)
+
+		if f.Status == nil || *f.Status != "pending" {
+			t.Errorf("Status = %v, want pending", f.Status)
+		}
+		if f.Filename == nil || *f.Filename != "report" {
+			t.Errorf("Filename = %v, want report", f.Filename)
+		}
+		if f.ExternalID == nil || *f.ExternalID != 42 {
+			t.Errorf("ExternalID = %v, want 42", f.ExternalID)
+		}
+		if f.ExternalPlatform == nil || *f.ExternalPlatform != "sharepoint" {
+			t.Errorf("ExternalPlatform = %v, want sharepoint", f.ExternalPlatform)
+		}
+		if f.ContentType == nil || *f.ContentType != "application/pdf" {
+			t.Errorf("ContentType = %v, want application/pdf", f.ContentType)
+		}
+		if f.StorageKey == nil || *f.StorageKey != "documents/abc" {
+			t.Errorf("StorageKey = %v, want documents/abc", f.StorageKey)
+		}
+	})
+
+	t.Run("empty params yield nil fields", func(t *testing.T) {
+		f := documents.FiltersFromQuery(url.Values{})
+
+		if f.Status != nil {
+			t.Errorf("Status = %v, want nil", f.Status)
+		}
+		if f.Filename != nil {
+			t.Errorf("Filename = %v, want nil", f.Filename)
+		}
+		if f.ExternalID != nil {
+			t.Errorf("ExternalID = %v, want nil", f.ExternalID)
+		}
+		if f.ExternalPlatform != nil {
+			t.Errorf("ExternalPlatform = %v, want nil", f.ExternalPlatform)
+		}
+		if f.ContentType != nil {
+			t.Errorf("ContentType = %v, want nil", f.ContentType)
+		}
+		if f.StorageKey != nil {
+			t.Errorf("StorageKey = %v, want nil", f.StorageKey)
+		}
+	})
+
+	t.Run("invalid external_id ignored", func(t *testing.T) {
+		values := url.Values{"external_id": {"not-a-number"}}
+		f := documents.FiltersFromQuery(values)
+
+		if f.ExternalID != nil {
+			t.Errorf("ExternalID = %v, want nil for invalid input", f.ExternalID)
+		}
+	})
+
+	t.Run("partial params", func(t *testing.T) {
+		values := url.Values{
+			"status":   {"review"},
+			"filename": {"classified"},
+		}
+
+		f := documents.FiltersFromQuery(values)
+
+		if f.Status == nil || *f.Status != "review" {
+			t.Errorf("Status = %v, want review", f.Status)
+		}
+		if f.Filename == nil || *f.Filename != "classified" {
+			t.Errorf("Filename = %v, want classified", f.Filename)
+		}
+		if f.ExternalPlatform != nil {
+			t.Errorf("ExternalPlatform = %v, want nil", f.ExternalPlatform)
+		}
+	})
+}
+
+func TestFiltersApply(t *testing.T) {
+	projection := query.
+		NewProjectionMap("public", "documents", "d").
+		Project("status", "Status").
+		Project("filename", "Filename").
+		Project("external_id", "ExternalID").
+		Project("external_platform", "ExternalPlatform").
+		Project("content_type", "ContentType").
+		Project("storage_key", "StorageKey")
+
+	t.Run("no filters produces no WHERE clause", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{}
+		f.Apply(b)
+		sql, args := b.Build()
+
+		wantSQL := "SELECT d.status, d.filename, d.external_id, d.external_platform, d.content_type, d.storage_key FROM public.documents d"
+		if sql != wantSQL {
+			t.Errorf("sql = %q, want %q", sql, wantSQL)
+		}
+		if len(args) != 0 {
+			t.Errorf("args = %v, want empty", args)
+		}
+	})
+
+	t.Run("status equals filter", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{Status: ptr("pending")}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 1 {
+			t.Fatalf("args length = %d, want 1", len(args))
+		}
+		if v, ok := args[0].(*string); !ok || *v != "pending" {
+			t.Errorf("args[0] = %v, want *pending", args[0])
+		}
+	})
+
+	t.Run("filename contains filter", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{Filename: ptr("report")}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 1 || args[0] != "%report%" {
+			t.Errorf("args = %v, want [%%report%%]", args)
+		}
+	})
+
+	t.Run("storage key contains filter", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{StorageKey: ptr("documents/abc")}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 1 || args[0] != "%documents/abc%" {
+			t.Errorf("args = %v, want [%%documents/abc%%]", args)
+		}
+	})
+
+	t.Run("multiple filters combine with AND", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{
+			Status:           ptr("pending"),
+			Filename:         ptr("report"),
+			ExternalPlatform: ptr("sharepoint"),
+		}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 3 {
+			t.Errorf("args length = %d, want 3", len(args))
+		}
+	})
+
+	t.Run("external_id equals filter", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{ExternalID: ptr(42)}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 1 {
+			t.Fatalf("args length = %d, want 1", len(args))
+		}
+		if v, ok := args[0].(*int); !ok || *v != 42 {
+			t.Errorf("args[0] = %v, want *42", args[0])
+		}
+	})
+
+	t.Run("content_type equals filter", func(t *testing.T) {
+		b := query.NewBuilder(projection)
+		f := documents.Filters{ContentType: ptr("application/pdf")}
+		f.Apply(b)
+		_, args := b.Build()
+
+		if len(args) != 1 {
+			t.Fatalf("args length = %d, want 1", len(args))
+		}
+		if v, ok := args[0].(*string); !ok || *v != "application/pdf" {
+			t.Errorf("args[0] = %v, want *application/pdf", args[0])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Establish the complete document domain foundation layer in `internal/documents/` — types, data access, and business logic with no HTTP handler concerns. The domain follows the System/Repository/Mapping/Errors pattern adapted from agent-lab.

Closes #16

## Changes

- **`internal/documents/document.go`** — Document, CreateCommand, and BatchResult types matching migration 000001 schema
- **`internal/documents/errors.go`** — Domain errors (ErrNotFound, ErrDuplicate, ErrFileTooLarge, ErrInvalidFile) and MapHTTPStatus
- **`internal/documents/mapping.go`** — ProjectionMap, scanDocument, Filters (Status, Filename, ExternalID, ExternalPlatform, ContentType, StorageKey), FiltersFromQuery, Apply
- **`internal/documents/system.go`** — System interface (List, Find, Create, CreateBatch, Delete)
- **`internal/documents/repository.go`** — Repository implementation with blob+DB atomicity, compensating delete, paginated filtered queries
- **`internal/api/domain.go`** — Wired documents.System into API Domain
- **`tests/documents/documents_test.go`** — 18 tests covering MapHTTPStatus, FiltersFromQuery, and Filters.Apply
- **`CHANGELOG.md`** — v0.1.0-dev.3.16 entry