### PR TITLE
Add workflow foundation — types, runtime, errors, and parsing

### DIFF
--- a/.claude/context/guides/.archive/38-workflow-foundation.md
+++ b/.claude/context/guides/.archive/38-workflow-foundation.md
@@ -1,0 +1,237 @@
+# 38 — Workflow Foundation: Types, Runtime, Errors, and Parsing
+
+## Problem Context
+
+Herald's `workflow/` package contains only a placeholder `doc.go`. All subsequent workflow sub-issues (#39 init node, #40 classify node, #41 enhance/graph assembly) depend on foundational types, a runtime dependency struct, sentinel errors, generic JSON parsing, and prompt composition. This issue establishes those shared building blocks.
+
+## Architecture Approach
+
+- **Two core types** — `ClassificationState` holds the overall document assessment, `ClassificationPage` holds per-page data (image path, markings, enhancement flags). Methods on `ClassificationState` derive enhancement decisions from page data
+- **Runtime bundles workflow dependencies** as a simple struct with exported fields, following the `internal/infrastructure/infrastructure.go` pattern but scoped to what workflow nodes need
+- **Generic JSON parser** lives in `pkg/formatting/` (alongside existing `bytes.go`) since it's a reusable utility, not workflow-specific
+- **Prompt composition** calls the prompts domain's `Instructions()` and `Spec()` methods, combining both layers with serialized running state for context accumulation
+
+## Implementation
+
+### Step 1: Add Dependencies
+
+```bash
+go get github.com/JaimeStill/go-agents-orchestration
+go get github.com/JaimeStill/document-context
+```
+
+Then delete the placeholder:
+
+```bash
+rm workflow/doc.go
+```
+
+### Step 2: `workflow/errors.go`
+
+New file — four sentinel errors scoped to workflow operations:
+
+```go
+package workflow
+
+import "errors"
+
+var (
+	ErrDocumentNotFound = errors.New("document not found")
+	ErrRenderFailed     = errors.New("failed to render page images")
+	ErrClassifyFailed   = errors.New("classification failed")
+	ErrEnhanceFailed    = errors.New("enhancement failed")
+)
+```
+
+### Step 3: `workflow/types.go`
+
+New file — two core types plus `Confidence` constants and `WorkflowResult`. The schema is intentionally lean to minimize token consumption per LLM response across potentially thousands of pages. Prompt specifications (`internal/prompts/specs.go`) will be updated separately to align with this schema.
+
+```go
+package workflow
+
+import (
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "HIGH"
+	ConfidenceMedium Confidence = "MEDIUM"
+	ConfidenceLow    Confidence = "LOW"
+)
+
+type ClassificationPage struct {
+	PageNumber    int      `json:"page_number"`
+	ImagePath     string   `json:"image_path"`
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+	Enhance       bool     `json:"enhance"`
+	Enhancements  string   `json:"enhancements"`
+}
+
+type ClassificationState struct {
+	Classification string               `json:"classification"`
+	Confidence     Confidence           `json:"confidence"`
+	Rationale      string               `json:"rationale"`
+	Pages          []ClassificationPage `json:"pages"`
+}
+
+func (s *ClassificationState) NeedsEnhance() bool {
+	return slices.ContainsFunc(s.Pages, func(p ClassificationPage) bool {
+		return p.Enhance
+	})
+}
+
+func (s *ClassificationState) EnhancePages() []int {
+	var indices []int
+	for i, p := range s.Pages {
+		if p.Enhance {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+type WorkflowResult struct {
+	DocumentID  uuid.UUID           `json:"document_id"`
+	Filename    string              `json:"filename"`
+	PageCount   int                 `json:"page_count"`
+	State       ClassificationState `json:"state"`
+	CompletedAt time.Time           `json:"completed_at"`
+}
+```
+
+### Step 4: `workflow/runtime.go`
+
+New file — dependency bundle for workflow nodes:
+
+```go
+package workflow
+
+import (
+	"log/slog"
+
+	"github.com/JaimeStill/herald/internal/documents"
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/storage"
+
+	gaconfig "github.com/JaimeStill/go-agents/pkg/config"
+)
+
+type Runtime struct {
+	Agent     gaconfig.AgentConfig
+	Storage   storage.System
+	Documents documents.System
+	Prompts   prompts.System
+	Logger    *slog.Logger
+}
+```
+
+### Step 5: `pkg/formatting/parse.go`
+
+New file in existing `pkg/formatting/` package — generic JSON parser with markdown code fence fallback:
+
+```go
+package formatting
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var ErrParseFailed = errors.New("failed to parse response")
+
+var jsonBlockRegex = regexp.MustCompile(`(?s)` + "```" + `(?:json)?\s*\n?(.*?)\n?` + "```")
+
+func Parse[T any](content string) (T, error) {
+	var result T
+	content = strings.TrimSpace(content)
+
+	if err := json.Unmarshal([]byte(content), &result); err == nil {
+		return result, nil
+	}
+
+	matches := jsonBlockRegex.FindStringSubmatch(content)
+	if len(matches) >= 2 {
+		cleaned := strings.TrimSpace(matches[1])
+		if err := json.Unmarshal([]byte(cleaned), &result); err == nil {
+			return result, nil
+		}
+	}
+
+	return result, fmt.Errorf("%w: %s", ErrParseFailed, content)
+}
+```
+
+### Step 6: `workflow/prompts.go`
+
+New file — prompt composition combining instructions, spec, and running classification state:
+
+```go
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+)
+
+func ComposePrompt(
+	ctx context.Context,
+	ps prompts.System,
+	stage prompts.Stage,
+	state *ClassificationState,
+) (string, error) {
+	instructions, err := ps.Instructions(ctx, stage)
+	if err != nil {
+		return "", fmt.Errorf("load instructions for %s: %w", stage, err)
+	}
+
+	spec, err := ps.Spec(ctx, stage)
+	if err != nil {
+		return "", fmt.Errorf("load spec for %s: %w", stage, err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(instructions)
+	sb.WriteString("\n\n")
+	sb.WriteString(spec)
+
+	if state != nil {
+		stateJSON, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("serialize classification state: %w", err)
+		}
+
+		sb.WriteString("\n\nCurrent classification state:\n\n")
+		sb.WriteString(string(stateJSON))
+	}
+
+	return sb.String(), nil
+}
+```
+
+## Validation Criteria
+
+- [ ] go-agents-orchestration and document-context added to go.mod
+- [ ] `rm workflow/doc.go` — placeholder removed
+- [ ] `ClassificationPage` and `ClassificationState` defined with JSON tags
+- [ ] `ClassificationPage.ImagePath` uses file path (not data URI)
+- [ ] `NeedsEnhance()` and `EnhancePages()` methods on `ClassificationState`
+- [ ] Runtime struct defined with all dependency fields
+- [ ] `pkg/formatting/parse.go` handles both direct JSON and markdown-fenced JSON
+- [ ] `ComposePrompt` calls `Instructions()` + `Spec()` from prompts system
+- [ ] `go vet ./...` passes
+- [ ] `mise run build` succeeds
+- [ ] `go mod tidy` produces no changes

