### PR TITLE
Add prompts domain extensions

### DIFF
--- a/.claude/context/guides/.archive/37-prompts-domain-extensions.md
+++ b/.claude/context/guides/.archive/37-prompts-domain-extensions.md
@@ -1,0 +1,425 @@
+# 37 - Prompts Domain Extensions
+
+## Problem Context
+
+The classification workflow (#26) needs a single source of truth for all prompt content. The workflow composes each stage's system prompt from two layers: tunable instructions (active DB override or hardcoded default) and immutable specifications (output JSON schema + behavioral constraints). The prompts domain currently only handles CRUD for named overrides — it has no way to resolve effective instructions for a stage or expose specifications. This issue adds both capabilities plus API endpoints for prompt authors to view specs when crafting instructions.
+
+## Architecture Approach
+
+Extend the existing prompts domain in-place. Hardcoded content lives in two new files (`instructions.go`, `specs.go`) with named constants and map-based accessors. Two new methods on `System` (`Instructions`, `Spec`) provide the workflow's entry points. Two new handler routes expose the content via API.
+
+Only the classify and enhance stages carry prompt content — init is purely image preparation with no LLM interaction. `StageInit` is removed from the prompts domain entirely (including a migration to tighten the DB CHECK constraint) since it was never a valid prompt stage.
+
+## Implementation
+
+### Step 1: Remove `StageInit` from `internal/prompts/stages.go`
+
+Remove the `StageInit` constant and its entry in the `stages` slice. Update the file to only contain classify and enhance.
+
+The full updated file:
+
+```go
+package prompts
+
+import (
+	"encoding/json"
+	"slices"
+)
+
+type Stage string
+
+const (
+	StageClassify Stage = "classify"
+	StageEnhance  Stage = "enhance"
+)
+
+var stages = []Stage{
+	StageClassify,
+	StageEnhance,
+}
+
+func Stages() []Stage {
+	return stages
+}
+
+func (s *Stage) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	v := Stage(raw)
+	if !slices.Contains(stages, v) {
+		return ErrInvalidStage
+	}
+	*s = v
+	return nil
+}
+
+func ParseStage(s string) (Stage, error) {
+	v := Stage(s)
+	if !slices.Contains(stages, v) {
+		return "", ErrInvalidStage
+	}
+	return v, nil
+}
+```
+
+### Step 2: Update `internal/prompts/errors.go`
+
+Update the `ErrInvalidStage` message to only list classify and enhance:
+
+```go
+ErrInvalidStage = errors.New("stage must be classify or enhance")
+```
+
+### Step 3: Add migration `000004_prompts_remove_init_stage`
+
+**`cmd/migrate/migrations/000004_prompts_remove_init_stage.up.sql`**:
+
+```sql
+DELETE FROM prompts WHERE stage = 'init';
+
+ALTER TABLE prompts
+  DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance'));
+```
+
+**`cmd/migrate/migrations/000004_prompts_remove_init_stage.down.sql`**:
+
+```sql
+ALTER TABLE prompts
+  DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('init', 'classify', 'enhance'));
+```
+
+### Step 4: Create `internal/prompts/instructions.go`
+
+New file with per-stage instruction constants, the lookup map, and accessor function.
+
+```go
+package prompts
+
+const classifyInstructions = `You are a security classification analyst reviewing a document page by page.
+
+For each page, examine all visible security markings including:
+- Banner lines (top and bottom of page)
+- Portion markings (paragraph-level classification indicators)
+- Classification authority blocks
+- Declassification instructions
+- Caveats and dissemination controls (e.g., NOFORN, REL TO, FOUO)
+
+Accumulate your findings across pages to build a complete classification picture of the
+document. When markings on different pages conflict, note the discrepancy and apply the
+highest classification encountered. Your confidence assessment should reflect the clarity
+and consistency of the markings found.`
+
+const enhanceInstructions = `You are re-assessing a document's security classification using enhanced page images.
+
+Previous classification analysis was limited by image quality. The affected pages have been
+re-rendered with adjusted brightness, contrast, and saturation settings to improve marking
+visibility. Focus your analysis on the enhanced pages, looking for markings that may have
+been obscured in the original rendering.
+
+Compare your findings against the prior classification state. If the enhanced images reveal
+additional or different markings, update the classification accordingly. If the enhanced
+images confirm the prior assessment, maintain the existing classification with increased
+confidence.`
+
+var instructions = map[Stage]string{
+	StageClassify: classifyInstructions,
+	StageEnhance:  enhanceInstructions,
+}
+
+func Instructions(stage Stage) (string, error) {
+	text, ok := instructions[stage]
+	if !ok {
+		return "", ErrInvalidStage
+	}
+	return text, nil
+}
+```
+
+### Step 5: Create `internal/prompts/specs.go`
+
+New file with per-stage specification constants, the lookup map, and accessor function.
+
+```go
+package prompts
+
+const classifySpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "page_number": <number>,
+  "image_quality_limiting": <true|false>
+}
+
+Field constraints:
+- classification: The overall security classification marking for the document
+  as assessed through this page (e.g., UNCLASSIFIED, CONFIDENTIAL, SECRET,
+  TOP SECRET, or with caveats like SECRET//NOFORN).
+- confidence: Categorical assessment of classification certainty.
+  HIGH = markings are clear, consistent, and unambiguous.
+  MEDIUM = markings are present but partially obscured or inconsistent.
+  LOW = markings are unclear, missing, or contradictory.
+- markings_found: Array of distinct marking strings found on this page,
+  exactly as they appear in the document.
+- rationale: Brief explanation of how the classification was determined
+  from the visible markings. Note any conflicts or ambiguities.
+- page_number: The 1-indexed page number being analyzed.
+- image_quality_limiting: Whether image quality prevented confident
+  reading of any markings on this page. true triggers potential
+  enhancement processing.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Process exactly one page per response
+- Accumulate classification state: if a prior state is provided in the
+  prompt, update it based on this page's findings
+- Apply the highest classification encountered across all pages
+- Never downgrade a classification based on a subsequent page`
+
+const enhanceSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "page_number": <number>,
+  "image_quality_limiting": <true|false>,
+  "enhanced": true,
+  "prior_confidence": "<HIGH|MEDIUM|LOW>"
+}
+
+Field constraints:
+- All fields from the classify specification apply, plus:
+- enhanced: Always true in enhancement responses.
+- prior_confidence: The confidence level from the classify stage that
+  triggered enhancement. Used to track whether enhancement improved
+  the assessment.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Focus analysis on re-rendered pages with improved image settings
+- Compare findings against the prior classification state
+- Maintain or upgrade classification; never downgrade
+- If enhanced images reveal no new information, preserve the prior
+  classification and note this in the rationale`
+
+var specs = map[Stage]string{
+	StageClassify: classifySpec,
+	StageEnhance:  enhanceSpec,
+}
+
+func Spec(stage Stage) (string, error) {
+	text, ok := specs[stage]
+	if !ok {
+		return "", ErrInvalidStage
+	}
+	return text, nil
+}
+```
+
+### Step 6: Extend `internal/prompts/system.go`
+
+Add two methods to the `System` interface, after `Deactivate`:
+
+```go
+Instructions(ctx context.Context, stage Stage) (string, error)
+Spec(ctx context.Context, stage Stage) (string, error)
+```
+
+### Step 7: Implement methods on `internal/prompts/repository.go`
+
+Add these two methods to the `repo` type. `"database/sql"` and `"errors"` are already imported.
+
+```go
+func (r *repo) Instructions(ctx context.Context, stage Stage) (string, error) {
+	var text string
+	err := r.db.QueryRowContext(ctx,
+		"SELECT instructions FROM prompts WHERE stage = $1 AND active = true",
+		stage,
+	).Scan(&text)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return Instructions(stage)
+	}
+	if err != nil {
+		return "", fmt.Errorf("query active instructions: %w", err)
+	}
+	return text, nil
+}
+
+func (r *repo) Spec(ctx context.Context, stage Stage) (string, error) {
+	return Spec(stage)
+}
+```
+
+### Step 8: Add handler routes to `internal/prompts/handler.go`
+
+Add the `StageContent` response type after `SearchRequest`:
+
+```go
+type StageContent struct {
+	Stage   Stage  `json:"stage"`
+	Content string `json:"content"`
+}
+```
+
+Add two new handler methods:
+
+```go
+func (h *Handler) Instructions(w http.ResponseWriter, r *http.Request) {
+	stage, err := ParseStage(r.PathValue("stage"))
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusBadRequest, err)
+		return
+	}
+
+	text, err := h.sys.Instructions(r.Context(), stage)
+	if err != nil {
+		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, StageContent{Stage: stage, Content: text})
+}
+
+func (h *Handler) Spec(w http.ResponseWriter, r *http.Request) {
+	stage, err := ParseStage(r.PathValue("stage"))
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusBadRequest, err)
+		return
+	}
+
+	text, err := h.sys.Spec(r.Context(), stage)
+	if err != nil {
+		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, StageContent{Stage: stage, Content: text})
+}
+```
+
+Add two new routes to the `Routes()` method's slice:
+
+```go
+{Method: "GET", Pattern: "/{stage}/instructions", Handler: h.Instructions},
+{Method: "GET", Pattern: "/{stage}/spec", Handler: h.Spec},
+```
+
+### Step 9: Update API Cartographer docs
+
+Add two new sections to `_project/api/prompts/README.md` after the **Deactivate Prompt** section:
+
+```markdown
+---
+
+## Get Stage Instructions
+
+`GET /api/prompts/{stage}/instructions`
+
+Returns the effective instructions for a workflow stage. If an active prompt override exists for the stage, returns its instructions. Otherwise, returns the hardcoded default instructions. Only classify and enhance stages have prompt content.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| stage | string | Workflow stage (classify, enhance) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Stage instructions |
+| 400 | Invalid stage |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stage | string | The requested stage |
+| content | string | The effective instruction text |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/prompts/classify/instructions" | jq .
+```
+
+---
+
+## Get Stage Specification
+
+`GET /api/prompts/{stage}/spec`
+
+Returns the hardcoded specification for a workflow stage. Specifications define the expected output format and behavioral constraints that the workflow parser depends on. Always read-only. Only classify and enhance stages have prompt content.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| stage | string | Workflow stage (classify, enhance) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Stage specification |
+| 400 | Invalid stage |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stage | string | The requested stage |
+| content | string | The specification text |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/prompts/classify/spec" | jq .
+```
+```
+
+Update the **List Prompts** and **Search Prompts** sections to reference stages as `(classify, enhance)` instead of `(init, classify, enhance)`.
+
+Update the **List Stages** description to note that it returns the valid prompt workflow stages.
+
+Update the **Create Prompt** and **Update Prompt** stage field description to `(classify, enhance)`.
+
+Add to `_project/api/prompts/prompts.http` after the Delete Prompt section:
+
+```
+### Get Stage Instructions
+GET {{HOST}}/api/prompts/classify/instructions
+
+### Get Stage Specification
+GET {{HOST}}/api/prompts/classify/spec
+```
+
+## Validation Criteria
+
+- [ ] `StageInit` removed from prompts package — only classify and enhance are valid
+- [ ] Migration `000004` tightens CHECK constraint to `('classify', 'enhance')`
+- [ ] `Instructions(ctx, stage)` returns active DB override when one exists
+- [ ] `Instructions(ctx, stage)` returns hardcoded default when no active override exists
+- [ ] `Spec(ctx, stage)` returns hardcoded specification
+- [ ] Both methods return `ErrInvalidStage` for unknown stages and never return empty
+- [ ] `ParseStage` validates string input against known stages
+- [ ] Handler routes return `StageContent` JSON with 200 OK
+- [ ] Handler routes return 400 Bad Request for invalid stage
+- [ ] `go vet ./...` passes
+- [ ] All existing tests pass
+- [ ] API docs updated with new endpoints and stage references

