### PR TITLE
Add classify node — sequential page-by-page context accumulation

### DIFF
--- a/.claude/context/guides/.archive/40-classify-node.md
+++ b/.claude/context/guides/.archive/40-classify-node.md
@@ -1,0 +1,351 @@
+# 40 — Classify Node
+
+## Problem Context
+
+The classify node is the core of the classification workflow. It processes pages sequentially so each page's findings feed into the next page's prompt (context accumulation) — adapted from the classify-docs pattern that achieved 96.3% accuracy. The classify node only populates per-page `ClassificationPage` data; document-level classification synthesis is deferred to a finalize node (#41).
+
+The hard-coded specs and prompts domain also need alignment with the optimized workflow types and the new 4-node topology (init → classify → enhance? → finalize).
+
+## Architecture Approach
+
+- **Per-page analysis only**: classify populates `ClassificationPage` fields; `ClassificationState` document-level fields are left empty for the finalize node
+- **Context accumulation via ComposePrompt**: first page passes `nil` (no prior context), subsequent pages pass `&classState` so the model sees prior page findings
+- **Just-in-time image encoding**: PNG read from disk, encoded to data URI, bytes released after encoding — one page image in memory at a time
+- **Per-request agent creation**: fresh `agent.Agent` per `Execute` call
+- **Page-only classify spec**: response schema aligned with `ClassificationPage` fields
+- **New finalize stage**: `StageFinalize` added to prompts domain with its own spec and instructions
+
+## Implementation
+
+### Step 1: Add `StageFinalize` (`internal/prompts/stages.go`)
+
+Add the finalize constant and include it in the stages slice:
+
+```go
+const (
+	StageClassify  Stage = "classify"
+	StageEnhance   Stage = "enhance"
+	StageFinalize  Stage = "finalize"
+)
+
+var stages = []Stage{
+	StageClassify,
+	StageEnhance,
+	StageFinalize,
+}
+```
+
+### Step 2: Update classify spec, add finalize spec (`internal/prompts/specs.go`)
+
+Replace `classifySpec` with a page-only response format aligned with `ClassificationPage` fields:
+
+```go
+const classifySpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "enhance": false,
+  "enhancements": ""
+}
+
+Field constraints:
+- markings_found: Array of distinct marking strings found on this page,
+  exactly as they appear in the document. Include the full marking text
+  with any caveats (e.g., "SECRET//NOFORN" not just "SECRET").
+- rationale: Brief explanation of what security markings were found on
+  this page and their significance. Note any conflicts or ambiguities
+  with prior page findings if a classification state is provided.
+- enhance: Whether image quality prevented confident reading of any
+  markings on this page. Set true only when markings are visibly present
+  but cannot be read with certainty due to image quality.
+- enhancements: When enhance is true, describe the specific image quality
+  issues and what adjustments might help (e.g., "faded banner markings —
+  increase brightness and contrast"). Empty string when enhance is false.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Process exactly one page per response
+- Report only what you observe on this page
+- If prior page findings are provided in the prompt, use them as context
+  to identify consistency or conflicts, but do not repeat prior findings
+  in markings_found — only include markings visible on the current page`
+```
+
+Replace `enhanceSpec` with an aligned version:
+
+```go
+const enhanceSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "enhance": false,
+  "enhancements": ""
+}
+
+Field constraints:
+- markings_found: Array of distinct marking strings found on this
+  enhanced page, exactly as they appear. Include the full marking text
+  with any caveats.
+- rationale: Brief explanation of what the enhanced image reveals compared
+  to the original. Note any new markings discovered or prior findings
+  confirmed by the improved image quality.
+- enhance: Whether image quality still prevents confident reading after
+  enhancement. Should typically be false after enhancement processing.
+- enhancements: Description of remaining quality issues if enhance is
+  still true. Empty string when enhance is false.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Focus analysis on the enhanced image with improved rendering settings
+- Compare findings against the prior page analysis provided in the prompt
+- Report only what you observe on the current enhanced page`
+```
+
+Add `finalizeSpec`:
+
+```go
+const finalizeSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "rationale": "<explanation>"
+}
+
+Field constraints:
+- classification: The overall security classification marking for the
+  document, synthesized from all page findings (e.g., UNCLASSIFIED,
+  CONFIDENTIAL, SECRET, TOP SECRET, or with caveats like SECRET//NOFORN).
+  Apply the highest classification encountered across all pages.
+- confidence: Categorical assessment of classification certainty.
+  HIGH = markings are clear, consistent, and unambiguous across pages.
+  MEDIUM = markings are present but partially obscured or inconsistent.
+  LOW = markings are unclear, missing, or contradictory.
+- rationale: Comprehensive explanation of the document classification
+  synthesized from all page findings. Reference specific page evidence,
+  note any cross-page conflicts, and explain how the final classification
+  was determined.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Consider all page findings holistically when determining classification
+- Apply the highest classification encountered across all pages
+- Never downgrade based on pages with lower or missing markings
+- Confidence reflects the overall clarity and consistency across all pages,
+  not just the most recent page analyzed`
+```
+
+Update the `specs` map:
+
+```go
+var specs = map[Stage]string{
+	StageClassify: classifySpec,
+	StageEnhance:  enhanceSpec,
+	StageFinalize: finalizeSpec,
+}
+```
+
+### Step 3: Add finalize instructions (`internal/prompts/instructions.go`)
+
+Add `finalizeInstructions`:
+
+```go
+const finalizeInstructions = `You are a security classification analyst producing the final document classification.
+
+Review all per-page analysis results provided in the classification state. Each page entry contains the markings found on that page and a rationale explaining the findings. Synthesize these per-page results into a single authoritative document classification.
+
+When determining the overall classification:
+- Apply the highest classification marking encountered across all pages
+- Consider the full marking text including caveats (e.g., NOFORN, REL TO, FOUO)
+- Resolve any cross-page conflicts by applying the most restrictive interpretation
+- Base your confidence on the overall clarity and consistency of markings across all pages`
+```
+
+Update the `instructions` map:
+
+```go
+var instructions = map[Stage]string{
+	StageClassify: classifyInstructions,
+	StageEnhance:  enhanceInstructions,
+	StageFinalize: finalizeInstructions,
+}
+```
+
+### Step 4: Database migration
+
+Create `cmd/migrate/migrations/000005_prompts_add_finalize_stage.up.sql`:
+
+```sql
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance', 'finalize'));
+```
+
+Create `cmd/migrate/migrations/000005_prompts_add_finalize_stage.down.sql`:
+
+```sql
+DELETE FROM prompts WHERE stage = 'finalize';
+
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance'));
+```
+
+### Step 5: Create `workflow/classify.go`
+
+Complete new file:
+
+```go
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/encoding"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type pageResponse struct {
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+	Enhance       bool     `json:"enhance"`
+	Enhancements  string   `json:"enhancements"`
+}
+
+func ClassifyNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		classState, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("classify: %w", err)
+		}
+
+		if err := classifyPages(ctx, rt, classState); err != nil {
+			return s, fmt.Errorf("classify: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "classify node complete",
+			"page_count", len(classState.Pages),
+		)
+
+		s = s.Set(KeyClassState, *classState)
+		return s, nil
+	})
+}
+
+func extractClassState(s state.State) (*ClassificationState, error) {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing %s in state", ErrClassifyFailed, KeyClassState)
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s is not ClassificationState", ErrClassifyFailed, KeyClassState)
+	}
+
+	return &cs, nil
+}
+
+func classifyPages(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrClassifyFailed, err)
+	}
+
+	for i := range cs.Pages {
+		if err := classifyPage(ctx, a, rt, cs, i); err != nil {
+			return fmt.Errorf("%w: page %d: %w", ErrClassifyFailed, i+1, err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "page classified",
+			"page", i+1,
+			"total", len(cs.Pages),
+			"markings", cs.Pages[i].MarkingsFound,
+			"enhance", cs.Pages[i].Enhance,
+		)
+	}
+
+	return nil
+}
+
+func classifyPage(ctx context.Context, a agent.Agent, rt *Runtime, cs *ClassificationState, pageIdx int) error {
+	dataURI, err := encodePageImage(cs.Pages[pageIdx].ImagePath)
+	if err != nil {
+		return err
+	}
+
+	var promptState *ClassificationState
+	if pageIdx > 0 {
+		promptState = cs
+	}
+
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageClassify, promptState)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.Vision(ctx, prompt, []string{dataURI})
+	if err != nil {
+		return fmt.Errorf("vision call: %w", err)
+	}
+
+	parsed, err := formatting.Parse[pageResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+
+	applyPageResponse(&cs.Pages[pageIdx], parsed)
+	return nil
+}
+
+func encodePageImage(imagePath string) (string, error) {
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		return "", fmt.Errorf("read image: %w", err)
+	}
+
+	dataURI, err := encoding.EncodeImageDataURI(data, document.PNG)
+	if err != nil {
+		return "", fmt.Errorf("encode image: %w", err)
+	}
+
+	return dataURI, nil
+}
+
+func applyPageResponse(page *ClassificationPage, resp pageResponse) {
+	page.MarkingsFound = resp.MarkingsFound
+	page.Rationale = resp.Rationale
+	page.Enhance = resp.Enhance
+	page.Enhancements = resp.Enhancements
+}
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` passes
+- [ ] Pages processed sequentially with context accumulation (prior page findings in prompt)
+- [ ] Each page response populates only `ClassificationPage` fields
+- [ ] Images loaded from disk and encoded just-in-time (one at a time)
+- [ ] Vision API called with base64 data URI per page
+- [ ] JSON response parsed with code fence fallback via `formatting.Parse`
+- [ ] ClassificationState stored in state with populated pages for downstream finalize
+- [ ] Classify spec is page-only, finalize spec covers document-level synthesis
+- [ ] `StageFinalize` added to stages, specs, instructions, and migration

--- a/.claude/context/sessions/40-classify-node.md
+++ b/.claude/context/sessions/40-classify-node.md
@@ -1,0 +1,41 @@
+# 40 — Classify Node
+
+## Summary
+
+Implemented the classify node for sequential page-by-page analysis with context accumulation. Introduced the 4-node workflow topology (init → classify → enhance? → finalize) by separating per-page analysis from document-level classification synthesis. Updated the prompts domain to add the `finalize` stage (stages, specs, instructions, migration) and aligned the classify/enhance specs with the optimized workflow types.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| 4-node workflow topology | init → classify → enhance? → finalize | Separating per-page analysis (classify) from document-level synthesis (finalize) eliminates incremental anchoring bias and ensures finalize sees all evidence holistically, including any enhanced pages |
+| Per-page-only classify response | Response schema matches `ClassificationPage` fields only | Document-level classification deferred to finalize node; classify focuses on what's visible per page |
+| Enhancements field purpose | Classify node describes what adjustments the enhance node should apply | Provides actionable context for the enhance node (e.g., "faded banner markings — increase brightness and contrast") |
+| Agent creation in classifyPages | Moved from ClassifyNode to classifyPages | Agent is only used within the page loop; keeps ClassifyNode focused on state extraction and storage |
+| Spec alignment with types | Updated specs to use `ClassificationPage` field names | Eliminated field name mismatches (image_quality_limiting → enhance) and removed obsolete document-level fields from classify spec |
+| No unit tests for ClassifyNode | Skip | Requires mocking agent, prompts.System, storage, and real Vision API calls — not worth the overhead |
+
+## Files Modified
+
+- `workflow/classify.go` — New: ClassifyNode, pageResponse, classifyPages, classifyPage, encodePageImage, applyPageResponse
+- `internal/prompts/stages.go` — Added StageFinalize constant
+- `internal/prompts/specs.go` — Rewrote classifySpec (page-only), updated enhanceSpec, added finalizeSpec
+- `internal/prompts/instructions.go` — Added finalizeInstructions
+- `cmd/migrate/migrations/000005_prompts_add_finalize_stage.up.sql` — New: adds finalize to CHECK constraint
+- `cmd/migrate/migrations/000005_prompts_add_finalize_stage.down.sql` — New: reverse migration
+- `_project/README.md` — Updated workflow topology, node descriptions, key decisions
+- `_project/objective.md` — Updated #41 scope and architecture decisions for 4-node topology
+- `tests/prompts/prompts_test.go` — Updated for StageFinalize
+- `tests/prompts/handler_test.go` — Updated for StageFinalize
+
+## Patterns Established
+
+- **Per-page-only node pattern**: Classify populates `ClassificationPage` fields per page; document-level `ClassificationState` fields are set by a downstream finalize node. This separation applies to enhance as well.
+- **Just-in-time image encoding**: PNG read from disk, encoded to data URI, bytes released. One page image in memory at a time.
+- **Context accumulation via ComposePrompt**: First page passes nil (no context), subsequent pages pass &classState so the model sees prior page findings.
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go build ./...` — clean
+- `go test ./tests/...` — all pass (prompts tests updated for StageFinalize)

