### PR TITLE
Add blob storage query endpoints

### DIFF
--- a/.claude/context/guides/.archive/21-blob-storage-query-endpoints.md
+++ b/.claude/context/guides/.archive/21-blob-storage-query-endpoints.md
@@ -1,0 +1,468 @@
+# 21 - Blob Storage Query Endpoints
+
+## Problem Context
+
+The document domain provides CRUD operations against PostgreSQL, but there are no endpoints for querying Azure Blob Storage directly. Clients cannot list what's in the store, inspect blob metadata, or download files without going through the SQL layer. This task adds three read-only HTTP endpoints under `/api/storage`.
+
+## Architecture Approach
+
+- **No domain system** — the storage handler talks directly to `storage.System`
+- **Handler in `internal/api/`** as an unexported `storageHandler`
+- **Marker-based pagination** — uses Azure's opaque continuation tokens, not `PageRequest/PageResult`
+- **Richer `Download` return** — change from `(io.ReadCloser, error)` to `(*BlobResult, error)` since the method is unused outside tests
+
+## Implementation
+
+### Step 1: Add `MaxListSize` to storage config
+
+**File:** `pkg/storage/config.go`
+
+Add `MaxListSize` field to the `Config` struct:
+
+```go
+type Config struct {
+	ContainerName    string `toml:"container_name"`
+	ConnectionString string `toml:"connection_string"`
+	MaxListSize      int32  `toml:"max_list_size"`
+}
+```
+
+Add the corresponding field to the `Env` struct:
+
+```go
+type Env struct {
+	ContainerName    string
+	ConnectionString string
+	MaxListSize      string
+}
+```
+
+Add the default in `loadDefaults()`:
+
+```go
+func (c *Config) loadDefaults() {
+	if c.ContainerName == "" {
+		c.ContainerName = "documents"
+	}
+	if c.MaxListSize == 0 {
+		c.MaxListSize = 50
+	}
+}
+```
+
+Add the env var override in `loadEnv()`:
+
+```go
+if env.MaxListSize != "" {
+	if v := os.Getenv(env.MaxListSize); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.MaxListSize = int32(n)
+		}
+	}
+}
+```
+
+This requires adding `"strconv"` to the imports.
+
+Add the merge overlay in `Merge()`:
+
+```go
+if overlay.MaxListSize != 0 {
+	c.MaxListSize = overlay.MaxListSize
+}
+```
+
+**File:** `internal/config/config.go`
+
+Add the env var mapping to `storageEnv`:
+
+```go
+var storageEnv = &storage.Env{
+	ContainerName:    "HERALD_STORAGE_CONTAINER_NAME",
+	ConnectionString: "HERALD_STORAGE_CONNECTION_STRING",
+	MaxListSize:      "HERALD_STORAGE_MAX_LIST_SIZE",
+}
+```
+
+### Step 2: Add `MaxListCap` constant and `ParseMaxResults` function
+
+**File:** `pkg/storage/storage.go`
+
+Add a package-level constant for the Azure hard ceiling and a function that encapsulates parsing, validation, and capping:
+
+```go
+const MaxListCap int32 = 5000
+```
+
+```go
+func ParseMaxResults(s string, fallback int32) (int32, error) {
+	if s == "" {
+		return fallback, nil
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("invalid max_results parameter")
+	}
+
+	return min(int32(n), MaxListCap), nil
+}
+```
+
+This requires adding `"strconv"` to the imports.
+
+**File:** `pkg/storage/config.go`
+
+Cap `MaxListSize` at `MaxListCap` in `loadDefaults()` and `loadEnv()`:
+
+In `loadDefaults()`, after setting the default:
+
+```go
+if c.MaxListSize == 0 {
+	c.MaxListSize = 50
+}
+if c.MaxListSize > MaxListCap {
+	c.MaxListSize = MaxListCap
+}
+```
+
+In `loadEnv()`, after parsing the env var value, apply the same cap:
+
+```go
+if env.MaxListSize != "" {
+	if v := os.Getenv(env.MaxListSize); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.MaxListSize = min(int32(n), MaxListCap)
+		}
+	}
+}
+```
+
+### Step 3: Add types, extend interface, update `Download` signature
+
+**File:** `pkg/storage/storage.go`
+
+Add `time` and `"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"` to imports.
+
+Add these types after the `System` interface. `BlobMeta` is the single metadata type used across all three endpoints — list, properties, and download:
+
+```go
+type BlobMeta struct {
+	Name          string    `json:"name"`
+	ContentType   string    `json:"content_type"`
+	ContentLength int64     `json:"content_length"`
+	LastModified  time.Time `json:"last_modified"`
+	ETag          string    `json:"etag"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+type BlobList struct {
+	Blobs      []BlobMeta `json:"blobs"`
+	NextMarker string     `json:"next_marker,omitempty"`
+}
+
+type BlobResult struct {
+	BlobMeta
+	Body io.ReadCloser `json:"-"`
+}
+```
+
+Update `Download` in the `System` interface from:
+
+```go
+Download(ctx context.Context, key string) (io.ReadCloser, error)
+```
+
+to:
+
+```go
+Download(ctx context.Context, key string) (*BlobResult, error)
+```
+
+Add two new methods to `System`:
+
+```go
+List(ctx context.Context, prefix string, marker string, maxResults int32) (*BlobList, error)
+Find(ctx context.Context, key string) (*BlobMeta, error)
+```
+
+### Step 4: Update `Download` implementation and add new methods
+
+**File:** `pkg/storage/storage.go`
+
+Replace the existing `Download` method:
+
+```go
+func (a *azure) Download(ctx context.Context, key string) (*BlobResult, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+
+	resp, err := a.client.DownloadStream(ctx, a.container, key, nil)
+	if err != nil {
+		if bloberror.HasCode(err, bloberror.BlobNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("download blob %s: %w", key, err)
+	}
+
+	result := &BlobResult{
+		BlobMeta: BlobMeta{Name: key},
+		Body:     resp.Body,
+	}
+	if resp.ContentType != nil {
+		result.ContentType = *resp.ContentType
+	}
+	if resp.ContentLength != nil {
+		result.ContentLength = *resp.ContentLength
+	}
+	return result, nil
+}
+```
+
+Add the `List` method. `NewListBlobsFlatPager` is on the container client, not the top-level azblob client:
+
+```go
+func (a *azure) List(ctx context.Context, prefix string, marker string, maxResults int32) (*BlobList, error) {
+	containerClient := a.client.ServiceClient().NewContainerClient(a.container)
+
+	opts := &container.ListBlobsFlatOptions{
+		MaxResults: &maxResults,
+	}
+	if prefix != "" {
+		opts.Prefix = &prefix
+	}
+	if marker != "" {
+		opts.Marker = &marker
+	}
+
+	pager := containerClient.NewListBlobsFlatPager(opts)
+	if !pager.More() {
+		return &BlobList{Blobs: []BlobMeta{}}, nil
+	}
+
+	resp, err := pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list blobs: %w", err)
+	}
+
+	blobs := make([]BlobMeta, 0, len(resp.Segment.BlobItems))
+	for _, b := range resp.Segment.BlobItems {
+		var meta BlobMeta
+		if b.Name != nil {
+			meta.Name = *b.Name
+		}
+		if b.Properties != nil {
+			if b.Properties.ContentType != nil {
+				meta.ContentType = *b.Properties.ContentType
+			}
+			if b.Properties.ContentLength != nil {
+				meta.ContentLength = *b.Properties.ContentLength
+			}
+			if b.Properties.LastModified != nil {
+				meta.LastModified = *b.Properties.LastModified
+			}
+			if b.Properties.ETag != nil {
+				meta.ETag = string(*b.Properties.ETag)
+			}
+			if b.Properties.CreationTime != nil {
+				meta.CreatedAt = *b.Properties.CreationTime
+			}
+		}
+		blobs = append(blobs, meta)
+	}
+
+	result := &BlobList{Blobs: blobs}
+	if resp.NextMarker != nil && *resp.NextMarker != "" {
+		result.NextMarker = *resp.NextMarker
+	}
+	return result, nil
+}
+```
+
+Add `Find` following the existing `Exists` pattern:
+
+```go
+func (a *azure) Find(ctx context.Context, key string) (*BlobMeta, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+
+	blobClient := a.client.
+		ServiceClient().
+		NewContainerClient(a.container).
+		NewBlobClient(key)
+
+	resp, err := blobClient.GetProperties(ctx, nil)
+	if err != nil {
+		if bloberror.HasCode(err, bloberror.BlobNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get blob properties %s: %w", key, err)
+	}
+
+	meta := &BlobMeta{Name: key}
+	if resp.ContentType != nil {
+		meta.ContentType = *resp.ContentType
+	}
+	if resp.ContentLength != nil {
+		meta.ContentLength = *resp.ContentLength
+	}
+	if resp.LastModified != nil {
+		meta.LastModified = *resp.LastModified
+	}
+	if resp.ETag != nil {
+		meta.ETag = string(*resp.ETag)
+	}
+	if resp.CreationTime != nil {
+		meta.CreatedAt = *resp.CreationTime
+	}
+	return meta, nil
+}
+```
+
+### Step 5: Create storage handler
+
+**File:** `internal/api/storage.go` (new)
+
+```go
+package api
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"strconv"
+
+	"github.com/JaimeStill/herald/pkg/handlers"
+	"github.com/JaimeStill/herald/pkg/routes"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type storageHandler struct {
+	store       storage.System
+	logger      *slog.Logger
+	maxListSize int32
+}
+
+func newStorageHandler(store storage.System, logger *slog.Logger, maxListSize int32) *storageHandler {
+	return &storageHandler{
+		store:       store,
+		logger:      logger.With("handler", "storage"),
+		maxListSize: maxListSize,
+	}
+}
+
+func (h *storageHandler) routes() routes.Group {
+	return routes.Group{
+		Prefix: "/storage",
+		Routes: []routes.Route{
+			{Method: "GET", Pattern: "", Handler: h.list},
+			{Method: "GET", Pattern: "/download/{key...}", Handler: h.download},
+			{Method: "GET", Pattern: "/{key...}", Handler: h.find},
+		},
+	}
+}
+
+func (h *storageHandler) list(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+	marker := r.URL.Query().Get("marker")
+
+	maxResults, err := storage.ParseMaxResults(r.URL.Query().Get("max_results"), h.maxListSize)
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusBadRequest, err)
+		return
+	}
+
+	result, err := h.store.List(r.Context(), prefix, marker, maxResults)
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusInternalServerError, err)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *storageHandler) find(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	meta, err := h.store.Find(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(w, h.logger, storage.MapHTTPStatus(err), err)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, meta)
+}
+
+func (h *storageHandler) download(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	result, err := h.store.Download(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(w, h.logger, storage.MapHTTPStatus(err), err)
+		return
+	}
+	defer result.Body.Close()
+
+	w.Header().Set("Content-Type", result.ContentType)
+	if result.ContentLength > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(result.ContentLength, 10))
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", path.Base(key)))
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, result.Body)
+}
+
+// storage.MapHTTPStatus removed — use storage.MapHTTPStatus from pkg/storage/errors.go
+```
+
+### Step 6: Wire into API module
+
+**File:** `internal/api/routes.go`
+
+Add `runtime *Runtime` parameter and register the storage handler route group:
+
+```go
+func registerRoutes(
+	mux *http.ServeMux,
+	domain *Domain,
+	cfg *config.Config,
+	runtime *Runtime,
+) {
+	storageH := newStorageHandler(runtime.Storage, runtime.Logger, cfg.Storage.MaxListSize)
+
+	routes.Register(
+		mux,
+		domain.Documents.Handler(cfg.API.MaxUploadSizeBytes()).Routes(),
+		storageH.routes(),
+	)
+}
+```
+
+**File:** `internal/api/api.go`
+
+Update the `registerRoutes` call to pass `runtime`:
+
+```go
+registerRoutes(mux, domain, cfg, runtime)
+```
+
+### Step 7: Update existing test
+
+**File:** `tests/storage/storage_test.go`
+
+The `Download` call in `TestKeyValidation` currently returns `(io.ReadCloser, error)` — now returns `(*storage.BlobResult, error)`. Since the result is discarded with `_`, no other changes needed.
+
+## Validation Criteria
+
+- [ ] `storage.System` interface extended with `List`, `Find`, and updated `Download`
+- [ ] `GET /api/storage` returns blob listing with marker-based pagination
+- [ ] `GET /api/storage/properties?key=...` returns blob metadata JSON
+- [ ] `GET /api/storage/download?key=...` streams blob with correct Content-Type and Content-Disposition headers
+- [ ] All endpoints work against Azurite in local development
+- [ ] `go vet ./...` passes
+- [ ] Tests pass (`mise run test`)
+- [ ] API Cartographer documentation generated at `_project/api/storage/`

--- a/.claude/context/sessions/21-blob-storage-query-endpoints.md
+++ b/.claude/context/sessions/21-blob-storage-query-endpoints.md
@@ -1,0 +1,47 @@
+# 21 - Blob Storage Query Endpoints
+
+## Summary
+
+Added three read-only HTTP endpoints under `/api/storage` that query Azure Blob Storage directly, bypassing the SQL layer. Extended the `storage.System` interface with `List`, `Find`, and updated `Download` to return a richer `BlobResult` type. Created a storage handler in `internal/api/` wired directly to the storage system without a domain layer.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Type consolidation | Single `BlobMeta` type + `BlobResult` embedding | Eliminates redundancy between list items, properties, and download metadata |
+| `Download` return type | `*BlobResult` (embeds `BlobMeta` + `Body`) | Surfaces content type and length from a single Azure call; method was unused so signature change was safe |
+| No domain system | Handler talks directly to `storage.System` | Pure pass-through queries; domain system would be unnecessary indirection |
+| Handler placement | Unexported `storageHandler` in `internal/api/` | No separate package needed without a domain system |
+| Marker-based pagination | `BlobList` with `NextMarker`, not `PageResult` | Azure Blob Storage uses opaque continuation tokens, not offset-based pages |
+| Path parameters for keys | `/{key...}` and `/download/{key...}` wildcards | Blob keys contain slashes; wildcard captures full path cleanly |
+| `MaxListSize` config | Configurable default with `MaxListCap` constant (5000) | Consistent with pagination config pattern; deployments can tune the default |
+| `ParseMaxResults` in `pkg/storage` | Encapsulates parsing, validation, and capping | Keeps handler clean; reusable; upper limit defined once as `MaxListCap` |
+| `MapHTTPStatus` in `pkg/storage/errors.go` | Co-located with error definitions | Consistent with `documents.MapHTTPStatus` pattern |
+| Inline nil checks | No `deref` helper functions | Explicit value handling at the Azure SDK boundary; avoids hiding behavior |
+
+## Files Modified
+
+- `pkg/storage/storage.go` — `BlobMeta`, `BlobList`, `BlobResult` types; `List`, `Find`, `ParseMaxResults`; updated `Download` signature and implementation
+- `pkg/storage/config.go` — `MaxListSize` field, env override, cap at `MaxListCap`
+- `pkg/storage/errors.go` — `MapHTTPStatus` function
+- `internal/api/storage.go` — new `storageHandler` with `list`, `find`, `download` endpoints
+- `internal/api/routes.go` — wired storage handler, added `runtime` parameter
+- `internal/api/api.go` — passed `runtime` to `registerRoutes`
+- `internal/config/config.go` — `HERALD_STORAGE_MAX_LIST_SIZE` env var mapping
+- `_project/api/storage.md` — API Cartographer spec for storage endpoints
+- `_project/api/README.md` — added storage group to route table
+- `tests/storage/storage_test.go` — `TestMapHTTPStatus`, `TestParseMaxResults`, `Find` in key validation
+- `tests/storage/config_test.go` — `MaxListSize` default, env override, cap, merge tests
+
+## Patterns Established
+
+- **Direct handler on `pkg/` interface**: When endpoints are pure pass-through to a `pkg/`-level system (no domain logic), the handler lives in `internal/api/` without a domain system layer
+- **Wildcard path parameters for storage keys**: `/{key...}` captures slash-containing blob keys
+- **Config-driven defaults with hard cap constant**: `MaxListSize` is configurable but capped at `MaxListCap`; `ParseMaxResults` encapsulates the parsing logic
+- **`MapHTTPStatus` on storage errors**: Error-to-status mapping co-located with sentinel errors in `pkg/storage/errors.go`
+
+## Validation Results
+
+- `go vet ./...` passes
+- `go test ./tests/...` — all 15 packages pass
+- Manual verification against Azurite: list, find, and download all return correct responses

--- a/.claude/plans/compiled-dazzling-wolf.md
+++ b/.claude/plans/compiled-dazzling-wolf.md
@@ -1,0 +1,104 @@
+# Issue #21 — Blob Storage Query Endpoints
+
+## Context
+
+The document domain provides CRUD operations against PostgreSQL, but there are no endpoints for querying Azure Blob Storage directly. Clients cannot list what's in the store, inspect blob metadata, or download files without going through the SQL layer. This adds three read-only endpoints under `/api/storage`.
+
+## Architecture Approach
+
+**No domain system needed.** The storage handler talks directly to `storage.System` (a `pkg/`-level interface). A domain system would be an unnecessary indirection for pure pass-through queries.
+
+**Handler in `internal/api/`**, not a separate package. The `storageHandler` is unexported in the `api` package — an internal implementation detail of the API module wired alongside the documents handler.
+
+**Marker-based pagination** — Azure Blob Storage uses opaque continuation tokens. The `ListResult` type does NOT use `PageRequest/PageResult` from `pkg/pagination/` because that pattern assumes offset-based pagination with total counts.
+
+**Richer `Download` return type** — The current `Download` method returns `(io.ReadCloser, error)`. Since it's unused outside tests (which discard the result), we change it to return `(*DownloadResult, error)` where `DownloadResult` bundles the body stream with content type, content length, and content disposition metadata. This lets the download handler set proper HTTP headers from a single Azure `DownloadStream` call instead of making a separate `GetProperties` round-trip.
+
+## Implementation
+
+### Step 1: Add types and extend `System` interface
+
+**File:** `pkg/storage/storage.go` (modify)
+
+Add `time` to imports. Add four new types:
+
+- `BlobItem` — name, content type, content length, last modified (for list results)
+- `BlobProperties` — extends BlobItem with ETag and created-at (for properties endpoint)
+- `ListResult` — items slice + optional next marker
+- `DownloadResult` — body `io.ReadCloser`, content type, content length (replaces raw `io.ReadCloser` return)
+
+Change `Download` return type from `(io.ReadCloser, error)` to `(*DownloadResult, error)`.
+
+Add two new methods to `System`:
+
+- `List(ctx, prefix, marker string, maxResults int32) (*ListResult, error)`
+- `GetProperties(ctx, key string) (*BlobProperties, error)`
+
+### Step 2: Update `Download` implementation
+
+**File:** `pkg/storage/storage.go` (modify)
+
+Update the `azure.Download` method to return `*DownloadResult` populated from the `DownloadStream` response's `ContentType` and `ContentLength` fields alongside the body.
+
+### Step 3: Implement `List` on `azure` struct
+
+**File:** `pkg/storage/storage.go` (modify)
+
+Uses `a.client.NewListBlobsFlatPager(a.container, opts)` with `Prefix`, `Marker`, and `MaxResults` on `ListBlobsFlatOptions`. Calls `pager.NextPage(ctx)` once for a single page. Maps `resp.Segment.BlobItems` to `[]BlobItem`. Returns `NextMarker` if present.
+
+Add pointer helpers `deref(*string) string` and `derefInt64(*int64) int64`.
+
+### Step 4: Implement `GetProperties` on `azure` struct
+
+**File:** `pkg/storage/storage.go` (modify)
+
+Follows the existing `Exists` pattern — builds blob client via `a.client.ServiceClient().NewContainerClient(a.container).NewBlobClient(key)`, calls `GetProperties`, maps `BlobNotFound` to `ErrNotFound`. Returns `BlobProperties` with all available metadata.
+
+### Step 5: Create storage handler
+
+**File:** `internal/api/storage.go` (new)
+
+Unexported `storageHandler` struct with `store storage.System` and `logger *slog.Logger`. Constructor `newStorageHandler`. Method `routes()` returning `routes.Group{Prefix: "/storage", ...}` with three routes:
+
+- `GET ""` → `list` — parses `prefix`, `marker`, `max_results` query params, defaults max to 50, caps at 5000
+- `GET "/properties"` → `properties` — parses `key` query param, calls `GetProperties`, maps errors
+- `GET "/download"` → `download` — parses `key`, calls `Download` (now returns `DownloadResult` with metadata), streams body with `Content-Type`, `Content-Length`, `Content-Disposition` headers
+
+Local `mapStorageHTTPStatus(err) int` for error → HTTP status mapping.
+
+### Step 6: Wire into API module
+
+**File:** `internal/api/routes.go` (modify)
+
+Add `runtime *Runtime` parameter to `registerRoutes`. Create `storageHandler` from `runtime.Storage` and `runtime.Logger`. Register its route group alongside documents.
+
+**File:** `internal/api/api.go` (modify)
+
+Pass `runtime` to `registerRoutes`.
+
+### Step 7: Update existing test
+
+**File:** `tests/storage/storage_test.go` (modify)
+
+Update the `Download` call in `TestKeyValidation` to match the new return type (`*DownloadResult` instead of `io.ReadCloser`). The test discards the result — only the variable type changes.
+
+## Files Changed
+
+| File | Status | Purpose |
+|------|--------|---------|
+| `pkg/storage/storage.go` | Modify | Types, interface change, new methods, azure implementations, helpers |
+| `internal/api/storage.go` | New | Storage handler with list, properties, download endpoints |
+| `internal/api/routes.go` | Modify | Wire storage handler, add runtime parameter |
+| `internal/api/api.go` | Modify | Pass runtime to registerRoutes |
+| `tests/storage/storage_test.go` | Modify | Update Download call for new return type |
+
+## Validation Criteria
+
+- [ ] `storage.System` interface extended with `List`, `GetProperties`, and updated `Download`
+- [ ] `GET /api/storage` returns blob listing with marker-based pagination
+- [ ] `GET /api/storage/properties?key=...` returns blob metadata JSON
+- [ ] `GET /api/storage/download?key=...` streams blob with correct Content-Type and Content-Disposition headers
+- [ ] All endpoints work against Azurite in local development
+- [ ] `go vet ./...` passes
+- [ ] `mise run test` passes
+- [ ] API Cartographer documentation generated at `_project/api/storage/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.0-dev.3.21
+
+- Add read-only blob storage query endpoints (list, find, download) with marker-based pagination, configurable max list size, and wildcard path parameter routing (#21)
+
 ## v0.1.0-dev.3.17
 
 - Add document HTTP handlers (List, Find, Search, Upload, Delete), multipart upload with pdfcpu page count extraction, configurable max upload size, and API route wiring (#17)

--- a/_project/api/README.md
+++ b/_project/api/README.md
@@ -20,6 +20,7 @@ export HERALD_API_BASE="http://localhost:8080"
 | Group | Path Prefix | Description |
 |-------|-------------|-------------|
 | [Documents](documents.md) | `/api/documents` | Document upload and management |
+| [Storage](storage.md) | `/api/storage` | Read-only blob storage queries |
 
 ## Root Endpoints
 

--- a/_project/api/storage.md
+++ b/_project/api/storage.md
@@ -1,0 +1,96 @@
+# Storage
+
+`/api/storage`
+
+Read-only Azure Blob Storage queries. Lists blobs, retrieves metadata, and downloads files directly from blob storage without going through the SQL layer.
+
+---
+
+## List Blobs
+
+`GET /api/storage`
+
+Returns a page of blobs with optional prefix filtering and marker-based pagination.
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| prefix | string | no | Filter blobs by name prefix |
+| marker | string | no | Opaque continuation token from a previous response |
+| max_results | integer | no | Maximum items per page (default 50, max 5000) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Blob listing with optional next_marker for pagination |
+| 400 | Invalid max_results parameter |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/storage" | jq .
+```
+
+### Full Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/storage?prefix=documents/&max_results=20&marker=abc123" | jq .
+```
+
+---
+
+## Find Blob
+
+`GET /api/storage/{key...}`
+
+Returns metadata for a single blob by storage key.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| key | string (wildcard) | Blob storage key (may contain slashes) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Blob metadata |
+| 400 | Invalid key |
+| 404 | Blob not found |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/storage/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf" | jq .
+```
+
+---
+
+## Download Blob
+
+`GET /api/storage/download/{key...}`
+
+Downloads a file by storage key. Streams the blob with appropriate Content-Type and Content-Disposition headers.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| key | string (wildcard) | Blob storage key (may contain slashes) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | File stream with Content-Type, Content-Length, and Content-Disposition headers |
+| 400 | Invalid key |
+| 404 | Blob not found |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/storage/download/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf" -o report.pdf
+```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,7 +16,7 @@ func NewModule(cfg *config.Config, infra *infrastructure.Infrastructure) (*modul
 	domain := NewDomain(runtime)
 
 	mux := http.NewServeMux()
-	registerRoutes(mux, domain, cfg)
+	registerRoutes(mux, domain, cfg, runtime)
 
 	m := module.New(cfg.API.BasePath, mux)
 	m.Use(middleware.CORS(&cfg.API.CORS))

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -11,9 +11,19 @@ func registerRoutes(
 	mux *http.ServeMux,
 	domain *Domain,
 	cfg *config.Config,
+	runtime *Runtime,
 ) {
+
+	documentsRoutes := domain.Documents.Handler(cfg.API.MaxUploadSizeBytes()).Routes()
+	storageRoutes := newStorageHandler(
+		runtime.Storage,
+		runtime.Logger,
+		cfg.Storage.MaxListSize,
+	).routes()
+
 	routes.Register(
 		mux,
-		domain.Documents.Handler(cfg.API.MaxUploadSizeBytes()).Routes(),
+		documentsRoutes,
+		storageRoutes,
 	)
 }

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"strconv"
+
+	"github.com/JaimeStill/herald/pkg/handlers"
+	"github.com/JaimeStill/herald/pkg/routes"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type storageHandler struct {
+	store       storage.System
+	logger      *slog.Logger
+	maxListSize int32
+}
+
+func newStorageHandler(
+	store storage.System,
+	logger *slog.Logger,
+	maxListSize int32,
+) *storageHandler {
+	return &storageHandler{
+		store:       store,
+		logger:      logger.With("handler", "storage"),
+		maxListSize: maxListSize,
+	}
+}
+
+func (h *storageHandler) routes() routes.Group {
+	return routes.Group{
+		Prefix: "/storage",
+		Routes: []routes.Route{
+			{Method: "GET", Pattern: "", Handler: h.list},
+			{Method: "GET", Pattern: "/download/{key...}", Handler: h.download},
+			{Method: "GET", Pattern: "/{key...}", Handler: h.find},
+		},
+	}
+}
+
+func (h *storageHandler) list(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+	marker := r.URL.Query().Get("marker")
+
+	maxResults, err := storage.ParseMaxResults(
+		r.URL.Query().Get("max_results"),
+		h.maxListSize,
+	)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			http.StatusBadRequest, err,
+		)
+		return
+	}
+
+	result, err := h.store.List(
+		r.Context(),
+		prefix,
+		marker,
+		maxResults,
+	)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			http.StatusInternalServerError, err,
+		)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, result)
+}
+
+func (h *storageHandler) find(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	meta, err := h.store.Find(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			storage.MapHTTPStatus(err), err,
+		)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, meta)
+}
+
+func (h *storageHandler) download(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	result, err := h.store.Download(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			storage.MapHTTPStatus(err), err,
+		)
+		return
+	}
+	defer result.Body.Close()
+
+	w.Header().Set("Content-Type", result.ContentType)
+
+	if result.ContentLength > 0 {
+		w.Header().Set(
+			"Content-Length",
+			strconv.FormatInt(result.ContentLength, 10),
+		)
+	}
+	w.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf("attachment; filename=%q", path.Base(key)),
+	)
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, result.Body)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ var databaseEnv = &database.Env{
 var storageEnv = &storage.Env{
 	ContainerName:    "HERALD_STORAGE_CONTAINER_NAME",
 	ConnectionString: "HERALD_STORAGE_CONNECTION_STRING",
+	MaxListSize:      "HERALD_STORAGE_MAX_LIST_SIZE",
 }
 
 // Config is the root configuration for the Herald service.

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,6 +1,9 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+)
 
 var (
 	// ErrNotFound indicates the requested blob does not exist.
@@ -10,3 +13,14 @@ var (
 	// ErrInvalidKey indicates the storage key contains a path traversal segment.
 	ErrInvalidKey = errors.New("storage key contains invalid path segment")
 )
+
+// MapHTTPStatus maps storage errors to HTTP status codes.
+func MapHTTPStatus(err error) int {
+	if errors.Is(err, ErrNotFound) {
+		return http.StatusNotFound
+	}
+	if errors.Is(err, ErrEmptyKey) || errors.Is(err, ErrInvalidKey) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}


### PR DESCRIPTION
## Summary

Add three read-only HTTP endpoints under `/api/storage` that query Azure Blob Storage directly, bypassing the SQL layer:

- `GET /api/storage` — List blobs with prefix filtering and marker-based pagination
- `GET /api/storage/{key...}` — Find blob metadata by storage key
- `GET /api/storage/download/{key...}` — Download a file by storage key

Closes #21

## Changes

- Extend `storage.System` interface with `List`, `Find`, and updated `Download` (returns `*BlobResult` with embedded `BlobMeta`)
- Add `BlobMeta`, `BlobList`, `BlobResult` types consolidating blob metadata representation
- Add `MaxListCap` constant, `ParseMaxResults` utility, and `MapHTTPStatus` error mapping
- Add configurable `MaxListSize` to storage config with `HERALD_STORAGE_MAX_LIST_SIZE` env var
- Create `storageHandler` in `internal/api/` wired directly to `storage.System`
- Use `/{key...}` wildcard path parameters for slash-containing blob keys
- Generate API Cartographer documentation at `_project/api/storage.md`
- Add tests for `ParseMaxResults`, `MapHTTPStatus`, `MaxListSize` config, and `Find` key validation