--- a/.claude/context/sessions/38-workflow-foundation.md
+++ b/.claude/context/sessions/38-workflow-foundation.md
@@ -1,0 +1,41 @@
+# 38 — Workflow Foundation: Types, Runtime, Errors, and Parsing
+
+## Summary
+
+Established the foundational `workflow/` package with shared types, a runtime dependency struct, sentinel errors, generic JSON parsing, and prompt composition. Added `go-agents-orchestration` and `document-context` dependencies. All subsequent workflow sub-issues (#39–#41) build on these definitions.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Type consolidation | Two core types (`ClassificationState`, `ClassificationPage`) instead of four | Reduces token consumption per LLM response; per-page classification/confidence are intermediate values that don't need persistence |
+| Enhancement methods | `NeedsEnhance()` and `EnhancePages()` on `ClassificationState` | Replaces standalone `QualityAssessment` struct; derives enhancement decisions from page data |
+| `NeedsEnhance` implementation | `slices.ContainsFunc` | Idiomatic Go; short-circuits on first match |
+| `EnhancePages` implementation | Range loop collecting indices | No standard library function for index-collecting filter |
+| JSON parser location | `pkg/formatting/parse.go` | Generic utility alongside existing `bytes.go`; not workflow-specific |
+| Workflow Runtime struct | Separate from Infrastructure | Infrastructure represents cold-start systems; workflow Runtime bundles the specific subset of dependencies nodes need, including domain systems created after Infrastructure |
+
+## Files Modified
+
+- `workflow/errors.go` — new: 4 sentinel errors, package doc comment
+- `workflow/types.go` — new: `Confidence`, `ClassificationPage`, `ClassificationState` (with methods), `WorkflowResult`
+- `workflow/runtime.go` — new: `Runtime` struct (AgentConfig, Storage, Documents, Prompts, Logger)
+- `workflow/prompts.go` — new: `ComposePrompt` combining instructions + spec + state
+- `pkg/formatting/parse.go` — new: `Parse[T any]` with markdown code fence fallback, `ErrParseFailed`
+- `go.mod` / `go.sum` — added `go-agents-orchestration` and `document-context` dependencies
+- `tests/formatting/parse_test.go` — new: 10 test cases for `Parse`
+- `tests/workflow/types_test.go` — new: tests for `NeedsEnhance`, `EnhancePages`, JSON round-trip, confidence constants
+- `tests/workflow/prompts_test.go` — new: tests for `ComposePrompt` with mock `prompts.System`
+
+## Patterns Established
+
+- **Workflow types are lean** — only persist what's needed; intermediate LLM response fields are consumed by nodes but not stored per-page
+- **Per-page rationale** — `ClassificationPage.Rationale` captures model notes that feed into overall assessment
+- **Enhancement as per-page flag** — `Enhance` bool + `Enhancements` string on `ClassificationPage` replaces a separate quality assessment struct
+- **Mock prompts.System** — test pattern for workflow tests needing a prompts dependency
+
+## Validation Results
+
+- `go vet ./...` — passes
+- `go test ./tests/...` — all 28 new tests pass, full suite green (17 packages)
+- `go mod tidy` — no changes

--- a/.claude/plans/eventual-humming-sunset.md
+++ b/.claude/plans/eventual-humming-sunset.md
@@ -1,0 +1,104 @@
+# Issue #38 — Workflow Foundation: Types, Runtime, Errors, and Parsing
+
+## Context
+
+Herald's `workflow/` package currently contains only `doc.go`. All subsequent workflow sub-issues (#39 init node, #40 classify node, #41 enhance/graph assembly) depend on the foundational types, runtime struct, sentinel errors, JSON parsing, and prompt composition defined here. This issue establishes the shared building blocks before any node implementation begins.
+
+## Dependencies to Add
+
+```bash
+go get github.com/JaimeStill/go-agents-orchestration
+go get github.com/JaimeStill/document-context
+```
+
+Neither is currently in `go.mod`. Both are needed by later workflow sub-issues but adding them now ensures `go mod tidy` resolves cleanly with the new imports.
+
+## Implementation Steps
+
+### Step 1: Add dependencies and remove placeholder
+
+- `go get` both libraries
+- Delete `workflow/doc.go` (replaced by the new files)
+
+### Step 2: `workflow/errors.go` — Sentinel errors
+
+Four workflow-scoped errors following Herald's `var ErrX = errors.New(...)` pattern:
+
+- `ErrDocumentNotFound`
+- `ErrRenderFailed`
+- `ErrClassifyFailed`
+- `ErrEnhanceFailed`
+
+No `MapHTTPStatus` — workflow is not an HTTP domain. Parse error lives in `pkg/formatting/` (see Step 5).
+
+**Pattern reference:** `internal/prompts/errors.go`, `internal/documents/errors.go`
+
+### Step 3: `workflow/types.go` — All shared types
+
+**`Confidence`** — String type with constants `ConfidenceHigh`, `ConfidenceMedium`, `ConfidenceLow` (mirrors `prompts.Stage` pattern from `internal/prompts/stages.go`).
+
+**`PageImage`** — `PageNumber int`, `ImagePath string`. File path in temp directory, not data URI.
+
+**`PageClassification`** — Per-page LLM response matching the spec in `internal/prompts/specs.go`:
+- `PageNumber`, `Classification`, `Confidence`, `MarkingsFound`, `Rationale`, `ImageQualityLimiting`
+
+**`ClassificationState`** — Accumulated across pages:
+- `Classification`, `Confidence`, `MarkingsFound` (all pages), `Rationale`, `QualityFactor` (any page quality-limited), `Pages []PageClassification`
+- `Enhanced`, `PriorConfidence` (set by enhance stage)
+
+**`QualityAssessment`** — `QualityLimiting bool`, `AffectedPages []int`. Derived from ClassificationState for enhance decision.
+
+**`WorkflowResult`** — Wraps ClassificationState with document metadata: `DocumentID`, `Filename`, `PageCount`, `State`, `CompletedAt`.
+
+### Step 4: `workflow/runtime.go` — Dependency bundle
+
+Simple struct with exported fields (matches `internal/infrastructure/infrastructure.go` pattern):
+
+```
+Runtime {
+    Agent     gaconfig.AgentConfig
+    Storage   storage.System
+    Documents documents.System
+    Prompts   prompts.System
+    Logger    *slog.Logger
+}
+```
+
+Uses `gaconfig` import alias per existing convention.
+
+### Step 5: `pkg/formatting/parse.go` — Generic JSON parsing
+
+Adds `Parse[T any](content string) (T, error)` to the existing `pkg/formatting/` package (alongside `bytes.go`):
+1. Try direct `json.Unmarshal`
+2. Fall back to markdown code fence extraction via regex
+3. Return `ErrParseFailed` (new sentinel in `pkg/formatting/`) wrapped with the raw content
+
+Also adds `ErrParseFailed` — either inline in `parse.go` or in a new `errors.go` in the package (single error, inline is fine).
+
+**Pattern reference:** `agent-lab/workflows/classify/parse.go` (generic with regex), `go-agents/tools/classify-docs/pkg/classify/parser.go` (simpler variant)
+
+### Step 6: `workflow/prompts.go` — Prompt composition
+
+`ComposePrompt(ctx, ps prompts.System, stage prompts.Stage, state *ClassificationState) (string, error)`:
+1. Call `ps.Instructions(ctx, stage)` — tunable layer (DB override or hardcoded default)
+2. Call `ps.Spec(ctx, stage)` — immutable output format
+3. Combine: instructions + spec + serialized ClassificationState (when non-nil)
+
+State is nil on first page (prompt = instructions + spec only). On subsequent pages, the accumulated state is JSON-serialized as context so the LLM knows what has been found.
+
+## Files Summary
+
+| File | Contents |
+|------|----------|
+| `workflow/errors.go` | 4 sentinel errors |
+| `workflow/types.go` | `Confidence`, `PageImage`, `PageClassification`, `ClassificationState`, `QualityAssessment`, `WorkflowResult` |
+| `workflow/runtime.go` | `Runtime` struct (AgentConfig, Storage, Documents, Prompts, Logger) |
+| `pkg/formatting/parse.go` | `Parse[T any]` with markdown code fence fallback + `ErrParseFailed` |
+| `workflow/prompts.go` | `ComposePrompt` composing instructions + spec + state |
+
+## Validation
+
+- `go vet ./...` passes
+- `mise run build` succeeds
+- `go mod tidy` produces no changes
+- JSON tags on types match the LLM response spec in `internal/prompts/specs.go`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0-dev.26.38
+
+- Add workflow foundation — classification types, runtime dependency struct, sentinel errors, generic JSON parser with markdown code fence fallback, and prompt composition (#38)
+
 ## v0.2.0-dev.26.37
 
 - Add hardcoded default instructions and specifications per workflow stage, `Instructions` and `Spec` methods on the prompts System interface, stage content API endpoints, `ParseStage` validation, and remove init as a prompt stage (#37)

--- a/pkg/formatting/parse.go
+++ b/pkg/formatting/parse.go
@@ -1,0 +1,37 @@
+package formatting
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrParseFailed is returned when content cannot be parsed as JSON,
+// either directly or from a markdown code fence.
+var ErrParseFailed = errors.New("failed to parse response")
+
+var jsonBlockRegex = regexp.MustCompile(`(?s)` + "```" + `(?:json)?\s*\n?(.*?)\n?` + "```")
+
+// Parse attempts to unmarshal content as JSON into T.
+// If direct parsing fails, it extracts JSON from a markdown code fence
+// and retries. Returns ErrParseFailed if both attempts fail.
+func Parse[T any](content string) (T, error) {
+	var result T
+	content = strings.TrimSpace(content)
+
+	if err := json.Unmarshal([]byte(content), &result); err == nil {
+		return result, nil
+	}
+
+	matches := jsonBlockRegex.FindStringSubmatch(content)
+	if len(matches) >= 2 {
+		cleaned := strings.TrimSpace(matches[1])
+		if err := json.Unmarshal([]byte(cleaned), &result); err == nil {
+			return result, nil
+		}
+	}
+
+	return result, fmt.Errorf("%w: %s", ErrParseFailed, content)
+}

--- a/tests/formatting/parse_test.go
+++ b/tests/formatting/parse_test.go
@@ -1,0 +1,110 @@
+package formatting_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type sample struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestParse(t *testing.T) {
+	t.Run("direct JSON", func(t *testing.T) {
+		got, err := formatting.Parse[sample](`{"name":"test","value":42}`)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got.Name != "test" || got.Value != 42 {
+			t.Errorf("Parse = %+v, want {Name:test Value:42}", got)
+		}
+	})
+
+	t.Run("direct JSON with whitespace", func(t *testing.T) {
+		got, err := formatting.Parse[sample](`  {"name":"padded","value":1}  `)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got.Name != "padded" {
+			t.Errorf("Name = %q, want padded", got.Name)
+		}
+	})
+
+	t.Run("markdown fenced JSON", func(t *testing.T) {
+		input := "```json\n{\"name\":\"fenced\",\"value\":7}\n```"
+		got, err := formatting.Parse[sample](input)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got.Name != "fenced" || got.Value != 7 {
+			t.Errorf("Parse = %+v, want {Name:fenced Value:7}", got)
+		}
+	})
+
+	t.Run("markdown fenced without language tag", func(t *testing.T) {
+		input := "```\n{\"name\":\"bare\",\"value\":3}\n```"
+		got, err := formatting.Parse[sample](input)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got.Name != "bare" || got.Value != 3 {
+			t.Errorf("Parse = %+v, want {Name:bare Value:3}", got)
+		}
+	})
+
+	t.Run("markdown fenced with surrounding text", func(t *testing.T) {
+		input := "Here is the result:\n```json\n{\"name\":\"wrapped\",\"value\":5}\n```\nDone."
+		got, err := formatting.Parse[sample](input)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got.Name != "wrapped" || got.Value != 5 {
+			t.Errorf("Parse = %+v, want {Name:wrapped Value:5}", got)
+		}
+	})
+
+	t.Run("invalid content returns ErrParseFailed", func(t *testing.T) {
+		_, err := formatting.Parse[sample]("not json at all")
+		if !errors.Is(err, formatting.ErrParseFailed) {
+			t.Errorf("error = %v, want ErrParseFailed", err)
+		}
+	})
+
+	t.Run("empty string returns ErrParseFailed", func(t *testing.T) {
+		_, err := formatting.Parse[sample]("")
+		if !errors.Is(err, formatting.ErrParseFailed) {
+			t.Errorf("error = %v, want ErrParseFailed", err)
+		}
+	})
+
+	t.Run("invalid JSON in code fence returns ErrParseFailed", func(t *testing.T) {
+		input := "```json\n{broken\n```"
+		_, err := formatting.Parse[sample](input)
+		if !errors.Is(err, formatting.ErrParseFailed) {
+			t.Errorf("error = %v, want ErrParseFailed", err)
+		}
+	})
+
+	t.Run("parses into map type", func(t *testing.T) {
+		got, err := formatting.Parse[map[string]any](`{"key":"value"}`)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if got["key"] != "value" {
+			t.Errorf("got[key] = %v, want value", got["key"])
+		}
+	})
+
+	t.Run("parses into slice type", func(t *testing.T) {
+		got, err := formatting.Parse[[]int](`[1,2,3]`)
+		if err != nil {
+			t.Fatalf("Parse error: %v", err)
+		}
+		if len(got) != 3 || got[0] != 1 || got[2] != 3 {
+			t.Errorf("got = %v, want [1 2 3]", got)
+		}
+	})
+}

--- a/tests/workflow/prompts_test.go
+++ b/tests/workflow/prompts_test.go
@@ -1,0 +1,162 @@
+package workflow_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/pagination"
+	"github.com/JaimeStill/herald/workflow"
+)
+
+type mockPrompts struct {
+	instructions map[prompts.Stage]string
+	specs        map[prompts.Stage]string
+}
+
+func (m *mockPrompts) Handler() *prompts.Handler                          { return nil }
+func (m *mockPrompts) List(context.Context, pagination.PageRequest, prompts.Filters) (*pagination.PageResult[prompts.Prompt], error) {
+	return nil, nil
+}
+func (m *mockPrompts) Find(context.Context, uuid.UUID) (*prompts.Prompt, error) { return nil, nil }
+func (m *mockPrompts) Create(context.Context, prompts.CreateCommand) (*prompts.Prompt, error) {
+	return nil, nil
+}
+func (m *mockPrompts) Update(context.Context, uuid.UUID, prompts.UpdateCommand) (*prompts.Prompt, error) {
+	return nil, nil
+}
+func (m *mockPrompts) Delete(context.Context, uuid.UUID) error                    { return nil }
+func (m *mockPrompts) Activate(context.Context, uuid.UUID) (*prompts.Prompt, error)   { return nil, nil }
+func (m *mockPrompts) Deactivate(context.Context, uuid.UUID) (*prompts.Prompt, error) { return nil, nil }
+
+func (m *mockPrompts) Instructions(_ context.Context, stage prompts.Stage) (string, error) {
+	text, ok := m.instructions[stage]
+	if !ok {
+		return "", prompts.ErrInvalidStage
+	}
+	return text, nil
+}
+
+func (m *mockPrompts) Spec(_ context.Context, stage prompts.Stage) (string, error) {
+	text, ok := m.specs[stage]
+	if !ok {
+		return "", prompts.ErrInvalidStage
+	}
+	return text, nil
+}
+
+func newMockPrompts() *mockPrompts {
+	return &mockPrompts{
+		instructions: map[prompts.Stage]string{
+			prompts.StageClassify: "classify instructions",
+			prompts.StageEnhance:  "enhance instructions",
+		},
+		specs: map[prompts.Stage]string{
+			prompts.StageClassify: "classify spec",
+			prompts.StageEnhance:  "enhance spec",
+		},
+	}
+}
+
+func TestComposePrompt(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockPrompts()
+
+	t.Run("nil state produces instructions and spec", func(t *testing.T) {
+		got, err := workflow.ComposePrompt(ctx, mock, prompts.StageClassify, nil)
+		if err != nil {
+			t.Fatalf("ComposePrompt error: %v", err)
+		}
+
+		if !strings.Contains(got, "classify instructions") {
+			t.Error("missing instructions in prompt")
+		}
+		if !strings.Contains(got, "classify spec") {
+			t.Error("missing spec in prompt")
+		}
+		if strings.Contains(got, "Current classification state") {
+			t.Error("nil state should not include state section")
+		}
+	})
+
+	t.Run("with state includes serialized state", func(t *testing.T) {
+		state := &workflow.ClassificationState{
+			Classification: "SECRET",
+			Confidence:     workflow.ConfidenceHigh,
+			Rationale:      "clear markings",
+			Pages: []workflow.ClassificationPage{
+				{
+					PageNumber:    1,
+					MarkingsFound: []string{"SECRET"},
+					Rationale:     "banner visible",
+				},
+			},
+		}
+
+		got, err := workflow.ComposePrompt(ctx, mock, prompts.StageClassify, state)
+		if err != nil {
+			t.Fatalf("ComposePrompt error: %v", err)
+		}
+
+		if !strings.Contains(got, "classify instructions") {
+			t.Error("missing instructions in prompt")
+		}
+		if !strings.Contains(got, "classify spec") {
+			t.Error("missing spec in prompt")
+		}
+		if !strings.Contains(got, "Current classification state") {
+			t.Error("missing state header in prompt")
+		}
+		if !strings.Contains(got, "SECRET") {
+			t.Error("missing classification value in serialized state")
+		}
+	})
+
+	t.Run("enhance stage uses enhance instructions and spec", func(t *testing.T) {
+		got, err := workflow.ComposePrompt(ctx, mock, prompts.StageEnhance, nil)
+		if err != nil {
+			t.Fatalf("ComposePrompt error: %v", err)
+		}
+
+		if !strings.Contains(got, "enhance instructions") {
+			t.Error("missing enhance instructions in prompt")
+		}
+		if !strings.Contains(got, "enhance spec") {
+			t.Error("missing enhance spec in prompt")
+		}
+	})
+
+	t.Run("invalid stage returns error", func(t *testing.T) {
+		_, err := workflow.ComposePrompt(ctx, mock, "banana", nil)
+		if err == nil {
+			t.Error("expected error for invalid stage")
+		}
+	})
+
+	t.Run("prompt structure is instructions then spec then state", func(t *testing.T) {
+		state := &workflow.ClassificationState{
+			Classification: "UNCLASSIFIED",
+			Confidence:     workflow.ConfidenceLow,
+			Rationale:      "no markings found",
+		}
+
+		got, err := workflow.ComposePrompt(ctx, mock, prompts.StageClassify, state)
+		if err != nil {
+			t.Fatalf("ComposePrompt error: %v", err)
+		}
+
+		instrIdx := strings.Index(got, "classify instructions")
+		specIdx := strings.Index(got, "classify spec")
+		stateIdx := strings.Index(got, "Current classification state")
+
+		if instrIdx >= specIdx {
+			t.Error("instructions should appear before spec")
+		}
+		if specIdx >= stateIdx {
+			t.Error("spec should appear before state")
+		}
+	})
+}

--- a/tests/workflow/types_test.go
+++ b/tests/workflow/types_test.go
@@ -1,0 +1,192 @@
+package workflow_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/JaimeStill/herald/workflow"
+)
+
+func TestNeedsEnhance(t *testing.T) {
+	tests := []struct {
+		name  string
+		pages []workflow.ClassificationPage
+		want  bool
+	}{
+		{
+			"no pages",
+			nil,
+			false,
+		},
+		{
+			"no enhancement needed",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: false},
+				{PageNumber: 2, Enhance: false},
+			},
+			false,
+		},
+		{
+			"one page needs enhancement",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: false},
+				{PageNumber: 2, Enhance: true},
+			},
+			true,
+		},
+		{
+			"all pages need enhancement",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: true},
+				{PageNumber: 2, Enhance: true},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &workflow.ClassificationState{Pages: tt.pages}
+			if got := state.NeedsEnhance(); got != tt.want {
+				t.Errorf("NeedsEnhance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnhancePages(t *testing.T) {
+	tests := []struct {
+		name  string
+		pages []workflow.ClassificationPage
+		want  []int
+	}{
+		{
+			"no pages",
+			nil,
+			nil,
+		},
+		{
+			"no enhancement needed",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: false},
+				{PageNumber: 2, Enhance: false},
+			},
+			nil,
+		},
+		{
+			"mixed enhancement",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: false},
+				{PageNumber: 2, Enhance: true},
+				{PageNumber: 3, Enhance: false},
+				{PageNumber: 4, Enhance: true},
+			},
+			[]int{1, 3},
+		},
+		{
+			"all pages need enhancement",
+			[]workflow.ClassificationPage{
+				{PageNumber: 1, Enhance: true},
+				{PageNumber: 2, Enhance: true},
+			},
+			[]int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &workflow.ClassificationState{Pages: tt.pages}
+			got := state.EnhancePages()
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("EnhancePages() = %v, want nil", got)
+				}
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("EnhancePages() length = %d, want %d", len(got), len(tt.want))
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("EnhancePages()[%d] = %d, want %d", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClassificationStateJSON(t *testing.T) {
+	state := workflow.ClassificationState{
+		Classification: "SECRET",
+		Confidence:     workflow.ConfidenceHigh,
+		Rationale:      "clear markings on all pages",
+		Pages: []workflow.ClassificationPage{
+			{
+				PageNumber:    1,
+				ImagePath:     "/tmp/doc/page-1.png",
+				MarkingsFound: []string{"SECRET", "NOFORN"},
+				Rationale:     "banner and portion markings visible",
+				Enhance:       false,
+			},
+			{
+				PageNumber:    2,
+				ImagePath:     "/tmp/doc/page-2.png",
+				MarkingsFound: []string{"SECRET"},
+				Rationale:     "banner partially obscured",
+				Enhance:       true,
+				Enhancements:  "brightness +20%",
+			},
+		},
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got workflow.ClassificationState
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Classification != state.Classification {
+		t.Errorf("Classification = %q, want %q", got.Classification, state.Classification)
+	}
+	if got.Confidence != state.Confidence {
+		t.Errorf("Confidence = %q, want %q", got.Confidence, state.Confidence)
+	}
+	if got.Rationale != state.Rationale {
+		t.Errorf("Rationale = %q, want %q", got.Rationale, state.Rationale)
+	}
+	if len(got.Pages) != 2 {
+		t.Fatalf("Pages length = %d, want 2", len(got.Pages))
+	}
+	if got.Pages[1].Enhance != true {
+		t.Errorf("Pages[1].Enhance = %v, want true", got.Pages[1].Enhance)
+	}
+	if got.Pages[1].Enhancements != "brightness +20%" {
+		t.Errorf("Pages[1].Enhancements = %q, want %q", got.Pages[1].Enhancements, "brightness +20%")
+	}
+}
+
+func TestConfidenceConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		c    workflow.Confidence
+		want string
+	}{
+		{"high", workflow.ConfidenceHigh, "HIGH"},
+		{"medium", workflow.ConfidenceMedium, "MEDIUM"},
+		{"low", workflow.ConfidenceLow, "LOW"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.c) != tt.want {
+				t.Errorf("Confidence = %q, want %q", tt.c, tt.want)
+			}
+		})
+	}
+}

