### PR TITLE
Add init node — concurrent page rendering with temp storage

### DIFF
--- a/.claude/context/guides/.archive/39-init-node.md
+++ b/.claude/context/guides/.archive/39-init-node.md
@@ -1,0 +1,238 @@
+# 39 — Init Node: Concurrent Page Rendering with Temp Storage
+
+## Problem Context
+
+The init node is the first stage of the classification workflow. It downloads a PDF from blob storage, opens it via document-context, and renders all pages to image files in a temp directory using concurrent ImageMagick rendering. Downstream nodes (classify, enhance) read these image files just-in-time for LLM vision calls, keeping memory proportional to one page at a time.
+
+## Architecture Approach
+
+The init node follows the `state.NewFunctionNode` closure pattern from go-agents-orchestration. It receives `document_id` and `temp_dir` from the state bag (set by `Execute` in #41), performs all PDF-to-image work, and returns updated state with the initial `ClassificationState` and document metadata.
+
+Page rendering is CPU-heavy (ImageMagick), so pages are rendered concurrently using `errgroup.Group` with `SetLimit`. Worker count is capped at `min(runtime.NumCPU(), pageCount)` — no point spawning more goroutines than pages or CPUs. Page extraction via `ExtractAllPages()` happens sequentially before the concurrent render phase.
+
+The simplified type system from #38 means the init node creates `ClassificationPage` structs with only `PageNumber` and `ImagePath` populated — no separate `PageImage` type needed.
+
+## Implementation
+
+### Step 1: Add dependencies
+
+```bash
+go get github.com/JaimeStill/document-context@latest
+go get github.com/JaimeStill/go-agents-orchestration@latest
+```
+
+`golang.org/x/sync` is already an indirect dependency. It will become direct when imported for `errgroup`.
+
+Run `go mod tidy` after adding the imports in Step 3.
+
+### Step 2: Add state key constants to `workflow/types.go`
+
+Add these constants above the `Confidence` type:
+
+```go
+const (
+	KeyDocumentID = "document_id"
+	KeyTempDir    = "temp_dir"
+	KeyFilename   = "filename"
+	KeyPageCount  = "page_count"
+	KeyClassState = "classification_state"
+)
+```
+
+### Step 3: Create `workflow/init.go`
+
+New file — complete implementation:
+
+```go
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/document-context/pkg/config"
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/image"
+	"github.com/JaimeStill/herald/internal/documents"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const sourcePDF = "source.pdf"
+
+func renderWorkerCount(pageCount int) int {
+	return max(min(runtime.NumCPU(), pageCount), 1)
+}
+
+// extractInitInputs reads the document ID and temp directory path from workflow state.
+func extractInitInputs(s state.State) (uuid.UUID, string, error) {
+	docIDVal, ok := s.Get(KeyDocumentID)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: missing %s in state", ErrDocumentNotFound, KeyDocumentID)
+	}
+
+	documentID, ok := docIDVal.(uuid.UUID)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: %s is not uuid.UUID", ErrDocumentNotFound, KeyDocumentID)
+	}
+
+	tempDirVal, ok := s.Get(KeyTempDir)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: missing %s in state", ErrRenderFailed, KeyTempDir)
+	}
+
+	tempDir, ok := tempDirVal.(string)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: %s is not string", ErrRenderFailed, KeyTempDir)
+	}
+
+	return documentID, tempDir, nil
+}
+
+// downloadPDF finds the document record, downloads its blob from storage,
+// and writes it to {tempDir}/source.pdf. Returns the document for metadata access.
+func downloadPDF(ctx context.Context, rt *Runtime, documentID uuid.UUID, tempDir string) (*documents.Document, error) {
+	doc, err := rt.Documents.Find(ctx, documentID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDocumentNotFound, err)
+	}
+
+	blob, err := rt.Storage.Download(ctx, doc.StorageKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: download blob: %w", ErrRenderFailed, err)
+	}
+	defer blob.Body.Close()
+
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfFile, err := os.Create(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: create temp pdf: %w", ErrRenderFailed, err)
+	}
+
+	if _, err := io.Copy(pdfFile, blob.Body); err != nil {
+		pdfFile.Close()
+		return nil, fmt.Errorf("%w: write temp pdf: %w", ErrRenderFailed, err)
+	}
+	pdfFile.Close()
+
+	return doc, nil
+}
+
+// renderPages opens the PDF at {tempDir}/source.pdf, creates an ImageMagick renderer,
+// extracts all pages, and renders them concurrently to PNG files in tempDir.
+func renderPages(ctx context.Context, tempDir string) ([]ClassificationPage, error) {
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfDoc, err := document.OpenPDF(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: open pdf: %w", ErrRenderFailed, err)
+	}
+	defer pdfDoc.Close()
+
+	renderer, err := image.NewImageMagickRenderer(config.DefaultImageConfig())
+	if err != nil {
+		return nil, fmt.Errorf("%w: create renderer: %w", ErrRenderFailed, err)
+	}
+
+	allPages, err := pdfDoc.ExtractAllPages()
+	if err != nil {
+		return nil, fmt.Errorf("%w: extract pages: %w", ErrRenderFailed, err)
+	}
+
+	pageCount := len(allPages)
+	pages := make([]ClassificationPage, pageCount)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(renderWorkerCount(pageCount))
+
+	for i, page := range allPages {
+		pageNum := i + 1
+		imgPath := filepath.Join(tempDir, fmt.Sprintf("page-%d.png", pageNum))
+		pages[i] = ClassificationPage{
+			PageNumber: pageNum,
+			ImagePath:  imgPath,
+		}
+
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			data, err := page.ToImage(renderer, nil)
+			if err != nil {
+				return fmt.Errorf("render page %d: %w", pageNum, err)
+			}
+
+			if err := os.WriteFile(imgPath, data, 0600); err != nil {
+				return fmt.Errorf("write page %d image: %w", pageNum, err)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRenderFailed, err)
+	}
+
+	return pages, nil
+}
+
+func initNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		documentID, tempDir, err := extractInitInputs(s)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		doc, err := downloadPDF(ctx, rt, documentID, tempDir)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		pages, err := renderPages(ctx, tempDir)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		rt.Logger.InfoContext(ctx, "init node complete",
+			"document_id", documentID,
+			"page_count", len(pages),
+		)
+
+		s = s.Set(KeyClassState, ClassificationState{Pages: pages})
+		s = s.Set(KeyFilename, doc.Filename)
+		s = s.Set(KeyPageCount, len(pages))
+
+		return s, nil
+	})
+}
+```
+
+### Step 4: Run `go mod tidy`
+
+```bash
+go mod tidy
+```
+
+This resolves the new direct dependencies and promotes `golang.org/x/sync` from indirect to direct.
+
+## Validation Criteria
+
+- [ ] `go mod tidy` produces no changes (after initial tidy)
+- [ ] `go vet ./...` passes
+- [ ] All existing tests pass: `go test ./tests/...`
+- [ ] `initNode` extracts `document_id` and `temp_dir` from state
+- [ ] PDF is downloaded from blob storage and written to `{tempDir}/source.pdf`
+- [ ] All pages rendered concurrently with bounded workers (`min(NumCPU, pageCount)`)
+- [ ] Each `ClassificationPage` has 1-indexed `PageNumber` and `ImagePath` at `{tempDir}/page-{N}.png`
+- [ ] `ClassificationState` with pages stored in state under `KeyClassState`
+- [ ] Document metadata (`filename`, `page_count`) stored in state
+- [ ] Errors wrap `ErrDocumentNotFound` or `ErrRenderFailed` as appropriate

--- a/.claude/context/sessions/39-init-node.md
+++ b/.claude/context/sessions/39-init-node.md
@@ -1,0 +1,33 @@
+# 39 — Init Node: Concurrent Page Rendering with Temp Storage
+
+## Summary
+
+Implemented the init node for the classification workflow. The node downloads a PDF from blob storage, opens it via document-context, and renders all pages to PNG images concurrently using ImageMagick with bounded worker count. Page images are written to a request-bound temp directory. The initial `ClassificationState` (with `ClassificationPage` entries containing page numbers and image paths) is stored in the workflow state bag for downstream nodes.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Node function convention | Single exported `*Node` function with clean body composed of helper calls | Each helper encapsulates one stage; the node body reads as an orchestration sequence |
+| Worker count | `max(min(runtime.NumCPU(), pageCount), 1)` | Caps at CPU count (ImageMagick is CPU-heavy) and page count (no excess goroutines), floor of 1; adapted from agent-lab |
+| Temp PDF filename | `sourcePDF` constant in init.go | Avoids hardcoded strings; scoped to the file since only `downloadPDF` and `renderPages` use it |
+| No new tests | InitNode requires mocking two domain systems + real PDF + ImageMagick | Integration-level testing; not worth the mocking overhead for unit tests |
+| Exported InitNode | Uppercase `InitNode` | Graph assembly in #41 needs to reference it |
+
+## Files Modified
+
+- `workflow/init.go` — new: `InitNode`, `downloadPDF`, `extractInitState`, `renderPages`, `renderWorkerCount`
+- `workflow/types.go` — added state key constants (`KeyDocumentID`, `KeyTempDir`, `KeyFilename`, `KeyPageCount`, `KeyClassState`)
+- `go.mod` / `go.sum` — added `document-context`, `go-agents-orchestration`; promoted `golang.org/x/sync` to direct
+
+## Patterns Established
+
+- **Workflow node file convention**: Each node gets its own file (`init.go`, `classify.go`, `enhance.go`). A single exported `*Node` function with a clean body composed of unexported helper calls that encapsulate each stage.
+- **State key constants**: `Key*` constants in `types.go` for the `state.State` data map keys shared across nodes.
+- **Bounded render concurrency**: `renderWorkerCount` helper using `max(min(NumCPU, pageCount), 1)`.
+
+## Validation Results
+
+- `go vet ./...` — passes
+- `go test ./tests/...` — all 17 packages pass
+- `go mod tidy` — clean after tidy

--- a/.claude/plans/elegant-tickling-clock.md
+++ b/.claude/plans/elegant-tickling-clock.md
@@ -1,0 +1,76 @@
+# 39 — Init Node: Concurrent Page Rendering with Temp Storage
+
+## Context
+
+The init node is the first stage of Herald's 3-node classification workflow (init → classify → enhance?). It bridges blob storage and the document-context library: downloading a PDF, opening it, rendering all pages to images concurrently via ImageMagick, and storing the results as files in a request-bound temp directory. Downstream nodes (classify, enhance) read these image files just-in-time for LLM vision calls.
+
+Issue #38 (workflow foundation) established the type system with two core types — `ClassificationState` and `ClassificationPage` — eliminating the need for a separate `PageImage` type. The init node populates `ClassificationPage` with only `PageNumber` and `ImagePath`, leaving classification fields for the classify node.
+
+## Implementation
+
+### Step 1: Add state key constants to `workflow/types.go`
+
+Define string constants for the keys used in the `state.State` data map. These are shared across all workflow nodes and the `Execute` function.
+
+```go
+const (
+    KeyDocumentID = "document_id"
+    KeyTempDir    = "temp_dir"
+    KeyFilename   = "filename"
+    KeyPageCount  = "page_count"
+    KeyClassState = "classification_state"
+)
+```
+
+**File:** `workflow/types.go`
+
+### Step 2: Create `workflow/init.go`
+
+New file containing the `initNode` function. Returns a `state.NewFunctionNode` closure that:
+
+1. Extracts `document_id` (uuid.UUID) and `temp_dir` (string) from state
+2. Looks up the document record via `runtime.Documents.Find(ctx, documentID)`
+3. Downloads the PDF blob via `runtime.Storage.Download(ctx, doc.StorageKey)` to `{tempDir}/source.pdf`
+4. Opens the PDF via `document.OpenPDF(pdfPath)`
+5. Creates a renderer via `image.NewImageMagickRenderer(config.DefaultImageConfig())`
+6. Extracts all pages via `doc.ExtractAllPages()`
+7. Renders pages concurrently using `errgroup.Group` with `SetLimit(renderWorkerCount(pageCount))`
+   - Worker count: `max(min(runtime.NumCPU(), pageCount), 1)` — adapted from agent-lab's pattern
+   - Each goroutine: `page.ToImage(renderer, nil)` → `os.WriteFile(filepath.Join(tempDir, "page-{N}.png"), data, 0600)`
+8. Builds `[]ClassificationPage` (only `PageNumber` + `ImagePath` populated)
+9. Stores initial `ClassificationState` (with pages) in state via `KeyClassState`
+10. Stores document metadata (`KeyFilename`, `KeyPageCount`) in state for `WorkflowResult` assembly
+
+**Signature:** `func initNode(runtime *Runtime) state.StateNode` (unexported — only used by graph assembly in #41)
+
+**Error wrapping:**
+- Document lookup failure → `ErrDocumentNotFound`
+- Blob download, PDF open, page extraction, rendering, file write failures → `ErrRenderFailed`
+
+**Dependencies added to go.mod:**
+- `github.com/JaimeStill/document-context`
+- `github.com/JaimeStill/go-agents-orchestration`
+- `golang.org/x/sync` (for `errgroup`) — already an indirect dep, becomes direct
+
+**Key files referenced:**
+- `workflow/runtime.go` — Runtime struct with Documents, Storage, Logger
+- `workflow/types.go` — ClassificationState, ClassificationPage
+- `workflow/errors.go` — ErrDocumentNotFound, ErrRenderFailed
+- `internal/documents/system.go` — `Find(ctx, uuid.UUID) (*Document, error)`
+- `pkg/storage/storage.go` — `Download(ctx, key) (*BlobResult, error)`, BlobResult.Body is `io.ReadCloser`
+- `document-context/pkg/document/pdf.go` — `OpenPDF(path)`, `ExtractAllPages()`, `ToImage(renderer, nil)`
+- `document-context/pkg/image/imagemagick.go` — `NewImageMagickRenderer(cfg)`
+- `document-context/pkg/config/image.go` — `DefaultImageConfig()`
+- `go-agents-orchestration/pkg/state/node.go` — `NewFunctionNode(fn)`
+- `go-agents-orchestration/pkg/state/state.go` — `State.Get(key)`, `State.Set(key, value)`
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go mod tidy` produces no changes
+- [ ] All existing tests pass: `go test ./tests/...`
+- [ ] New tests for `initNode` cover: state key extraction, document lookup, page rendering output, error wrapping with sentinels
+- [ ] Init node produces `ClassificationState` with correct number of `ClassificationPage` entries
+- [ ] Each `ClassificationPage` has `PageNumber` (1-indexed) and `ImagePath` pointing to `{tempDir}/page-{N}.png`
+- [ ] Concurrency is bounded via `errgroup.SetLimit`
+- [ ] Errors wrap `ErrDocumentNotFound` or `ErrRenderFailed` as appropriate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0-dev.26.39
+
+- Add init node with concurrent page rendering to temp storage, state key constants, and document-context/go-agents-orchestration dependencies (#39)
+
 ## v0.2.0-dev.26.38
 
 - Add workflow foundation — classification types, runtime dependency struct, sentinel errors, generic JSON parser with markdown code fence fallback, and prompt composition (#38)

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,14 @@ go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
+	github.com/JaimeStill/document-context v0.1.1
 	github.com/JaimeStill/go-agents v0.3.0
+	github.com/JaimeStill/go-agents-orchestration v0.3.2
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/pdfcpu/pdfcpu v0.11.1
+	golang.org/x/sync v0.18.0
 )
 
 require (
@@ -27,7 +30,6 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/image v0.32.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,12 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/JaimeStill/document-context v0.1.1 h1:JuxHfv83T6nF5Lu1ID9m6f1yaVxbweBxJBnEuO4QYDY=
+github.com/JaimeStill/document-context v0.1.1/go.mod h1:QYynVYa7NfYEIMF3G3MPSQPnEfIK2tddlJrQnAQhOhI=
 github.com/JaimeStill/go-agents v0.3.0 h1:MBPbuIipP3Rue1JpinuTcTrkRkl2p1TSAvh95WbE514=
 github.com/JaimeStill/go-agents v0.3.0/go.mod h1:Ui+Ea0YrnI37MbWXP7VxqX3IcIppkQRSO4/DEl4/4B4=
+github.com/JaimeStill/go-agents-orchestration v0.3.2 h1:/KmPPTlfTvLNUJ5y9Kuw1gDXZL5wzSSstIJouox9WZ8=
+github.com/JaimeStill/go-agents-orchestration v0.3.2/go.mod h1:wmGCjN1wgSdjf83gATj63h1HNyELHQNzmYTX8TRzoS4=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/workflow/init.go
+++ b/workflow/init.go
@@ -1,0 +1,175 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/document-context/pkg/config"
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/image"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/documents"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const sourcePDF = "source.pdf"
+
+// InitNode returns a state node that downloads a PDF from blob storage,
+// renders all pages to PNG images concurrently via ImageMagick, and stores
+// the initial ClassificationState in the workflow state bag.
+func InitNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		documentID, tempDir, err := extractInitState(s)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		doc, err := downloadPDF(ctx, rt, documentID, tempDir)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		pages, err := renderPages(ctx, tempDir)
+		if err != nil {
+			return s, fmt.Errorf("init: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "init node complete",
+			"document_id", documentID,
+			"page_count", len(pages),
+		)
+
+		s = s.Set(KeyClassState, ClassificationState{Pages: pages})
+		s = s.Set(KeyFilename, doc.Filename)
+		s = s.Set(KeyPageCount, len(pages))
+
+		return s, nil
+	})
+}
+
+func downloadPDF(
+	ctx context.Context,
+	rt *Runtime,
+	documentID uuid.UUID,
+	tempDir string,
+) (*documents.Document, error) {
+	doc, err := rt.Documents.Find(ctx, documentID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDocumentNotFound, err)
+	}
+
+	blob, err := rt.Storage.Download(ctx, doc.StorageKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: download blob: %w", ErrRenderFailed, err)
+	}
+	defer blob.Body.Close()
+
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfFile, err := os.Create(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: create temp pdf: %w", ErrRenderFailed, err)
+	}
+
+	if _, err := io.Copy(pdfFile, blob.Body); err != nil {
+		pdfFile.Close()
+		return nil, fmt.Errorf("%w: write temp pdf: %w", ErrRenderFailed, err)
+	}
+	pdfFile.Close()
+
+	return doc, nil
+}
+
+func extractInitState(s state.State) (uuid.UUID, string, error) {
+	docIDVal, ok := s.Get(KeyDocumentID)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: missing %s in state", ErrDocumentNotFound, KeyDocumentID)
+	}
+
+	documentID, ok := docIDVal.(uuid.UUID)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: %s is not uuid.UUID", ErrDocumentNotFound, KeyDocumentID)
+	}
+
+	tempDirVal, ok := s.Get(KeyTempDir)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: missing %s in state", ErrRenderFailed, KeyTempDir)
+	}
+
+	tempDir, ok := tempDirVal.(string)
+	if !ok {
+		return uuid.Nil, "", fmt.Errorf("%w: %s is not string", ErrRenderFailed, KeyTempDir)
+	}
+
+	return documentID, tempDir, nil
+}
+
+func renderPages(ctx context.Context, tempDir string) ([]ClassificationPage, error) {
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfDoc, err := document.OpenPDF(pdfPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: open pdf: %w", ErrRenderFailed, err)
+	}
+	defer pdfDoc.Close()
+
+	renderer, err := image.NewImageMagickRenderer(config.DefaultImageConfig())
+	if err != nil {
+		return nil, fmt.Errorf("%w: create renderer: %w", ErrRenderFailed, err)
+	}
+
+	allPages, err := pdfDoc.ExtractAllPages()
+	if err != nil {
+		return nil, fmt.Errorf("%w: extract pages: %w", ErrRenderFailed, err)
+	}
+
+	pageCount := len(allPages)
+	pages := make([]ClassificationPage, pageCount)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(renderWorkerCount(pageCount))
+
+	for i, page := range allPages {
+		pageNum := i + 1
+		imgPath := filepath.Join(tempDir, fmt.Sprintf("page-%d.png", pageNum))
+		pages[i] = ClassificationPage{
+			PageNumber: pageNum,
+			ImagePath:  imgPath,
+		}
+
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			data, err := page.ToImage(renderer, nil)
+			if err != nil {
+				return fmt.Errorf("render page %d: %w", pageNum, err)
+			}
+
+			if err := os.WriteFile(imgPath, data, 0600); err != nil {
+				return fmt.Errorf("write page %d image: %w", pageNum, err)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrRenderFailed, err)
+	}
+
+	return pages, nil
+}
+
+func renderWorkerCount(pageCount int) int {
+	return max(min(runtime.NumCPU(), pageCount), 1)
+}

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -7,6 +7,14 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	KeyDocumentID = "document_id"
+	KeyTempDir    = "temp_dir"
+	KeyFilename   = "filename"
+	KeyPageCount  = "page_count"
+	KeyClassState = "classification_state"
+)
+
 // Confidence represents a categorical assessment of classification certainty.
 type Confidence string
 


### PR DESCRIPTION
## Summary

Implement the init node, the first stage of the classification workflow. Downloads a PDF from blob storage, opens it via document-context, and renders all pages to PNG images concurrently using ImageMagick with bounded worker count. Page images are written to a request-bound temp directory, and the initial `ClassificationState` is stored in the workflow state bag for downstream nodes.

Closes #39

## Changes

- Add `workflow/init.go` with `InitNode`, `downloadPDF`, `extractInitState`, `renderPages`, and `renderWorkerCount`
- Add state key constants (`KeyDocumentID`, `KeyTempDir`, `KeyFilename`, `KeyPageCount`, `KeyClassState`) to `workflow/types.go`
- Add `document-context` and `go-agents-orchestration` dependencies; promote `golang.org/x/sync` to direct
- Establish workflow node file convention: single exported `*Node` function with clean body composed of stage-encapsulating helpers