### PR TITLE
Add classification engine database migration

### DIFF
--- a/.claude/context/guides/.archive/30-classification-engine-migration.md
+++ b/.claude/context/guides/.archive/30-classification-engine-migration.md
@@ -1,0 +1,68 @@
+# 30 - Classification Engine Database Migration
+
+## Problem Context
+
+Herald's Phase 2 classification engine requires two new tables: `classifications` (1:1 with documents, storing inference results) and `prompts` (named overrides per workflow stage). These tables are the persistence foundation for all subsequent Phase 2 objectives.
+
+## Architecture Approach
+
+Single migration `000002_classification_engine` following the pattern established by `000001_initial_schema`. Both tables are created in the up migration; the down migration drops them in reverse dependency order.
+
+## Implementation
+
+### Step 1: Create the up migration
+
+**New file:** `cmd/migrate/migrations/000002_classification_engine.up.sql`
+
+```sql
+CREATE TABLE classifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID NOT NULL UNIQUE
+    REFERENCES documents(id) ON DELETE CASCADE,
+  classification TEXT NOT NULL,
+  confidence TEXT NOT NULL
+    CHECK (confidence IN ('HIGH', 'MEDIUM', 'LOW')),
+  markings_found JSONB NOT NULL DEFAULT '[]',
+  rationale TEXT NOT NULL,
+  classified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  model_name TEXT NOT NULL,
+  provider_name TEXT NOT NULL,
+  validated_by TEXT,
+  validated_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_classifications_classification ON classifications(classification);
+CREATE INDEX idx_classifications_confidence ON classifications(confidence);
+CREATE INDEX idx_classifications_classified_at ON classifications(classified_at DESC);
+
+CREATE TABLE prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  stage TEXT NOT NULL
+    CHECK (stage IN ('init', 'classify', 'enhance')),
+  system_prompt TEXT NOT NULL,
+  description TEXT
+);
+
+CREATE INDEX idx_prompts_stage ON prompts(stage);
+```
+
+### Step 2: Create the down migration
+
+**New file:** `cmd/migrate/migrations/000002_classification_engine.down.sql`
+
+```sql
+DROP TABLE IF EXISTS classifications;
+DROP TABLE IF EXISTS prompts;
+```
+
+## Validation Criteria
+
+- [ ] `go run ./cmd/migrate/ up` applies cleanly with no errors
+- [ ] `go run ./cmd/migrate/ down 1` reverts cleanly (drops both tables)
+- [ ] Re-applying after revert succeeds (idempotent up/down cycle)
+- [ ] `document_id` UNIQUE constraint enforces 1:1 relationship
+- [ ] `ON DELETE CASCADE` removes classification when parent document is deleted
+- [ ] `confidence` CHECK rejects values outside HIGH/MEDIUM/LOW
+- [ ] `stage` CHECK rejects values outside init/classify/enhance
+- [ ] All four indexes are created