--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -1,1 +1,0 @@
-package workflow

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -1,0 +1,14 @@
+// Package workflow implements the classification workflow for Herald.
+// It provides foundational types, prompt composition, and response parsing
+// used by the 3-node state graph (init → classify → enhance?).
+package workflow
+
+import "errors"
+
+// Sentinel errors for workflow operations.
+var (
+	ErrDocumentNotFound = errors.New("document not found")
+	ErrRenderFailed     = errors.New("failed to render page images")
+	ErrClassifyFailed   = errors.New("classification failed")
+	ErrEnhanceFailed    = errors.New("enhancement failed")
+)

--- a/workflow/prompts.go
+++ b/workflow/prompts.go
@@ -1,0 +1,48 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+)
+
+// ComposePrompt builds a system prompt by combining tunable instructions,
+// immutable specifications, and the running classification state for a given
+// workflow stage. When state is nil (first page), the prompt contains only
+// instructions and spec.
+func ComposePrompt(
+	ctx context.Context,
+	ps prompts.System,
+	stage prompts.Stage,
+	state *ClassificationState,
+) (string, error) {
+	instructions, err := ps.Instructions(ctx, stage)
+	if err != nil {
+		return "", fmt.Errorf("load instructions for %s: %w", stage, err)
+	}
+
+	spec, err := ps.Spec(ctx, stage)
+	if err != nil {
+		return "", fmt.Errorf("load spec for %s: %w", stage, err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(instructions)
+	sb.WriteString("\n\n")
+	sb.WriteString(spec)
+
+	if state != nil {
+		stateJSON, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("serialize classification state: %w", err)
+		}
+
+		sb.WriteString("\n\nCurrent classification state:\n\n")
+		sb.WriteString(string(stateJSON))
+	}
+
+	return sb.String(), nil
+}

--- a/workflow/runtime.go
+++ b/workflow/runtime.go
@@ -1,0 +1,21 @@
+package workflow
+
+import (
+	"log/slog"
+
+	"github.com/JaimeStill/herald/internal/documents"
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/storage"
+
+	gaconfig "github.com/JaimeStill/go-agents/pkg/config"
+)
+
+// Runtime bundles the dependencies that workflow nodes require.
+// It is constructed by higher-level composition code from Infrastructure and Domain systems.
+type Runtime struct {
+	Agent     gaconfig.AgentConfig
+	Storage   storage.System
+	Documents documents.System
+	Prompts   prompts.System
+	Logger    *slog.Logger
+}

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -1,0 +1,65 @@
+package workflow
+
+import (
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Confidence represents a categorical assessment of classification certainty.
+type Confidence string
+
+// Confidence levels for classification results.
+const (
+	ConfidenceHigh   Confidence = "HIGH"
+	ConfidenceMedium Confidence = "MEDIUM"
+	ConfidenceLow    Confidence = "LOW"
+)
+
+// WorkflowResult is the final output from a classification workflow execution.
+type WorkflowResult struct {
+	DocumentID  uuid.UUID           `json:"document_id"`
+	Filename    string              `json:"filename"`
+	PageCount   int                 `json:"page_count"`
+	State       ClassificationState `json:"state"`
+	CompletedAt time.Time           `json:"completed_at"`
+}
+
+// ClassificationPage holds per-page data accumulated during classification.
+// ImagePath references the rendered page image in a temp directory.
+// Enhance signals that this page should be re-rendered with adjusted settings.
+type ClassificationPage struct {
+	PageNumber    int      `json:"page_number"`
+	ImagePath     string   `json:"image_path"`
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+	Enhance       bool     `json:"enhance"`
+	Enhancements  string   `json:"enhancements"`
+}
+
+// ClassificationState holds the running document classification accumulated across pages.
+type ClassificationState struct {
+	Classification string               `json:"classification"`
+	Confidence     Confidence           `json:"confidence"`
+	Rationale      string               `json:"rationale"`
+	Pages          []ClassificationPage `json:"pages"`
+}
+
+// NeedsEnhance reports whether any page is flagged for enhancement.
+func (s *ClassificationState) NeedsEnhance() bool {
+	return slices.ContainsFunc(s.Pages, func(p ClassificationPage) bool {
+		return p.Enhance
+	})
+}
+
+// EnhancePages returns the indices of pages flagged for enhancement.
+func (s *ClassificationState) EnhancePages() []int {
+	var indices []int
+	for i, p := range s.Pages {
+		if p.Enhance {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}


### PR DESCRIPTION
## Summary

Establish the foundational `workflow/` package with shared types, runtime dependency struct, sentinel errors, generic JSON parsing, and prompt composition. All subsequent workflow sub-issues (#39–#41) build on these definitions.

Closes #38

## Changes

- `workflow/types.go` — `Confidence` constants, `ClassificationPage`, `ClassificationState` (with `NeedsEnhance()` and `EnhancePages()` methods), `WorkflowResult`
- `workflow/runtime.go` — `Runtime` struct bundling AgentConfig, Storage, Documents, Prompts, Logger
- `workflow/errors.go` — sentinel errors for workflow operations (package doc comment)
- `workflow/prompts.go` — `ComposePrompt` combining instructions + spec + running state
- `pkg/formatting/parse.go` — generic `Parse[T any]` with markdown code fence fallback
- `go.mod` — added `go-agents-orchestration` and `document-context` dependencies
- Tests for all new exported API surfaces (28 test cases)