--- a/.claude/plans/snuggly-napping-falcon.md
+++ b/.claude/plans/snuggly-napping-falcon.md
@@ -1,0 +1,134 @@
+# 40 — Classify Node
+
+## Context
+
+The classify node processes pages sequentially so each page's findings inform the next page's prompt (context accumulation). This session also introduces the 4-node workflow topology: `init → classify → enhance? → finalize`. The classify node only populates per-page `ClassificationPage` data. A new finalize node (issue #41) will synthesize document-level `ClassificationState` from all page findings in a single inference.
+
+The hard-coded specs were written before type optimization and need alignment. The `finalize` stage needs to be introduced across the prompts domain (stages, specs, instructions, migration).
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `internal/prompts/stages.go` | Modify | Add `StageFinalize` |
+| `internal/prompts/specs.go` | Modify | Page-only classify spec, add finalize spec |
+| `internal/prompts/instructions.go` | Modify | Add finalize instructions |
+| `cmd/migrate/migrations/000005_prompts_add_finalize_stage.up.sql` | Create | Add `finalize` to CHECK constraint |
+| `cmd/migrate/migrations/000005_prompts_add_finalize_stage.down.sql` | Create | Reverse migration |
+| `workflow/classify.go` | Create | ClassifyNode implementation |
+
+## Step 1: Add `StageFinalize` (`internal/prompts/stages.go`)
+
+Add `StageFinalize Stage = "finalize"` constant and include it in the `stages` slice.
+
+## Step 2: Update classify spec, add finalize spec (`internal/prompts/specs.go`)
+
+**Classify spec** — page-only response aligned with `ClassificationPage` fields:
+```json
+{
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "enhance": false,
+  "enhancements": ""
+}
+```
+
+Field constraints describe per-page analysis. Behavioral constraints emphasize: analyze one page, report what you find, flag quality issues via `enhance`/`enhancements` for downstream processing. Context accumulation note: prior page findings are provided in the prompt but the model does not produce document-level classification.
+
+**Finalize spec** — document-level synthesis aligned with `ClassificationState` fields:
+```json
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "rationale": "<explanation>"
+}
+```
+
+Field constraints describe document-level synthesis from all page findings. Behavioral constraints: apply highest classification across all pages, never downgrade, assess confidence based on clarity and consistency of all markings found.
+
+Add both to the `specs` map.
+
+## Step 3: Add finalize instructions (`internal/prompts/instructions.go`)
+
+Add `finalizeInstructions` — instructs the model to review all per-page analysis results and produce the authoritative document-level classification, confidence, and rationale. Add to `instructions` map.
+
+## Step 4: Migration (`cmd/migrate/migrations/000005_*`)
+
+**Up:**
+```sql
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+ALTER TABLE prompts ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance', 'finalize'));
+```
+
+**Down:**
+```sql
+DELETE FROM prompts WHERE stage = 'finalize';
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+ALTER TABLE prompts ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance'));
+```
+
+## Step 5: Create `workflow/classify.go`
+
+### Exported function
+
+`ClassifyNode(rt *Runtime) state.StateNode` — returns `state.NewFunctionNode` closure.
+
+### Flow
+
+1. Extract `ClassificationState` from state bag via `KeyClassState`
+2. Create agent via `agent.New(&rt.Agent)` (per-request creation)
+3. Classify all pages sequentially via `classifyPages`
+4. Store updated `ClassificationState` in state bag
+5. Log node completion
+
+### Unexported types and helpers
+
+**`pageResponse`** — intermediate parsing type matching the page-only spec:
+```go
+type pageResponse struct {
+    MarkingsFound []string `json:"markings_found"`
+    Rationale     string   `json:"rationale"`
+    Enhance       bool     `json:"enhance"`
+    Enhancements  string   `json:"enhancements"`
+}
+```
+
+**`classifyPages(ctx, agent, rt, *ClassificationState) error`** — sequential loop. For each page: encode image, compose prompt, call vision, parse, apply response.
+
+**`classifyPage(ctx, agent, rt, *ClassificationState, pageIndex) error`** — single page processing:
+1. Read PNG from `page.ImagePath` via `os.ReadFile`
+2. Encode to data URI via `encoding.EncodeImageDataURI(data, document.PNG)`
+3. Compose prompt: first page passes `nil` to `ComposePrompt`, subsequent pages pass `&classState` (model sees prior page findings as context)
+4. Call `agent.Vision(ctx, prompt, []string{dataURI})`
+5. Parse via `formatting.Parse[pageResponse](resp.Content())`
+6. Apply response to `ClassificationPage` fields only
+
+**`encodePageImage(imagePath string) (string, error)`** — read + encode, bytes released after.
+
+**`applyPageResponse(page *ClassificationPage, resp pageResponse)`** — maps response to page fields (markings_found, rationale, enhance, enhancements).
+
+### Key dependencies
+
+| Package | Import | Usage |
+|---------|--------|-------|
+| `go-agents/pkg/agent` | `agent.New`, `agent.Vision` | Per-request agent creation, vision calls |
+| `document-context/pkg/document` | `document.PNG` | Image format constant |
+| `document-context/pkg/encoding` | `encoding.EncodeImageDataURI` | Base64 data URI encoding |
+| `go-agents-orchestration/pkg/state` | `state.StateNode`, `state.NewFunctionNode` | Node interface |
+| `herald/internal/prompts` | `prompts.StageClassify` | Stage constant |
+| `herald/pkg/formatting` | `formatting.Parse[pageResponse]` | JSON parsing with code fence fallback |
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` passes
+- [ ] Pages processed sequentially with context accumulation (prior page findings in prompt)
+- [ ] Each page response populates only `ClassificationPage` fields
+- [ ] Images loaded from disk and encoded just-in-time (one at a time)
+- [ ] Vision API called with base64 data URI per page
+- [ ] JSON response parsed with code fence fallback via `formatting.Parse`
+- [ ] ClassificationState stored in state with populated pages for downstream finalize
+- [ ] Classify spec is page-only, finalize spec covers document-level synthesis
+- [ ] `StageFinalize` added to stages, specs, instructions, and migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0-dev.26.40
+
+- Add classify node with sequential page-by-page context accumulation, per-page-only analysis, and just-in-time image encoding (#40)
+- Introduce 4-node workflow topology (init → classify → enhance? → finalize) with dedicated finalize stage for document-level classification synthesis (#40)
+- Align classify and enhance specs with optimized workflow types, add finalize stage to prompts domain (stages, specs, instructions, migration) (#40)
+
 ## v0.2.0-dev.26.39
 
 - Add init node with concurrent page rendering to temp storage, state key constants, and document-context/go-agents-orchestration dependencies (#39)

--- a/cmd/migrate/migrations/000005_prompts_add_finalize_stage.down.sql
+++ b/cmd/migrate/migrations/000005_prompts_add_finalize_stage.down.sql
@@ -1,0 +1,7 @@
+DELETE FROM prompts WHERE stage = 'finalize';
+
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance'));

--- a/cmd/migrate/migrations/000005_prompts_add_finalize_stage.up.sql
+++ b/cmd/migrate/migrations/000005_prompts_add_finalize_stage.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE prompts DROP CONSTRAINT prompts_stage_check;
+
+ALTER TABLE prompts
+  ADD CONSTRAINT prompts_stage_check
+  CHECK (stage IN ('classify', 'enhance', 'finalize'));

--- a/internal/prompts/instructions.go
+++ b/internal/prompts/instructions.go
@@ -17,9 +17,20 @@ Previous classification analysis was limited by image quality. The affected page
 
 Compare your findings against the prior classification state. If the enhanced images reveal additional or different markings, update the classification accordingly. If the enhanced images confirm the prior assessment, maintain the existing classification with increased confidence.`
 
+const finalizeInstructions = `You are a security classification analyst producing the final document classification.
+
+Review all per-page analysis results provided in the classification state. Each page entry contains the markings found on that page and a rationale explaining the findings. Synthesize these per-page results into a single authoritative document classification.
+
+When determining the overall classification:
+- Apply the highest classification marking encountered across all pages
+- Consider the full marking text including caveats (e.g., NOFORN, REL TO, FOUO)
+- Resolve any cross-page conflicts by applying the most restrictive interpretation
+- Base your confidence on the overall clarity and consistency of markings across all pages`
+
 var instructions = map[Stage]string{
 	StageClassify: classifyInstructions,
 	StageEnhance:  enhanceInstructions,
+	StageFinalize: finalizeInstructions,
 }
 
 // Instructions returns the hardcoded default instructions for a workflow stage.

--- a/internal/prompts/specs.go
+++ b/internal/prompts/specs.go
@@ -3,70 +3,95 @@ package prompts
 const classifySpec = `Respond with a JSON object matching this exact structure:
 
 {
-  "classification": "<marking>",
-  "confidence": "<HIGH|MEDIUM|LOW>",
   "markings_found": ["<marking1>", "<marking2>"],
   "rationale": "<explanation>",
-  "page_number": <number>,
-  "image_quality_limiting": <true|false>
+  "enhance": false,
+  "enhancements": ""
 }
 
 Field constraints:
-- classification: The overall security classification marking for the document
-  as assessed through this page (e.g., UNCLASSIFIED, CONFIDENTIAL, SECRET,
-  TOP SECRET, or with caveats like SECRET//NOFORN).
-- confidence: Categorical assessment of classification certainty.
-  HIGH = markings are clear, consistent, and unambiguous.
-  MEDIUM = markings are present but partially obscured or inconsistent.
-  LOW = markings are unclear, missing, or contradictory.
 - markings_found: Array of distinct marking strings found on this page,
-  exactly as they appear in the document.
-- rationale: Brief explanation of how the classification was determined
-  from the visible markings. Note any conflicts or ambiguities.
-- page_number: The 1-indexed page number being analyzed.
-- image_quality_limiting: Whether image quality prevented confident
-  reading of any markings on this page. true triggers potential
-  enhancement processing.
+  exactly as they appear in the document. Include the full marking text
+  with any caveats (e.g., "SECRET//NOFORN" not just "SECRET").
+- rationale: Brief explanation of what security markings were found on
+  this page and their significance. Note any conflicts or ambiguities
+  with prior page findings if a classification state is provided.
+- enhance: Whether image quality prevented confident reading of any
+  markings on this page. Set true only when markings are visibly present
+  but cannot be read with certainty due to image quality.
+- enhancements: When enhance is true, describe the specific image quality
+  issues and what adjustments might help (e.g., "faded banner markings —
+  increase brightness and contrast"). Empty string when enhance is false.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
 - Process exactly one page per response
-- Accumulate classification state: if a prior state is provided in the
-  prompt, update it based on this page's findings
-- Apply the highest classification encountered across all pages
-- Never downgrade a classification based on a subsequent page`
+- Report only what you observe on this page
+- If prior page findings are provided in the prompt, use them as context
+  to identify consistency or conflicts, but do not repeat prior findings
+  in markings_found — only include markings visible on the current page`
 
 const enhanceSpec = `Respond with a JSON object matching this exact structure:
 
 {
-  "classification": "<marking>",
-  "confidence": "<HIGH|MEDIUM|LOW>",
   "markings_found": ["<marking1>", "<marking2>"],
   "rationale": "<explanation>",
-  "page_number": <number>,
-  "image_quality_limiting": <true|false>,
-  "enhanced": true,
-  "prior_confidence": "<HIGH|MEDIUM|LOW>"
+  "enhance": false,
+  "enhancements": ""
 }
 
 Field constraints:
-- All fields from the classify specification apply, plus:
-- enhanced: Always true in enhancement responses.
-- prior_confidence: The confidence level from the classify stage that
-  triggered enhancement. Used to track whether enhancement improved
-  the assessment.
+- markings_found: Array of distinct marking strings found on this
+  enhanced page, exactly as they appear. Include the full marking text
+  with any caveats.
+- rationale: Brief explanation of what the enhanced image reveals compared
+  to the original. Note any new markings discovered or prior findings
+  confirmed by the improved image quality.
+- enhance: Whether image quality still prevents confident reading after
+  enhancement. Should typically be false after enhancement processing.
+- enhancements: Description of remaining quality issues if enhance is
+  still true. Empty string when enhance is false.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
-- Focus analysis on re-rendered pages with improved image settings
-- Compare findings against the prior classification state
-- Maintain or upgrade classification; never downgrade
-- If enhanced images reveal no new information, preserve the prior
-  classification and note this in the rationale`
+- Focus analysis on the enhanced image with improved rendering settings
+- Compare findings against the prior page analysis provided in the prompt
+- Report only what you observe on the current enhanced page`
+
+const finalizeSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "rationale": "<explanation>"
+}
+
+Field constraints:
+- classification: The overall security classification marking for the
+  document, synthesized from all page findings (e.g., UNCLASSIFIED,
+  CONFIDENTIAL, SECRET, TOP SECRET, or with caveats like SECRET//NOFORN).
+  Apply the highest classification encountered across all pages.
+- confidence: Categorical assessment of classification certainty.
+  HIGH = markings are clear, consistent, and unambiguous across pages.
+  MEDIUM = markings are present but partially obscured or inconsistent.
+  LOW = markings are unclear, missing, or contradictory.
+- rationale: Comprehensive explanation of the document classification
+  synthesized from all page findings. Reference specific page evidence,
+  note any cross-page conflicts, and explain how the final classification
+  was determined.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Consider all page findings holistically when determining classification
+- Apply the highest classification encountered across all pages
+- Never downgrade based on pages with lower or missing markings
+- Confidence reflects the overall clarity and consistency across all pages,
+  not just the most recent page analyzed`
 
 var specs = map[Stage]string{
 	StageClassify: classifySpec,
 	StageEnhance:  enhanceSpec,
+	StageFinalize: finalizeSpec,
 }
 
 // Spec returns the hardcoded specification for a workflow stage.

--- a/internal/prompts/stages.go
+++ b/internal/prompts/stages.go
@@ -12,11 +12,13 @@ type Stage string
 const (
 	StageClassify Stage = "classify"
 	StageEnhance  Stage = "enhance"
+	StageFinalize Stage = "finalize"
 )
 
 var stages = []Stage{
 	StageClassify,
 	StageEnhance,
+	StageFinalize,
 }
 
 // Stages returns the list of valid workflow stages.

--- a/tests/prompts/handler_test.go
+++ b/tests/prompts/handler_test.go
@@ -174,11 +174,11 @@ func TestHandlerStages(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if len(stages) != 2 {
-		t.Fatalf("stages length = %d, want 2", len(stages))
+	if len(stages) != 3 {
+		t.Fatalf("stages length = %d, want 3", len(stages))
 	}
 
-	want := []prompts.Stage{prompts.StageClassify, prompts.StageEnhance}
+	want := []prompts.Stage{prompts.StageClassify, prompts.StageEnhance, prompts.StageFinalize}
 	for i, s := range stages {
 		if s != want[i] {
 			t.Errorf("stages[%d] = %q, want %q", i, s, want[i])

--- a/tests/prompts/prompts_test.go
+++ b/tests/prompts/prompts_test.go
@@ -42,11 +42,11 @@ func TestMapHTTPStatus(t *testing.T) {
 func TestStages(t *testing.T) {
 	stages := prompts.Stages()
 
-	if len(stages) != 2 {
-		t.Fatalf("len(Stages()) = %d, want 2", len(stages))
+	if len(stages) != 3 {
+		t.Fatalf("len(Stages()) = %d, want 3", len(stages))
 	}
 
-	want := []prompts.Stage{prompts.StageClassify, prompts.StageEnhance}
+	want := []prompts.Stage{prompts.StageClassify, prompts.StageEnhance, prompts.StageFinalize}
 	for i, s := range stages {
 		if s != want[i] {
 			t.Errorf("Stages()[%d] = %q, want %q", i, s, want[i])
@@ -62,6 +62,7 @@ func TestStageUnmarshalJSON(t *testing.T) {
 		}{
 			{`"classify"`, prompts.StageClassify},
 			{`"enhance"`, prompts.StageEnhance},
+			{`"finalize"`, prompts.StageFinalize},
 		}
 
 		for _, tt := range tests {
@@ -144,6 +145,7 @@ func TestParseStage(t *testing.T) {
 		}{
 			{"classify", prompts.StageClassify},
 			{"enhance", prompts.StageEnhance},
+			{"finalize", prompts.StageFinalize},
 		}
 
 		for _, tt := range tests {

--- a/workflow/classify.go
+++ b/workflow/classify.go
@@ -1,0 +1,138 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/encoding"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type pageResponse struct {
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+	Enhance       bool     `json:"enhance"`
+	Enhancements  string   `json:"enhancements"`
+}
+
+// ClassifyNode returns a state node that performs sequential page-by-page
+// analysis. Each page image is encoded to a data URI just-in-time and sent
+// to the vision model with accumulated prior page findings as context. The
+// node populates per-page ClassificationPage fields only; document-level
+// classification synthesis is deferred to the finalize node.
+func ClassifyNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		classState, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("classify: %w", err)
+		}
+
+		if err := classifyPages(ctx, rt, classState); err != nil {
+			return s, fmt.Errorf("classify: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "classify node complete",
+			"page_count", len(classState.Pages),
+		)
+
+		s = s.Set(KeyClassState, *classState)
+		return s, nil
+	})
+}
+
+func extractClassState(s state.State) (*ClassificationState, error) {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing %s in state", ErrClassifyFailed, KeyClassState)
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s is not ClassificationState", ErrClassifyFailed, KeyClassState)
+	}
+
+	return &cs, nil
+}
+
+func classifyPages(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrClassifyFailed, err)
+	}
+
+	for i := range cs.Pages {
+		if err := classifyPage(ctx, a, rt, cs, i); err != nil {
+			return fmt.Errorf("%w: page %d: %w", ErrClassifyFailed, i+1, err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "page classified",
+			"page", i+1,
+			"total", len(cs.Pages),
+			"markings", cs.Pages[i].MarkingsFound,
+			"enhance", cs.Pages[i].Enhance,
+		)
+	}
+
+	return nil
+}
+
+func classifyPage(ctx context.Context, a agent.Agent, rt *Runtime, cs *ClassificationState, pageIdx int) error {
+	dataURI, err := encodePageImage(cs.Pages[pageIdx].ImagePath)
+	if err != nil {
+		return err
+	}
+
+	var promptState *ClassificationState
+	if pageIdx > 0 {
+		promptState = cs
+	}
+
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageClassify, promptState)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.Vision(ctx, prompt, []string{dataURI})
+	if err != nil {
+		return fmt.Errorf("vision call: %w", err)
+	}
+
+	parsed, err := formatting.Parse[pageResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+
+	applyPageResponse(&cs.Pages[pageIdx], parsed)
+	return nil
+}
+
+func encodePageImage(imagePath string) (string, error) {
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		return "", fmt.Errorf("read image: %w", err)
+	}
+
+	dataURI, err := encoding.EncodeImageDataURI(data, document.PNG)
+	if err != nil {
+		return "", fmt.Errorf("encode image: %w", err)
+	}
+
+	return dataURI, nil
+}
+
+func applyPageResponse(page *ClassificationPage, resp pageResponse) {
+	page.MarkingsFound = resp.MarkingsFound
+	page.Rationale = resp.Rationale
+	page.Enhance = resp.Enhance
+	page.Enhancements = resp.Enhancements
+}


### PR DESCRIPTION
## Summary

- Implement the classify node with sequential page-by-page analysis and context accumulation, populating per-page `ClassificationPage` fields only
- Introduce the 4-node workflow topology (init → classify → enhance? → finalize) with a dedicated finalize node for document-level classification synthesis
- Add `StageFinalize` to the prompts domain (stages, specs, instructions) with database migration
- Align classify and enhance specs with the optimized workflow types from #38
- Update project documentation and GitHub issue #41 to reflect the architectural change

Closes #40

## Changes

- **`workflow/classify.go`** — New: `ClassifyNode`, sequential page loop with just-in-time image encoding, Vision API calls, and `formatting.Parse` response parsing
- **`internal/prompts/stages.go`** — Add `StageFinalize` constant
- **`internal/prompts/specs.go`** — Page-only classify spec, updated enhance spec, new finalize spec
- **`internal/prompts/instructions.go`** — Add finalize instructions
- **`cmd/migrate/migrations/000005_*`** — Add `finalize` to prompts table CHECK constraint
- **`_project/README.md`** — 4-node workflow topology, updated node descriptions and key decisions
- **`_project/objective.md`** — Updated #41 scope and architecture decisions
- **`tests/prompts/*`** — Updated for `StageFinalize`