--- a/.claude/context/sessions/37-prompts-domain-extensions.md
+++ b/.claude/context/sessions/37-prompts-domain-extensions.md
@@ -1,0 +1,43 @@
+# 37 - Prompts Domain Extensions
+
+## Summary
+
+Extended the prompts domain with hardcoded default instructions and specifications per workflow stage, two new System interface methods (`Instructions`, `Spec`), and two new API endpoints. Removed `StageInit` from the prompts domain entirely since the init workflow node performs image rendering with no LLM interaction. Added a database migration to tighten the stage CHECK constraint to only allow classify and enhance.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Init stage removal | Remove `StageInit` from prompts entirely | Init node is pure image preparation — no LLM calls, no prompt content needed |
+| Hardcoded content organization | Separate files (`instructions.go`, `specs.go`) with named constants | Prompt bodies can grow large; constants keep maps clean and files focused |
+| Naming convention | `Spec` (abbreviated) consistently across all layers | Aligns file name (`specs.go`), accessor (`Spec()`), interface method, handler method, and URL pattern (`/{stage}/spec`) |
+| Instructions fallback | DB active override → hardcoded default | `repo.Instructions` queries for active prompt first, falls back to `Instructions()` package function on `sql.ErrNoRows` |
+| Spec sourcing | Pure hardcoded, no DB interaction | Specs are immutable output format contracts; no reason to query DB |
+
+## Files Modified
+
+- `internal/prompts/stages.go` — removed `StageInit`, added `ParseStage`
+- `internal/prompts/errors.go` — updated `ErrInvalidStage` message
+- `internal/prompts/instructions.go` — new: classify/enhance instruction constants + `Instructions()` accessor
+- `internal/prompts/specs.go` — new: classify/enhance spec constants + `Spec()` accessor
+- `internal/prompts/system.go` — added `Instructions` and `Spec` to interface
+- `internal/prompts/repository.go` — implemented both methods on `repo`
+- `internal/prompts/handler.go` — added `StageContent` type, `Instructions`/`Spec` handlers, two new routes
+- `cmd/migrate/migrations/000004_prompts_remove_init_stage.up.sql` — new migration
+- `cmd/migrate/migrations/000004_prompts_remove_init_stage.down.sql` — new migration
+- `_project/api/prompts/README.md` — documented new endpoints, updated stage references
+- `_project/api/prompts/prompts.http` — added curl examples for new endpoints
+- `tests/prompts/prompts_test.go` — updated for StageInit removal, added ParseStage/Instructions/Spec tests
+- `tests/prompts/handler_test.go` — updated mock, added Instructions/Spec handler tests, updated route assertions
+
+## Patterns Established
+
+- **Hardcoded prompt content pattern**: Named constants in dedicated files, unexported map for lookup, exported accessor function with stage validation
+- **Stage-scoped content endpoints**: `StageContent` response type with `{stage}` path parameter validated via `ParseStage`
+- **DB-with-fallback pattern**: Query for active override, fall back to package-level accessor on `sql.ErrNoRows`
+
+## Validation Results
+
+- `go vet ./...` passes
+- All 16 test packages pass
+- `go mod tidy` produces no changes