--- a/.claude/context/sessions/30-classification-engine-migration.md
+++ b/.claude/context/sessions/30-classification-engine-migration.md
@@ -1,0 +1,30 @@
+# 30 - Classification Engine Database Migration
+
+## Summary
+
+Created migration `000002_classification_engine` adding `classifications` and `prompts` tables to the Herald database schema. These tables are the persistence foundation for Phase 2's classification engine — `classifications` stores 1:1 inference results linked to documents, and `prompts` stores named prompt overrides per workflow stage.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Table ordering in up migration | classifications before prompts | classifications has the FK dependency on documents; prompts is independent |
+| Down migration ordering | classifications then prompts | Drop FK-dependent table first, though both are independent of each other |
+| `classification` column | Unconstrained TEXT | Security marking values may include unexpected levels (per objective #24 decision 9) |
+| `confidence` column | CHECK-constrained to HIGH/MEDIUM/LOW | Known enum, categorical scoring aligned with classify-docs |
+
+## Files Modified
+
+- `cmd/migrate/migrations/000002_classification_engine.up.sql` (new)
+- `cmd/migrate/migrations/000002_classification_engine.down.sql` (new)
+
+## Patterns Established
+
+- None new — follows the migration pattern from `000001_initial_schema`
+
+## Validation Results
+
+- Migration up applies cleanly (version 2, not dirty)
+- Single-step revert (`-steps -1`) reverts to version 1
+- Re-apply after revert succeeds
+- Constraint validation deferred to API integration testing

--- a/.claude/plans/pure-plotting-diffie.md
+++ b/.claude/plans/pure-plotting-diffie.md
@@ -1,0 +1,57 @@
+# Issue #30 — Classification Engine Database Migration
+
+## Context
+
+Second sub-issue of Objective #24. Herald needs `classifications` and `prompts` tables to support the Phase 2 classification engine. The issue specifies exact schemas, constraints, and indexes.
+
+## Approach
+
+Create migration `000002_classification_engine` following the pattern established by `000001_initial_schema`.
+
+### Files
+
+- `cmd/migrate/migrations/000002_classification_engine.up.sql` — new
+- `cmd/migrate/migrations/000002_classification_engine.down.sql` — new
+
+### Up Migration
+
+1. Create `classifications` table:
+   - `id UUID PK DEFAULT gen_random_uuid()`
+   - `document_id UUID NOT NULL UNIQUE FK → documents(id) ON DELETE CASCADE`
+   - `classification TEXT NOT NULL`
+   - `confidence TEXT NOT NULL CHECK ('HIGH','MEDIUM','LOW')`
+   - `markings_found JSONB NOT NULL DEFAULT '[]'`
+   - `rationale TEXT NOT NULL`
+   - `classified_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+   - `model_name TEXT NOT NULL`
+   - `provider_name TEXT NOT NULL`
+   - `validated_by TEXT`
+   - `validated_at TIMESTAMPTZ`
+
+2. Create `prompts` table:
+   - `id UUID PK DEFAULT gen_random_uuid()`
+   - `name TEXT NOT NULL UNIQUE`
+   - `stage TEXT NOT NULL CHECK ('init','classify','enhance')`
+   - `system_prompt TEXT NOT NULL`
+   - `description TEXT`
+
+3. Create indexes:
+   - `idx_classifications_classification` on `classification`
+   - `idx_classifications_confidence` on `confidence`
+   - `idx_classifications_classified_at` on `classified_at DESC`
+   - `idx_prompts_stage` on `stage`
+
+### Down Migration
+
+Drop tables in reverse dependency order: `classifications` first (depends on `documents`), then `prompts`.
+
+## Verification
+
+```bash
+# Apply migration
+mise run dev  # or manually: go run ./cmd/migrate/ up
+
+# Verify tables exist and constraints work
+# Revert migration
+go run ./cmd/migrate/ down 1
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0-dev.24.30
+
+- Add classification engine database migration with classifications and prompts tables, CHECK constraints, and indexes (#30)
+
 ## v0.2.0-dev.24.29
 
 - Migrate config format from TOML to JSON, add go-agents AgentConfig to Config and Infrastructure with env var overrides and startup validation (#29)

--- a/cmd/migrate/migrations/000002_classification_engine.down.sql
+++ b/cmd/migrate/migrations/000002_classification_engine.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS classifications;
+DROP TABLE IF EXISTS prompts;

--- a/cmd/migrate/migrations/000002_classification_engine.up.sql
+++ b/cmd/migrate/migrations/000002_classification_engine.up.sql
@@ -1,0 +1,30 @@
+CREATE TABLE classifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID NOT NULL UNIQUE
+    REFERENCES documents(id) ON DELETE CASCADE,
+  classification TEXT NOT NULL,
+  confidence TEXT NOT NULL
+    CHECK (confidence IN ('HIGH', 'MEDIUM', 'LOW')),
+  markings_found JSONB NOT NULL DEFAULT '[]',
+  rationale TEXT NOT NULL,
+  classified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  model_name TEXT NOT NULL,
+  provider_name TEXT NOT NULL,
+  validated_by TEXT,
+  validated_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_classifications_classification ON classifications(classification);
+CREATE INDEX idx_classifications_confidence ON classifications(confidence);
+CREATE INDEX idx_classifications_classified_at ON classifications(classified_at DESC);
+
+CREATE TABLE prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  stage TEXT NOT NULL
+    CHECK (stage IN ('init', 'classify', 'enhance')),
+  system_prompt TEXT NOT NULL,
+  description TEXT
+);
+
+CREATE INDEX idx_prompts_stage ON prompts(stage);


### PR DESCRIPTION
## Summary

Create migration `000002_classification_engine` establishing the persistence layer for the Phase 2 classification engine. Adds `classifications` table (1:1 with documents, stores inference results with flattened model metadata and validation columns) and `prompts` table (named prompt overrides per workflow stage).

Closes #30

## Changes

- `classifications` table with UNIQUE FK to documents (ON DELETE CASCADE), confidence CHECK constraint (HIGH/MEDIUM/LOW), JSONB markings_found, flattened model/provider columns, and nullable validation fields
- `prompts` table with unique name, stage CHECK constraint (init/classify/enhance), system_prompt, and optional description
- Indexes on classification, confidence, classified_at DESC, and stage
- Down migration drops both tables