--- a/.claude/plans/compressed-twirling-balloon.md
+++ b/.claude/plans/compressed-twirling-balloon.md
@@ -1,0 +1,129 @@
+# Plan: Issue #37 — Prompts Domain Extensions
+
+## Context
+
+The classification workflow (#26) needs a single source of truth for all prompt content. Currently the prompts domain only handles CRUD for named prompt overrides stored in PostgreSQL. The workflow needs two additional capabilities: (1) resolve the effective instructions for a stage — the active DB override or a hardcoded default — and (2) retrieve the immutable specification (output JSON schema + behavioral constraints) for a stage. Both must never return empty. Exposing specs via API gives prompt authors read-only context when crafting instructions.
+
+## Approach
+
+Extend the existing prompts domain with three additions: a `defaults.go` file containing hardcoded content, two new methods on the `System` interface, and two new handler routes.
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `internal/prompts/instructions.go` | **Create** — per-stage instruction constants, `instructions` map, `DefaultInstructions()` accessor |
+| `internal/prompts/specs.go` | **Create** — per-stage spec constants, `specs` map, `Specification()` accessor |
+| `internal/prompts/stages.go` | **Edit** — add `ParseStage(s string) (Stage, error)` for path param validation |
+| `internal/prompts/system.go` | **Edit** — add `Instructions` and `Spec` to the interface |
+| `internal/prompts/repository.go` | **Edit** — implement both methods on `repo` |
+| `internal/prompts/handler.go` | **Edit** — add handler methods and routes |
+| `_project/api/prompts/README.md` | **Edit** — document new endpoints |
+| `_project/api/prompts/prompts.http` | **Edit** — add curl examples |
+
+## Implementation Steps
+
+### Step 1: `instructions.go` — hardcoded default instructions
+
+New file with one constant per stage and an accessor function:
+
+```go
+const (
+    initInstructions     = `...`
+    classifyInstructions = `...`
+    enhanceInstructions  = `...`
+)
+
+var instructions = map[Stage]string{
+    StageInit:     initInstructions,
+    StageClassify: classifyInstructions,
+    StageEnhance:  enhanceInstructions,
+}
+
+func DefaultInstructions(stage Stage) (string, error)  // validates stage, returns content
+```
+
+Returns `ErrInvalidStage` if the stage is not found. Content will be placeholder text that captures the intent of each stage — refined during workflow implementation (#38–41).
+
+### Step 2: `specs.go` — hardcoded specifications
+
+Same structure as instructions — one constant per stage and an accessor function:
+
+```go
+const (
+    initSpec     = `...`
+    classifySpec = `...`
+    enhanceSpec  = `...`
+)
+
+var specs = map[Stage]string{
+    StageInit:     initSpec,
+    StageClassify: classifySpec,
+    StageEnhance:  enhanceSpec,
+}
+
+func Specification(stage Stage) (string, error)  // validates stage, returns content
+```
+
+Returns `ErrInvalidStage` if the stage is not found. Specs define the expected JSON output structure and behavioral constraints the workflow parser depends on.
+
+### Step 3: `stages.go` — add `ParseStage`
+
+Add a standalone validation function for path parameter parsing:
+
+```go
+func ParseStage(s string) (Stage, error)
+```
+
+Returns `ErrInvalidStage` if the string doesn't match a known stage. Used by handler methods to validate `{stage}` path params.
+
+### Step 4: `system.go` — extend interface
+
+Add two methods:
+
+```go
+Instructions(ctx context.Context, stage Stage) (string, error)
+Spec(ctx context.Context, stage Stage) (string, error)
+```
+
+### Step 5: `repository.go` — implement methods
+
+**`Instructions`**: Query for the active prompt for the given stage (`WHERE stage = $1 AND active = true`). If found, return its `instructions` field. If no active override exists (`sql.ErrNoRows`), fall back to `DefaultInstructions(stage)`. Validates stage before querying.
+
+**`Spec`**: Delegates directly to `Specification(stage)`. No DB interaction — specs are always hardcoded. Included on the System interface so callers don't need to know the sourcing distinction.
+
+### Step 6: `handler.go` — add routes and handlers
+
+Response type for both endpoints:
+
+```go
+type StageContent struct {
+    Stage   Stage  `json:"stage"`
+    Content string `json:"content"`
+}
+```
+
+Two new handler methods:
+- `Instructions(w, r)` — parses `{stage}` via `ParseStage`, calls `sys.Instructions`, responds with `StageContent`
+- `Spec(w, r)` — parses `{stage}` via `ParseStage`, calls `sys.Spec`, responds with `StageContent`
+
+Two new routes added to `Routes()`:
+- `GET /{stage}/instructions`
+- `GET /{stage}/spec`
+
+### Step 7: API Cartographer — update docs
+
+Add endpoint documentation for both new routes in `_project/api/prompts/README.md` and curl examples in `prompts.http`.
+
+## Validation Criteria
+
+- [ ] `Instructions(ctx, stage)` returns active DB override when one exists
+- [ ] `Instructions(ctx, stage)` returns hardcoded default when no active override exists
+- [ ] `Spec(ctx, stage)` returns hardcoded specification
+- [ ] Both methods return `ErrInvalidStage` for unknown stages and never return empty
+- [ ] `ParseStage` validates string input against known stages
+- [ ] Handler routes return `StageContent` JSON with 200 OK
+- [ ] Handler routes return 400 Bad Request for invalid stage
+- [ ] `go vet ./...` passes
+- [ ] All existing tests pass
+- [ ] API docs updated with new endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0-dev.26.37
+
+- Add hardcoded default instructions and specifications per workflow stage, `Instructions` and `Spec` methods on the prompts System interface, stage content API endpoints, `ParseStage` validation, and remove init as a prompt stage (#37)
+
 ## v0.2.0-dev.25.34
 
 - Add prompts domain with full CRUD, typed stage enum with JSON validation, partial unique index for single active prompt per stage, and atomic activation swap (#34)

--- a/_project/api/documents/documents.http
+++ b/_project/api/documents/documents.http
@@ -1,16 +1,25 @@
 ### List Documents
-GET {{HOST}}/api/documents
+
+GET {{HOST}}/api/documents HTTP/1.1
+
 
 ### List Documents with Filters
-GET {{HOST}}/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf
+
+GET {{HOST}}/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf HTTP/1.1
+
 
 ### Find Document
+
 # Replace with a valid document ID
-@documentId=550e8400-e29b-41d4-a716-446655440000
-GET {{HOST}}/api/documents/{{documentId}}
+
+@documentId = 550e8400-e29b-41d4-a716-446655440000
+
+GET {{HOST}}/api/documents/{{documentId}} HTTP/1.1
+
 
 ### Search Documents
-POST {{HOST}}/api/documents/search
+
+POST {{HOST}}/api/documents/search HTTP/1.1
 Content-Type: application/json
 
 {
@@ -18,31 +27,35 @@ Content-Type: application/json
   "page_size": 20
 }
 
+
 ### Search Documents with Filters
-POST {{HOST}}/api/documents/search
+
+POST {{HOST}}/api/documents/search HTTP/1.1
 Content-Type: application/json
 
 {
+  "content_type": "application/pdf",
+  "external_id": 12345,
+  "external_platform": "HQ",
+  "filename": "report",
   "page": 1,
   "page_size": 20,
   "search": "quarterly",
   "sort": "-uploaded_at",
-  "status": "pending",
-  "filename": "report",
-  "external_id": 12345,
-  "external_platform": "HQ",
-  "content_type": "application/pdf"
+  "status": "pending"
 }
 
+
 ### Upload Document
-POST {{HOST}}/api/documents
+
+POST {{HOST}}/api/documents HTTP/1.1
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
 Content-Disposition: form-data; name="file"; filename="report.pdf"
 Content-Type: application/pdf
 
-< ./_project/marked-documents/secret-01.pdf
+< ../../marked-documents/single-secret.pdf
 --boundary
 Content-Disposition: form-data; name="external_id"
 
@@ -53,7 +66,11 @@ Content-Disposition: form-data; name="external_platform"
 HQ
 --boundary--
 
+
 ### Delete Document
+
 # Replace with a valid document ID
-@documentId=550e8400-e29b-41d4-a716-446655440000
-DELETE {{HOST}}/api/documents/{{documentId}}
+
+@documentId = 550e8400-e29b-41d4-a716-446655440000
+
+DELETE {{HOST}}/api/documents/{{documentId}} HTTP/1.1

--- a/_project/api/prompts/README.md
+++ b/_project/api/prompts/README.md
@@ -2,7 +2,7 @@
 
 `/api/prompts`
 
-Named prompt instruction overrides for workflow stages. Each prompt targets a specific stage (init, classify, enhance) and provides tunable instructions. At most one prompt per stage can be active.
+Named prompt instruction overrides for workflow stages. Each prompt targets a specific stage (classify, enhance) and provides tunable instructions. At most one prompt per stage can be active.
 
 ---
 
@@ -20,7 +20,7 @@ Returns a paginated list of prompts with optional filters.
 | page_size | integer | no | Results per page |
 | search | string | no | Search across name and description |
 | sort | string | no | Comma-separated sort fields, prefix `-` for descending |
-| stage | string | no | Filter by stage (init, classify, enhance) |
+| stage | string | no | Filter by stage (classify, enhance) |
 | name | string | no | Filter by name (contains, case-insensitive) |
 | active | boolean | no | Filter by active status |
 
@@ -48,7 +48,7 @@ curl -s "$HERALD_API_BASE/api/prompts?page=1&page_size=20&search=detailed&sort=n
 
 `GET /api/prompts/stages`
 
-Returns the authoritative list of valid workflow stages.
+Returns the authoritative list of valid prompt workflow stages.
 
 ### Responses
 
@@ -107,7 +107,7 @@ Content-Type: `application/json`
 | page_size | integer | no | Results per page |
 | search | string | no | Search across name and description |
 | sort | string | no | Comma-separated sort fields, prefix `-` for descending |
-| stage | string | no | Filter by stage (init, classify, enhance) |
+| stage | string | no | Filter by stage (classify, enhance) |
 | name | string | no | Filter by name (contains) |
 | active | boolean | no | Filter by active status |
 
@@ -157,7 +157,7 @@ Content-Type: `application/json`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | name | string | yes | Unique name for the prompt |
-| stage | string | yes | Workflow stage (init, classify, enhance) |
+| stage | string | yes | Workflow stage (classify, enhance) |
 | instructions | string | yes | Prompt instruction text |
 | description | string | no | Description of the prompt's purpose |
 
@@ -203,7 +203,7 @@ Content-Type: `application/json`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | name | string | yes | Unique name for the prompt |
-| stage | string | yes | Workflow stage (init, classify, enhance) |
+| stage | string | yes | Workflow stage (classify, enhance) |
 | instructions | string | yes | Prompt instruction text |
 | description | string | no | Description of the prompt's purpose |
 
@@ -308,4 +308,72 @@ Deactivates a prompt. The stage falls back to hard-coded default instructions.
 
 ```bash
 curl -s -X POST "$HERALD_API_BASE/api/prompts/550e8400-e29b-41d4-a716-446655440000/deactivate" | jq .
+```
+
+---
+
+## Get Stage Instructions
+
+`GET /api/prompts/{stage}/instructions`
+
+Returns the effective instructions for a workflow stage. If an active prompt override exists for the stage, returns its instructions. Otherwise, returns the hardcoded default instructions.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| stage | string | Workflow stage (classify, enhance) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Stage instructions |
+| 400 | Invalid stage |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stage | string | The requested stage |
+| content | string | The effective instruction text |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/prompts/classify/instructions" | jq .
+```
+
+---
+
+## Get Stage Spec
+
+`GET /api/prompts/{stage}/spec`
+
+Returns the hardcoded specification for a workflow stage. Specifications define the expected output format and behavioral constraints that the workflow parser depends on. Always read-only.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| stage | string | Workflow stage (classify, enhance) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | Stage specification |
+| 400 | Invalid stage |
+
+### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stage | string | The requested stage |
+| content | string | The specification text |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/prompts/classify/spec" | jq .
 ```

--- a/_project/api/prompts/prompts.http
+++ b/_project/api/prompts/prompts.http
@@ -1,30 +1,53 @@
 ### Create Prompt
-POST {{HOST}}/api/prompts
+
+POST {{HOST}}/api/prompts HTTP/1.1
 Content-Type: application/json
 
 {
-  "name": "detailed-classify",
-  "stage": "classify",
+  "description": "Detailed classification instructions with emphasis on portion markings",
   "instructions": "Analyze each page thoroughly, noting all security markings including portion markings, banner lines, and classification authority blocks.",
-  "description": "Detailed classification instructions with emphasis on portion markings"
+  "name": "detailed-classify",
+  "stage": "classify"
 }
 
+
 ### List Prompts
-GET {{HOST}}/api/prompts
+
+GET {{HOST}}/api/prompts HTTP/1.1
+
 
 ### List Prompts with Filters
-GET {{HOST}}/api/prompts?stage=classify&active=false
+
+GET {{HOST}}/api/prompts?stage=classify&active=false HTTP/1.1
+
 
 ### List Stages
-GET {{HOST}}/api/prompts/stages
+
+GET {{HOST}}/api/prompts/stages HTTP/1.1
+
 
 ### Find Prompt
+
 # Replace with a valid prompt ID
-@promptId=550e8400-e29b-41d4-a716-446655440000
-GET {{HOST}}/api/prompts/{{promptId}}
+
+@promptId = 550e8400-e29b-41d4-a716-446655440000
+
+GET {{HOST}}/api/prompts/{{promptId}} HTTP/1.1
+
+
+### Get Stage Instructions
+
+GET {{HOST}}/api/prompts/classify/instructions HTTP/1.1
+
+
+### Get Stage Spec
+
+GET {{HOST}}/api/prompts/classify/spec HTTP/1.1
+
 
 ### Search Prompts
-POST {{HOST}}/api/prompts/search
+
+POST {{HOST}}/api/prompts/search HTTP/1.1
 Content-Type: application/json
 
 {
@@ -33,30 +56,46 @@ Content-Type: application/json
   "stage": "classify"
 }
 
+
 ### Update Prompt
+
 # Replace with a valid prompt ID
-@promptId=550e8400-e29b-41d4-a716-446655440000
-PUT {{HOST}}/api/prompts/{{promptId}}
+
+@promptId = 550e8400-e29b-41d4-a716-446655440000
+
+PUT {{HOST}}/api/prompts/{{promptId}} HTTP/1.1
 Content-Type: application/json
 
 {
-  "name": "detailed-classify-v2",
-  "stage": "classify",
+  "description": "Enhanced classification instructions v2",
   "instructions": "Analyze each page thoroughly. Pay special attention to banner lines, portion markings, and classification authority blocks. Note any discrepancies between portion and banner markings.",
-  "description": "Enhanced classification instructions v2"
+  "name": "detailed-classify-v2",
+  "stage": "classify"
 }
 
+
 ### Activate Prompt
+
 # Replace with a valid prompt ID
-@promptId=550e8400-e29b-41d4-a716-446655440000
-POST {{HOST}}/api/prompts/{{promptId}}/activate
+
+@promptId = 550e8400-e29b-41d4-a716-446655440000
+
+POST {{HOST}}/api/prompts/{{promptId}}/activate HTTP/1.1
+
 
 ### Deactivate Prompt
+
 # Replace with a valid prompt ID
-@promptId=550e8400-e29b-41d4-a716-446655440000
-POST {{HOST}}/api/prompts/{{promptId}}/deactivate
+
+@promptId = 550e8400-e29b-41d4-a716-446655440000
+
+POST {{HOST}}/api/prompts/{{promptId}}/deactivate HTTP/1.1
+
 
 ### Delete Prompt
+
 # Replace with a valid prompt ID
-@promptId=550e8400-e29b-41d4-a716-446655440000
-DELETE {{HOST}}/api/prompts/{{promptId}}
+
+@promptId = 550e8400-e29b-41d4-a716-446655440000
+
+DELETE {{HOST}}/api/prompts/{{promptId}} HTTP/1.1

--- a/_project/api/storage/storage.http
+++ b/_project/api/storage/storage.http
@@ -1,13 +1,22 @@
 ### List Blobs
-GET {{HOST}}/api/storage
+
+GET {{HOST}}/api/storage HTTP/1.1
+
 
 ### List Blobs with Filters
-GET {{HOST}}/api/storage?prefix=documents/&max_results=20
+
+GET {{HOST}}/api/storage?prefix=documents/&max_results=20 HTTP/1.1
+
 
 ### Find Blob
+
 # Replace with a valid storage key
-GET {{HOST}}/api/storage/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf
+
+GET {{HOST}}/api/storage/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf HTTP/1.1
+
 
 ### Download Blob
+
 # Replace with a valid storage key
-GET {{HOST}}/api/storage/download/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf
+
+GET {{HOST}}/api/storage/download/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf HTTP/1.1

--- a/cmd/migrate/migrations/000004_prompts_remove_init_stage.down.sql
+++ b/cmd/migrate/migrations/000004_prompts_remove_init_stage.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE prompts
+  DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('init', 'classify', 'enhance'));

--- a/cmd/migrate/migrations/000004_prompts_remove_init_stage.up.sql
+++ b/cmd/migrate/migrations/000004_prompts_remove_init_stage.up.sql
@@ -1,0 +1,8 @@
+DELETE FROM prompts WHERE stage = 'init';
+
+ALTER TABLE prompts
+  DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance'));

--- a/internal/prompts/errors.go
+++ b/internal/prompts/errors.go
@@ -9,7 +9,7 @@ import (
 var (
 	ErrNotFound     = errors.New("prompt not found")
 	ErrDuplicate    = errors.New("prompt name already exists")
-	ErrInvalidStage = errors.New("stage must be init, classify, or enhance")
+	ErrInvalidStage = errors.New("stage must be classify or enhance")
 )
 
 // MapHTTPStatus maps prompt domain errors to appropriate HTTP status codes.

--- a/internal/prompts/instructions.go
+++ b/internal/prompts/instructions.go
@@ -1,0 +1,33 @@
+package prompts
+
+const classifyInstructions = `You are a security classification analyst reviewing a document page by page.
+
+For each page, examine all visible security markings, including:
+- Banner lines (top and bottom of page)
+- Portion markings (paragraph-level classification indicators)
+- Classification authority blocks
+- Declassification instructions
+- Caveats and dissemination controls (e.g., NOFORN, REL TO, FOUO)
+
+Accumulate your findings across pages to build a complete classification picture of the document. When markings on different pages conflict, note the discrepency and apply the highest classification encountered. Your confidence assessment should reflect the clarity and consistency of the markings found.`
+
+const enhanceInstructions = `You are re-assessing a document's security classification using enhanced page images.
+
+Previous classification analysis was limited by image quality. The affected pages have been re-renedered with adjusted brightness, contrast, and/or saturation settings to improve marking visibility. Focus your analysis on the enhanced pages, looking for markings that may have been obscured in the original rendering.
+
+Compare your findings against the prior classification state. If the enhanced images reveal additional or different markings, update the classification accordingly. If the enhanced images confirm the prior assessment, maintain the existing classification with increased confidence.`
+
+var instructions = map[Stage]string{
+	StageClassify: classifyInstructions,
+	StageEnhance:  enhanceInstructions,
+}
+
+// Instructions returns the hardcoded default instructions for a workflow stage.
+// Returns ErrInvalidStage if the stage is not recognized.
+func Instructions(stage Stage) (string, error) {
+	text, ok := instructions[stage]
+	if !ok {
+		return "", ErrInvalidStage
+	}
+	return text, nil
+}

--- a/internal/prompts/specs.go
+++ b/internal/prompts/specs.go
@@ -1,0 +1,81 @@
+package prompts
+
+const classifySpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "page_number": <number>,
+  "image_quality_limiting": <true|false>
+}
+
+Field constraints:
+- classification: The overall security classification marking for the document
+  as assessed through this page (e.g., UNCLASSIFIED, CONFIDENTIAL, SECRET,
+  TOP SECRET, or with caveats like SECRET//NOFORN).
+- confidence: Categorical assessment of classification certainty.
+  HIGH = markings are clear, consistent, and unambiguous.
+  MEDIUM = markings are present but partially obscured or inconsistent.
+  LOW = markings are unclear, missing, or contradictory.
+- markings_found: Array of distinct marking strings found on this page,
+  exactly as they appear in the document.
+- rationale: Brief explanation of how the classification was determined
+  from the visible markings. Note any conflicts or ambiguities.
+- page_number: The 1-indexed page number being analyzed.
+- image_quality_limiting: Whether image quality prevented confident
+  reading of any markings on this page. true triggers potential
+  enhancement processing.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Process exactly one page per response
+- Accumulate classification state: if a prior state is provided in the
+  prompt, update it based on this page's findings
+- Apply the highest classification encountered across all pages
+- Never downgrade a classification based on a subsequent page`
+
+const enhanceSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "page_number": <number>,
+  "image_quality_limiting": <true|false>,
+  "enhanced": true,
+  "prior_confidence": "<HIGH|MEDIUM|LOW>"
+}
+
+Field constraints:
+- All fields from the classify specification apply, plus:
+- enhanced: Always true in enhancement responses.
+- prior_confidence: The confidence level from the classify stage that
+  triggered enhancement. Used to track whether enhancement improved
+  the assessment.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Focus analysis on re-rendered pages with improved image settings
+- Compare findings against the prior classification state
+- Maintain or upgrade classification; never downgrade
+- If enhanced images reveal no new information, preserve the prior
+  classification and note this in the rationale`
+
+var specs = map[Stage]string{
+	StageClassify: classifySpec,
+	StageEnhance:  enhanceSpec,
+}
+
+// Spec returns the hardcoded specification for a workflow stage.
+// Specifications define the expected output format and behavioral constraints.
+// Returns ErrInvalidStage if the stage is not recognized.
+func Spec(stage Stage) (string, error) {
+	text, ok := specs[stage]
+	if !ok {
+		return "", ErrInvalidStage
+	}
+	return text, nil
+}

--- a/internal/prompts/stages.go
+++ b/internal/prompts/stages.go
@@ -10,13 +10,11 @@ type Stage string
 
 // Valid workflow stages.
 const (
-	StageInit     Stage = "init"
 	StageClassify Stage = "classify"
 	StageEnhance  Stage = "enhance"
 )
 
 var stages = []Stage{
-	StageInit,
 	StageClassify,
 	StageEnhance,
 }
@@ -38,4 +36,14 @@ func (s *Stage) UnmarshalJSON(data []byte) error {
 	}
 	*s = v
 	return nil
+}
+
+// ParseStage validates a string as a known workflow stage.
+// Returns ErrInvalidStage if the value is not recognized.
+func ParseStage(s string) (Stage, error) {
+	v := Stage(s)
+	if !slices.Contains(stages, v) {
+		return "", ErrInvalidStage
+	}
+	return v, nil
 }

--- a/internal/prompts/system.go
+++ b/internal/prompts/system.go
@@ -19,9 +19,13 @@ type System interface {
 	) (*pagination.PageResult[Prompt], error)
 
 	Find(ctx context.Context, id uuid.UUID) (*Prompt, error)
+	Instructions(ctx context.Context, stage Stage) (string, error)
+	Spec(ctx context.Context, stage Stage) (string, error)
+
 	Create(ctx context.Context, cmd CreateCommand) (*Prompt, error)
 	Update(ctx context.Context, id uuid.UUID, cmd UpdateCommand) (*Prompt, error)
 	Delete(ctx context.Context, id uuid.UUID) error
+
 	Activate(ctx context.Context, id uuid.UUID) (*Prompt, error)
 	Deactivate(ctx context.Context, id uuid.UUID) (*Prompt, error)
 }


### PR DESCRIPTION
## Summary

- Add hardcoded default instructions and specifications per workflow stage (`instructions.go`, `specs.go`) with named constants and map-based accessors
- Add `Instructions` and `Spec` methods to the prompts `System` interface with DB-override-with-fallback for instructions and pure hardcoded for specs
- Add `ParseStage` validation function and `StageContent` response type
- Add `GET /{stage}/instructions` and `GET /{stage}/spec` API endpoints
- Remove `init` as a valid prompt stage (migration `000004`) — init node is pure image rendering with no LLM interaction
- Update API Cartographer docs and `.http` test file
- Fix `documents.http` file reference path

Closes #37