### PR TITLE
Add enhance node, finalize node, graph assembly, and Execute function

### DIFF
--- a/.claude/context/guides/.archive/41-enhance-finalize-graph-execute.md
+++ b/.claude/context/guides/.archive/41-enhance-finalize-graph-execute.md
@@ -1,0 +1,629 @@
+# 41 — Enhance Node, Finalize Node, Graph Assembly, and Execute Function
+
+## Problem Context
+
+The workflow package has init and classify nodes but no way to run them. This issue completes the classification workflow by adding the remaining nodes (enhance with re-rendering + reclassification, finalize for document-level synthesis), wiring the state graph, and exposing a top-level `Execute` function that manages the full lifecycle including temp directory creation and cleanup.
+
+## Architecture Approach
+
+The graph follows agent-lab's assembly pattern: register nodes, wire edges with predicates, set entry/exit points. Herald's conditional edge evaluates `ClassificationState.NeedsEnhance()` via a custom `TransitionPredicate` that extracts the classification state from the state bag.
+
+**Type change:** The `Enhance bool` + `Enhancements string` fields on `ClassificationPage` are replaced with a single `Enhancements *EnhanceSettings` pointer. `EnhanceSettings` carries structured rendering parameters (brightness, contrast, saturation) that map directly to document-context's `ImageMagickConfig` filter fields. `NeedsEnhance()` checks for any page with non-nil `Enhancements` — single source of truth, no bool/data inconsistency.
+
+**Enhance node:** A hybrid rendering + inference node. For each flagged page: re-opens the PDF from temp dir, re-renders with adjusted ImageMagick settings derived from `EnhanceSettings`, sends the enhanced image through a vision call to update the per-page classification, then clears the `Enhancements` pointer.
+
+**Finalize node:** Uses `agent.Chat` (not Vision) to synthesize document-level classification from all per-page findings. The `Execute` function owns temp directory lifecycle via defer.
+
+## Implementation
+
+### Step 1: Add `EnhanceSettings` and update `ClassificationPage` in `workflow/types.go`
+
+Add the new type and update the page struct. Replace `Enhance bool` + `Enhancements string` with `Enhancements *EnhanceSettings`:
+
+```go
+type EnhanceSettings struct {
+	Brightness *int `json:"brightness,omitempty"`
+	Contrast   *int `json:"contrast,omitempty"`
+	Saturation *int `json:"saturation,omitempty"`
+}
+```
+
+Updated `ClassificationPage` (replaces both `Enhance` and `Enhancements` fields):
+
+```go
+type ClassificationPage struct {
+	PageNumber    int              `json:"page_number"`
+	ImagePath     string           `json:"image_path"`
+	MarkingsFound []string         `json:"markings_found"`
+	Rationale     string           `json:"rationale"`
+	Enhancements  *EnhanceSettings `json:"enhancements,omitempty"`
+}
+```
+
+Add `Enhance` convenience method to `ClassificationPage`:
+
+```go
+func (p *ClassificationPage) Enhance() bool {
+	return p.Enhancements != nil
+}
+```
+
+Updated `NeedsEnhance` and `EnhancePages` to use it:
+
+```go
+func (s *ClassificationState) NeedsEnhance() bool {
+	return slices.ContainsFunc(s.Pages, func(p ClassificationPage) bool {
+		return p.Enhance()
+	})
+}
+
+func (s *ClassificationState) EnhancePages() []int {
+	var indices []int
+	for i, p := range s.Pages {
+		if p.Enhance() {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+```
+
+### Step 2: Update `classify.go` response type and apply function
+
+Update the log line in `classifyPages` — replace `"enhance", cs.Pages[i].Enhance` with:
+
+```go
+"enhance", cs.Pages[i].Enhance(),
+```
+
+Update `pageResponse` to match the new type shape:
+
+```go
+type pageResponse struct {
+	MarkingsFound []string         `json:"markings_found"`
+	Rationale     string           `json:"rationale"`
+	Enhancements  *EnhanceSettings `json:"enhancements,omitempty"`
+}
+```
+
+Update `applyPageResponse`:
+
+```go
+func applyPageResponse(page *ClassificationPage, resp pageResponse) {
+	page.MarkingsFound = resp.MarkingsFound
+	page.Rationale = resp.Rationale
+	page.Enhancements = resp.Enhancements
+}
+```
+
+### Step 3: Update classify spec in `internal/prompts/specs.go`
+
+Replace the `classifySpec` constant with structured `enhancements` output:
+
+```go
+const classifySpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>",
+  "enhancements": null
+}
+
+Field constraints:
+- markings_found: Array of distinct marking strings found on this page,
+  exactly as they appear in the document. Include the full marking text
+  with any caveats (e.g., "SECRET//NOFORN" not just "SECRET").
+- rationale: Brief explanation of what security markings were found on
+  this page and their significance. Note any conflicts or ambiguities
+  with prior page findings if a classification state is provided.
+- enhancements: Set to null when the image is clear enough to read all
+  markings confidently. When image quality prevents confident reading of
+  any markings, provide an object with rendering adjustments:
+  {
+    "brightness": <80-200, 100=neutral, increase for faded/dark pages>,
+    "contrast": <-50 to 50, 0=neutral, increase to sharpen faded markings>,
+    "saturation": <80-200, 100=neutral, adjust for color-related issues>
+  }
+  Only include fields that need adjustment; omit fields that should stay
+  at their neutral values.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Process exactly one page per response
+- Report only what you observe on this page
+- If prior page findings are provided in the prompt, use them as context
+  to identify consistency or conflicts, but do not repeat prior findings
+  in markings_found — only include markings visible on the current page`
+```
+
+Replace the `enhanceSpec` constant for reclassification (just markings_found + rationale):
+
+```go
+const enhanceSpec = `Respond with a JSON object matching this exact structure:
+
+{
+  "markings_found": ["<marking1>", "<marking2>"],
+  "rationale": "<explanation>"
+}
+
+Field constraints:
+- markings_found: Array of distinct marking strings found on this
+  enhanced page, exactly as they appear. Include the full marking text
+  with any caveats.
+- rationale: Brief explanation of what the enhanced image reveals compared
+  to the original assessment. Note any new markings discovered or prior
+  findings confirmed by the improved image quality.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Focus analysis on the enhanced image with improved rendering settings
+- Compare findings against the prior page analysis provided in the prompt
+- Report only what you observe on the current enhanced page`
+```
+
+### Step 4: Add `ErrFinalizeFailed` sentinel to `workflow/errors.go`
+
+Add to the existing `var` block:
+
+```go
+ErrFinalizeFailed = errors.New("finalize failed")
+```
+
+### Step 5: Create `workflow/enhance.go`
+
+Re-renders flagged pages with adjusted ImageMagick settings from `EnhanceSettings`, then reclassifies each enhanced page via vision call to update per-page findings. Clears `Enhancements` after processing.
+
+```go
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/JaimeStill/document-context/pkg/config"
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/image"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type enhanceResponse struct {
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+}
+
+func EnhanceNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		cs, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		tempDir, err := extractTempDir(s)
+		if err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		enhanced := cs.EnhancePages()
+
+		if err := enhancePages(ctx, rt, cs, tempDir); err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "enhance node complete",
+			"pages_enhanced", len(enhanced),
+		)
+
+		s = s.Set(KeyClassState, *cs)
+		return s, nil
+	})
+}
+
+func extractTempDir(s state.State) (string, error) {
+	val, ok := s.Get(KeyTempDir)
+	if !ok {
+		return "", fmt.Errorf("%w: missing %s in state", ErrEnhanceFailed, KeyTempDir)
+	}
+
+	tempDir, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: %s is not string", ErrEnhanceFailed, KeyTempDir)
+	}
+
+	return tempDir, nil
+}
+
+func enhancePages(ctx context.Context, rt *Runtime, cs *ClassificationState, tempDir string) error {
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfDoc, err := document.OpenPDF(pdfPath)
+	if err != nil {
+		return fmt.Errorf("%w: open pdf: %w", ErrEnhanceFailed, err)
+	}
+	defer pdfDoc.Close()
+
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrEnhanceFailed, err)
+	}
+
+	for _, i := range cs.EnhancePages() {
+		if err := enhancePage(ctx, a, rt, pdfDoc, cs, i, tempDir); err != nil {
+			return fmt.Errorf("%w: page %d: %w", ErrEnhanceFailed, cs.Pages[i].PageNumber, err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "page enhanced",
+			"page", cs.Pages[i].PageNumber,
+			"markings", cs.Pages[i].MarkingsFound,
+		)
+	}
+
+	return nil
+}
+
+func enhancePage(
+	ctx context.Context,
+	a agent.Agent,
+	rt *Runtime,
+	pdfDoc document.Document,
+	cs *ClassificationState,
+	pageIdx int,
+	tempDir string,
+) error {
+	page := &cs.Pages[pageIdx]
+
+	// Re-render with adjusted settings
+	imgPath, err := rerender(pdfDoc, page, tempDir)
+	if err != nil {
+		return err
+	}
+	page.ImagePath = imgPath
+
+	// Encode enhanced image for vision call
+	dataURI, err := encodePageImage(imgPath)
+	if err != nil {
+		return err
+	}
+
+	// Compose prompt with current classification state as context
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageEnhance, cs)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.Vision(ctx, prompt, []string{dataURI})
+	if err != nil {
+		return fmt.Errorf("vision call: %w", err)
+	}
+
+	parsed, err := formatting.Parse[enhanceResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+
+	// Update page findings and clear enhancement flag
+	page.MarkingsFound = parsed.MarkingsFound
+	page.Rationale = parsed.Rationale
+	page.Enhancements = nil
+
+	return nil
+}
+
+func rerender(pdfDoc document.Document, page *ClassificationPage, tempDir string) (string, error) {
+	p, err := pdfDoc.ExtractPage(page.PageNumber)
+	if err != nil {
+		return "", fmt.Errorf("extract page %d: %w", page.PageNumber, err)
+	}
+
+	cfg := buildEnhanceConfig(page.Enhancements)
+	renderer, err := image.NewImageMagickRenderer(cfg)
+	if err != nil {
+		return "", fmt.Errorf("create renderer: %w", err)
+	}
+
+	data, err := p.ToImage(renderer, nil)
+	if err != nil {
+		return "", fmt.Errorf("render page %d: %w", page.PageNumber, err)
+	}
+
+	imgPath := filepath.Join(tempDir, fmt.Sprintf("page-%d-enhanced.png", page.PageNumber))
+	if err := os.WriteFile(imgPath, data, 0600); err != nil {
+		return "", fmt.Errorf("write enhanced page %d: %w", page.PageNumber, err)
+	}
+
+	return imgPath, nil
+}
+
+func buildEnhanceConfig(settings *EnhanceSettings) config.ImageConfig {
+	opts := map[string]any{
+		"background": "white",
+	}
+
+	if settings.Brightness != nil {
+		opts["brightness"] = *settings.Brightness
+	}
+
+	if settings.Contrast != nil {
+		opts["contrast"] = *settings.Contrast
+	}
+
+	if settings.Saturation != nil {
+		opts["saturation"] = *settings.Saturation
+	}
+
+	return config.ImageConfig{
+		Format:  "png",
+		DPI:     300,
+		Options: opts,
+	}
+}
+
+```
+
+**Notes:**
+- `EnhancePages()` returns the indices of flagged pages — the enhance loop iterates only those
+- `rerender` extracts the specific page from the PDF (still in temp dir as `source.pdf`), creates a renderer with the adjusted config, and writes the enhanced image to a separate file (`page-N-enhanced.png`)
+- `encodePageImage` is reused from classify.go (same data URI encoding)
+- `enhanceResponse` only has `markings_found` + `rationale` — no enhancement fields since the page has been enhanced
+- After reclassification, `Enhancements` is set to `nil` so the page is no longer flagged
+- The log message captures the count before processing via `len(cs.EnhancePages())`
+
+### Step 6: Create `workflow/finalize.go`
+
+```go
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type finalizeResponse struct {
+	Classification string     `json:"classification"`
+	Confidence     Confidence `json:"confidence"`
+	Rationale      string     `json:"rationale"`
+}
+
+func FinalizeNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		cs, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("finalize: %w", err)
+		}
+
+		if err := synthesize(ctx, rt, cs); err != nil {
+			return s, fmt.Errorf("finalize: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "finalize node complete",
+			"classification", cs.Classification,
+			"confidence", cs.Confidence,
+		)
+
+		s = s.Set(KeyClassState, *cs)
+		return s, nil
+	})
+}
+
+func synthesize(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrFinalizeFailed, err)
+	}
+
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageFinalize, cs)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrFinalizeFailed, err)
+	}
+
+	resp, err := a.Chat(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("%w: chat call: %w", ErrFinalizeFailed, err)
+	}
+
+	parsed, err := formatting.Parse[finalizeResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("%w: parse response: %w", ErrFinalizeFailed, err)
+	}
+
+	cs.Classification = parsed.Classification
+	cs.Confidence = parsed.Confidence
+	cs.Rationale = parsed.Rationale
+
+	return nil
+}
+```
+
+### Step 7: Create `workflow/workflow.go`
+
+```go
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	orchconfig "github.com/JaimeStill/go-agents-orchestration/pkg/config"
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+)
+
+func Execute(ctx context.Context, rt *Runtime, documentID uuid.UUID) (*WorkflowResult, error) {
+	tempDir, err := os.MkdirTemp("", "herald-classify-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	graph, err := buildGraph(rt)
+	if err != nil {
+		return nil, fmt.Errorf("build graph: %w", err)
+	}
+
+	initialState := state.New(nil)
+	initialState = initialState.Set(KeyDocumentID, documentID)
+	initialState = initialState.Set(KeyTempDir, tempDir)
+
+	finalState, err := graph.Execute(ctx, initialState)
+	if err != nil {
+		return nil, fmt.Errorf("execute graph: %w", err)
+	}
+
+	return extractResult(finalState)
+}
+
+func buildGraph(rt *Runtime) (state.StateGraph, error) {
+	cfg := orchconfig.DefaultGraphConfig("herald-classify")
+	cfg.Observer = "noop"
+
+	graph, err := state.NewGraph(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("init", InitNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("classify", ClassifyNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("enhance", EnhanceNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("finalize", FinalizeNode(rt)); err != nil {
+		return nil, err
+	}
+
+	// init → classify (unconditional)
+	if err := graph.AddEdge("init", "classify", nil); err != nil {
+		return nil, err
+	}
+
+	// classify → enhance (when any page needs enhancement)
+	if err := graph.AddEdge("classify", "enhance", needsEnhance); err != nil {
+		return nil, err
+	}
+
+	// classify → finalize (when no enhancement needed)
+	if err := graph.AddEdge("classify", "finalize", state.Not(needsEnhance)); err != nil {
+		return nil, err
+	}
+
+	// enhance → finalize (unconditional)
+	if err := graph.AddEdge("enhance", "finalize", nil); err != nil {
+		return nil, err
+	}
+
+	if err := graph.SetEntryPoint("init"); err != nil {
+		return nil, err
+	}
+
+	if err := graph.SetExitPoint("finalize"); err != nil {
+		return nil, err
+	}
+
+	return graph, nil
+}
+
+func needsEnhance(s state.State) bool {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return false
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return false
+	}
+
+	return cs.NeedsEnhance()
+}
+
+func extractResult(s state.State) (*WorkflowResult, error) {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyClassState)
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return nil, fmt.Errorf("%s is not ClassificationState", KeyClassState)
+	}
+
+	docIDVal, ok := s.Get(KeyDocumentID)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyDocumentID)
+	}
+
+	documentID, ok := docIDVal.(uuid.UUID)
+	if !ok {
+		return nil, fmt.Errorf("%s is not uuid.UUID", KeyDocumentID)
+	}
+
+	filenameVal, ok := s.Get(KeyFilename)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyFilename)
+	}
+
+	filename, ok := filenameVal.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s is not string", KeyFilename)
+	}
+
+	pageCountVal, ok := s.Get(KeyPageCount)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyPageCount)
+	}
+
+	pageCount, ok := pageCountVal.(int)
+	if !ok {
+		return nil, fmt.Errorf("%s is not int", KeyPageCount)
+	}
+
+	return &WorkflowResult{
+		DocumentID:  documentID,
+		Filename:    filename,
+		PageCount:   pageCount,
+		State:       cs,
+		CompletedAt: time.Now(),
+	}, nil
+}
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` passes
+- [ ] `EnhanceSettings` struct with `Brightness`, `Contrast`, `Saturation` as `*int`
+- [ ] `ClassificationPage` uses `Enhancements *EnhanceSettings` (no separate `Enhance` bool)
+- [ ] `NeedsEnhance()` checks for non-nil `Enhancements`
+- [ ] Classify spec outputs structured `enhancements` (object or null)
+- [ ] Enhance spec outputs only `markings_found` + `rationale` (no enhancement fields)
+- [ ] Enhance node re-renders flagged pages with settings-derived `ImageConfig`, reclassifies via vision, clears `Enhancements`
+- [ ] Finalize node performs single Chat inference producing document-level classification, confidence, and rationale
+- [ ] State graph wired with conditional edge using `ClassificationState.NeedsEnhance()`
+- [ ] Single exit point (finalize) — both paths converge to finalize
+- [ ] Execute creates temp directory and defers cleanup on all paths
+- [ ] Execute function creates initial state, runs graph, returns WorkflowResult

--- a/.claude/context/sessions/41-enhance-finalize-graph-execute.md
+++ b/.claude/context/sessions/41-enhance-finalize-graph-execute.md
@@ -1,0 +1,42 @@
+# 41 — Enhance Node, Finalize Node, Graph Assembly, and Execute Function
+
+## Summary
+
+Completed the classification workflow by adding the enhance node (re-render + reclassify), finalize node (document-level synthesis via Chat), state graph assembly with conditional enhancement edge, and the top-level `Execute` function with temp directory lifecycle management. Also introduced `EnhanceSettings` as a structured type replacing the previous `Enhance bool` + `Enhancements string` fields, and updated the classify/enhance prompt specs to match.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Enhancement signal | `Enhancements *EnhanceSettings` (nil = no enhancement) instead of separate `Enhance bool` + `Enhancements string` | Single source of truth — no risk of bool/data inconsistency. Classify agent outputs structured rendering parameters directly. |
+| EnhanceSettings fields | `Brightness *int`, `Contrast *int`, `Saturation *int` | Maps directly to document-context's `ImageMagickConfig` filter fields. Pointer types distinguish "not set" from "neutral value". |
+| Enhance node role | Hybrid rendering + inference | Re-renders flagged pages programmatically from structured settings (no LLM needed for rendering params), then reclassifies via vision to update per-page findings. |
+| Finalize inference | `agent.Chat` (not Vision) | Finalize reviews text data (all per-page findings as serialized JSON context), not images. |
+| Graph observer | `"noop"` | Herald explicitly excludes observer/checkpoint infrastructure per architectural decisions. |
+| `Enhance()` convenience method | On `ClassificationPage` | Centralizes `Enhancements != nil` check — used by log lines, `NeedsEnhance()`, and `EnhancePages()`. |
+
+## Files Modified
+
+- `workflow/types.go` — added `EnhanceSettings`, `ClassificationPage.Enhance()`, replaced `Enhance bool` + `Enhancements string` with `Enhancements *EnhanceSettings`, updated `NeedsEnhance()` and `EnhancePages()`
+- `workflow/errors.go` — added `ErrFinalizeFailed`, updated package doc
+- `workflow/classify.go` — updated `pageResponse`, `applyPageResponse`, log line to use `Enhance()`
+- `workflow/enhance.go` — new file: `EnhanceNode`, `enhancePages`, `enhancePage`, `rerender`, `buildEnhanceConfig`, `extractTempDir`
+- `workflow/finalize.go` — new file: `FinalizeNode`, `synthesize`
+- `workflow/workflow.go` — new file: `Execute`, `buildGraph`, `needsEnhance` predicate, `extractResult`
+- `internal/prompts/specs.go` — updated classify spec (structured `enhancements` output), updated enhance spec (markings_found + rationale only)
+- `internal/prompts/instructions.go` — updated enhance instructions wording
+- `config.json` — added chat capability to model config
+- `tests/workflow/types_test.go` — updated for new type shape, added `TestEnhance`, `TestEnhanceSettingsJSON`
+- `tests/workflow/prompts_test.go` — added `StageFinalize` to mock, added finalize stage test
+
+## Patterns Established
+
+- **Structured enhancement settings**: Classify agent outputs rendering parameters as a typed struct rather than free text, eliminating an LLM interpretation step from the enhance pipeline
+- **Convenience predicate method**: `ClassificationPage.Enhance()` centralizes the nil-check pattern for enhancement flagging
+- **Hybrid node pattern**: Enhance node combines rendering (programmatic from structured settings) with inference (vision reclassification) in a single node
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go build ./...` — clean
+- `go test ./tests/...` — all 17 packages pass (17/17 workflow tests pass)

--- a/.claude/plans/elegant-juggling-curry.md
+++ b/.claude/plans/elegant-juggling-curry.md
@@ -1,0 +1,127 @@
+# 41 — Enhance Node, Finalize Node, Graph Assembly, and Execute Function
+
+## Context
+
+This is the final sub-issue of Objective #26 (Classification Workflow). The init node (#39) and classify node (#40) are complete. This issue adds the remaining pieces: a placeholder enhance node, a finalize node for document-level synthesis, the state graph wiring all nodes together, and the top-level `Execute` function.
+
+## Files to Create
+
+- `workflow/enhance.go` — placeholder enhance node
+- `workflow/finalize.go` — document-level classification synthesis node
+- `workflow/workflow.go` — graph assembly + `Execute` entry point
+
+## Files to Modify
+
+- `workflow/errors.go` — add `ErrFinalizeFailed` sentinel
+
+## Implementation
+
+### Step 1: Add `ErrFinalizeFailed` to `workflow/errors.go`
+
+Add alongside existing sentinels:
+
+```go
+ErrFinalizeFailed = errors.New("finalize failed")
+```
+
+### Step 2: `workflow/enhance.go` — Placeholder Node
+
+Pass-through node that returns state unchanged. Full signature so graph topology is complete.
+
+```go
+func EnhanceNode(rt *Runtime) state.StateNode {
+    return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+        rt.Logger.InfoContext(ctx, "enhance node skipped (placeholder)")
+        return s, nil
+    })
+}
+```
+
+Minimal — no state extraction needed since it's a no-op placeholder.
+
+### Step 3: `workflow/finalize.go` — Synthesis Node
+
+Performs a single `agent.Chat` inference (not Vision — no images) to produce document-level classification from all page findings.
+
+**Response type:**
+
+```go
+type finalizeResponse struct {
+    Classification string     `json:"classification"`
+    Confidence     Confidence `json:"confidence"`
+    Rationale      string     `json:"rationale"`
+}
+```
+
+**Node flow:**
+1. Extract `ClassificationState` from state bag (reuse `extractClassState` from classify.go)
+2. Create agent via `agent.New(&rt.Agent)`
+3. Compose prompt via `ComposePrompt(ctx, rt.Prompts, prompts.StageFinalize, classState)` — passes full state with all page data
+4. Call `a.Chat(ctx, prompt)` — text-only, no images
+5. Parse response via `formatting.Parse[finalizeResponse](resp.Content())`
+6. Apply response fields to `ClassificationState` document-level fields
+7. Write updated state back to bag
+
+**Key:** Uses `prompts.StageFinalize` — the instructions and spec already exist in the prompts package.
+
+### Step 4: `workflow/workflow.go` — Graph Assembly and Execute
+
+**Custom predicate** for the conditional edge:
+
+```go
+func needsEnhance(s state.State) bool {
+    val, ok := s.Get(KeyClassState)
+    if !ok {
+        return false
+    }
+    cs, ok := val.(ClassificationState)
+    if !ok {
+        return false
+    }
+    return cs.NeedsEnhance()
+}
+```
+
+**Graph assembly** (`buildGraph`):
+- Nodes: `init`, `classify`, `enhance`, `finalize`
+- Edges:
+  - `init → classify` (unconditional)
+  - `classify → enhance` (predicate: `needsEnhance`)
+  - `classify → finalize` (predicate: `!needsEnhance` via `state.Not`)
+  - `enhance → finalize` (unconditional)
+- Entry point: `init`
+- Exit point: `finalize`
+- Graph config: `config.DefaultGraphConfig("herald-classify")` with observer overridden to `"noop"` (Herald excludes observer infrastructure)
+
+**`Execute` function:**
+
+```go
+func Execute(ctx context.Context, rt *Runtime, documentID uuid.UUID) (*WorkflowResult, error)
+```
+
+1. `os.MkdirTemp("", "herald-classify-*")` — create temp dir
+2. `defer os.RemoveAll(tempDir)` — cleanup on all paths
+3. Create initial state via `state.New(nil)`, set `KeyDocumentID` and `KeyTempDir`
+4. `buildGraph(rt)` — assemble the graph
+5. `graph.Execute(ctx, initialState)` — run it
+6. Extract `WorkflowResult` from final state (`KeyClassState`, `KeyFilename`, `KeyPageCount`)
+7. Return result with `time.Now()` as `CompletedAt`
+
+## Key Patterns
+
+- **Reuse `extractClassState`** from classify.go — finalize.go calls it the same way
+- **Predicate wraps `NeedsEnhance()`** — custom `TransitionPredicate` extracts from state bag
+- **`state.Not(needsEnhance)`** for the skip-enhance edge — uses built-in predicate combinator
+- **`config.DefaultGraphConfig` with noop observer** — Herald explicitly excludes observer/checkpoint infrastructure
+- **Node names as constants** not needed — only used in `buildGraph`, string literals are fine for a single-workflow project
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` passes
+- [ ] Enhance node returns state unchanged (placeholder)
+- [ ] Finalize node uses `agent.Chat` (not Vision)
+- [ ] Graph topology: init → classify → enhance? → finalize (single exit point)
+- [ ] Execute creates temp directory and defers cleanup
+- [ ] Execute creates initial state, runs graph, returns WorkflowResult
+- [ ] Conditional edge uses `ClassificationState.NeedsEnhance()` via custom predicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0-dev.26.41
+
+- Add enhance node (re-render flagged pages with structured ImageMagick settings, reclassify via vision), finalize node (document-level classification synthesis via Chat), state graph assembly with conditional enhancement edge, and top-level Execute function with temp directory lifecycle (#41)
+- Replace `Enhance bool` + `Enhancements string` with `EnhanceSettings` struct carrying typed rendering parameters (brightness, contrast, saturation), enabling programmatic re-rendering without LLM interpretation (#41)
+
 ## v0.2.0-dev.26.40
 
 - Add classify node with sequential page-by-page context accumulation, per-page-only analysis, and just-in-time image encoding (#40)

--- a/config.json
+++ b/config.json
@@ -63,6 +63,9 @@
     "model": {
       "name": "gpt-5-mini",
       "capabilities": {
+        "chat": {
+          "max_completion_tokens": 4096
+        },
         "vision": {
           "max_tokens": 4096,
           "temperature": 0.1

--- a/internal/prompts/specs.go
+++ b/internal/prompts/specs.go
@@ -5,8 +5,7 @@ const classifySpec = `Respond with a JSON object matching this exact structure:
 {
   "markings_found": ["<marking1>", "<marking2>"],
   "rationale": "<explanation>",
-  "enhance": false,
-  "enhancements": ""
+  "enhancements": null
 }
 
 Field constraints:
@@ -16,12 +15,16 @@ Field constraints:
 - rationale: Brief explanation of what security markings were found on
   this page and their significance. Note any conflicts or ambiguities
   with prior page findings if a classification state is provided.
-- enhance: Whether image quality prevented confident reading of any
-  markings on this page. Set true only when markings are visibly present
-  but cannot be read with certainty due to image quality.
-- enhancements: When enhance is true, describe the specific image quality
-  issues and what adjustments might help (e.g., "faded banner markings —
-  increase brightness and contrast"). Empty string when enhance is false.
+- enhancements: Set to null when the image is clear enough to read all
+  markings confidently. When image quality prevents confident reading of
+  any markings, provide an object with rendering adjustments:
+  {
+    "brightness": <80-200, 100=neutral, increase for faded/dark pages>,
+    "contrast": <-50 to 50, 0=neutral, increase to sharpen faded markings>,
+    "saturation": <80-200, 100=neutral, adjust for color-related issues>
+  }
+  Only include fields that need adjustment; omit fields that should stay
+  at their neutral values.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
@@ -35,9 +38,7 @@ const enhanceSpec = `Respond with a JSON object matching this exact structure:
 
 {
   "markings_found": ["<marking1>", "<marking2>"],
-  "rationale": "<explanation>",
-  "enhance": false,
-  "enhancements": ""
+  "rationale": "<explanation>"
 }
 
 Field constraints:
@@ -45,12 +46,8 @@ Field constraints:
   enhanced page, exactly as they appear. Include the full marking text
   with any caveats.
 - rationale: Brief explanation of what the enhanced image reveals compared
-  to the original. Note any new markings discovered or prior findings
-  confirmed by the improved image quality.
-- enhance: Whether image quality still prevents confident reading after
-  enhancement. Should typically be false after enhancement processing.
-- enhancements: Description of remaining quality issues if enhance is
-  still true. Empty string when enhance is false.
+  to the original assessment. Note any new markings discovered or prior
+  findings confirmed by the improved image quality.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing

--- a/tests/workflow/prompts_test.go
+++ b/tests/workflow/prompts_test.go
@@ -53,10 +53,12 @@ func newMockPrompts() *mockPrompts {
 		instructions: map[prompts.Stage]string{
 			prompts.StageClassify: "classify instructions",
 			prompts.StageEnhance:  "enhance instructions",
+			prompts.StageFinalize: "finalize instructions",
 		},
 		specs: map[prompts.Stage]string{
 			prompts.StageClassify: "classify spec",
 			prompts.StageEnhance:  "enhance spec",
+			prompts.StageFinalize: "finalize spec",
 		},
 	}
 }
@@ -126,6 +128,29 @@ func TestComposePrompt(t *testing.T) {
 		}
 		if !strings.Contains(got, "enhance spec") {
 			t.Error("missing enhance spec in prompt")
+		}
+	})
+
+	t.Run("finalize stage uses finalize instructions and spec", func(t *testing.T) {
+		state := &workflow.ClassificationState{
+			Pages: []workflow.ClassificationPage{
+				{PageNumber: 1, MarkingsFound: []string{"SECRET"}, Rationale: "banner visible"},
+			},
+		}
+
+		got, err := workflow.ComposePrompt(ctx, mock, prompts.StageFinalize, state)
+		if err != nil {
+			t.Fatalf("ComposePrompt error: %v", err)
+		}
+
+		if !strings.Contains(got, "finalize instructions") {
+			t.Error("missing finalize instructions in prompt")
+		}
+		if !strings.Contains(got, "finalize spec") {
+			t.Error("missing finalize spec in prompt")
+		}
+		if !strings.Contains(got, "Current classification state") {
+			t.Error("finalize prompt should include state")
 		}
 	})
 

--- a/workflow/classify.go
+++ b/workflow/classify.go
@@ -17,10 +17,10 @@ import (
 )
 
 type pageResponse struct {
-	MarkingsFound []string `json:"markings_found"`
-	Rationale     string   `json:"rationale"`
-	Enhance       bool     `json:"enhance"`
-	Enhancements  string   `json:"enhancements"`
+	MarkingsFound []string         `json:"markings_found"`
+	Rationale     string           `json:"rationale"`
+	Enhance       bool             `json:"enhance"`
+	Enhancements  *EnhanceSettings `json:"enhancements,omitempty"`
 }
 
 // ClassifyNode returns a state node that performs sequential page-by-page
@@ -79,7 +79,7 @@ func classifyPages(ctx context.Context, rt *Runtime, cs *ClassificationState) er
 			"page", i+1,
 			"total", len(cs.Pages),
 			"markings", cs.Pages[i].MarkingsFound,
-			"enhance", cs.Pages[i].Enhance,
+			"enhance", cs.Pages[i].Enhance(),
 		)
 	}
 
@@ -133,6 +133,5 @@ func encodePageImage(imagePath string) (string, error) {
 func applyPageResponse(page *ClassificationPage, resp pageResponse) {
 	page.MarkingsFound = resp.MarkingsFound
 	page.Rationale = resp.Rationale
-	page.Enhance = resp.Enhance
 	page.Enhancements = resp.Enhancements
 }

--- a/workflow/enhance.go
+++ b/workflow/enhance.go
@@ -1,0 +1,197 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/JaimeStill/document-context/pkg/config"
+	"github.com/JaimeStill/document-context/pkg/document"
+	"github.com/JaimeStill/document-context/pkg/image"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type enhanceResponse struct {
+	MarkingsFound []string `json:"markings_found"`
+	Rationale     string   `json:"rationale"`
+}
+
+// EnhanceNode returns a state node that re-renders flagged pages with adjusted
+// ImageMagick settings and reclassifies them via vision. For each page with
+// non-nil Enhancements, it re-renders from the source PDF using the specified
+// brightness/contrast/saturation adjustments, sends the enhanced image to the
+// vision model, and updates the per-page findings. Clears Enhancements after
+// processing so the page is no longer flagged.
+func EnhanceNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		cs, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		tempDir, err := extractTempDir(s)
+		if err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		enhanced := cs.EnhancePages()
+
+		if err := enhancePages(ctx, rt, cs, tempDir); err != nil {
+			return s, fmt.Errorf("enhance: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "enhance node complete",
+			"pages_enhanced", len(enhanced),
+		)
+
+		s = s.Set(KeyClassState, *cs)
+		return s, nil
+	})
+}
+
+func buildEnhanceConfig(settings *EnhanceSettings) config.ImageConfig {
+	opts := map[string]any{
+		"background": "white",
+	}
+
+	if settings.Brightness != nil {
+		opts["brightness"] = *settings.Brightness
+	}
+
+	if settings.Contrast != nil {
+		opts["contrast"] = *settings.Contrast
+	}
+
+	if settings.Saturation != nil {
+		opts["saturation"] = *settings.Saturation
+	}
+
+	return config.ImageConfig{
+		Format:  "png",
+		DPI:     300,
+		Options: opts,
+	}
+}
+
+func enhancePage(
+	ctx context.Context,
+	a agent.Agent,
+	rt *Runtime,
+	pdfDoc document.Document,
+	cs *ClassificationState,
+	pageIdx int,
+	tempDir string,
+) error {
+	page := &cs.Pages[pageIdx]
+
+	// Re-render with adjusted settings
+	imgPath, err := rerender(pdfDoc, page, tempDir)
+	if err != nil {
+		return err
+	}
+	page.ImagePath = imgPath
+
+	// Encode enhanced image for vision call
+	dataURI, err := encodePageImage(imgPath)
+	if err != nil {
+		return err
+	}
+
+	// Compose prompt with current classification state as context
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageEnhance, cs)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.Vision(ctx, prompt, []string{dataURI})
+	if err != nil {
+		return fmt.Errorf("vision call: %w", err)
+	}
+
+	parsed, err := formatting.Parse[enhanceResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+
+	// Update page findings and clear enhancement flag
+	page.MarkingsFound = parsed.MarkingsFound
+	page.Rationale = parsed.Rationale
+	page.Enhancements = nil
+
+	return nil
+}
+
+func enhancePages(ctx context.Context, rt *Runtime, cs *ClassificationState, tempDir string) error {
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	pdfDoc, err := document.OpenPDF(pdfPath)
+	if err != nil {
+		return fmt.Errorf("%w: open pdf: %w", ErrEnhanceFailed, err)
+	}
+	defer pdfDoc.Close()
+
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrEnhanceFailed, err)
+	}
+
+	for _, i := range cs.EnhancePages() {
+		if err := enhancePage(ctx, a, rt, pdfDoc, cs, i, tempDir); err != nil {
+			return fmt.Errorf("%w: page %d: %w", ErrEnhanceFailed, cs.Pages[i].PageNumber, err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "page enhanced",
+			"page", cs.Pages[i].PageNumber,
+			"markings", cs.Pages[i].MarkingsFound,
+		)
+	}
+
+	return nil
+}
+
+func extractTempDir(s state.State) (string, error) {
+	val, ok := s.Get(KeyTempDir)
+	if !ok {
+		return "", fmt.Errorf("%w: missing %s in state", ErrEnhanceFailed, KeyTempDir)
+	}
+
+	tempDir, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: %s is not string", ErrEnhanceFailed, KeyTempDir)
+	}
+
+	return tempDir, nil
+}
+
+func rerender(pdfDoc document.Document, page *ClassificationPage, tempDir string) (string, error) {
+	p, err := pdfDoc.ExtractPage(page.PageNumber)
+	if err != nil {
+		return "", fmt.Errorf("extract page %d: %w", page.PageNumber, err)
+	}
+
+	cfg := buildEnhanceConfig(page.Enhancements)
+	renderer, err := image.NewImageMagickRenderer(cfg)
+	if err != nil {
+		return "", fmt.Errorf("create renderer: %w", err)
+	}
+
+	data, err := p.ToImage(renderer, nil)
+	if err != nil {
+		return "", fmt.Errorf("render page %d: %w", page.PageNumber, err)
+	}
+
+	imgPath := filepath.Join(tempDir, fmt.Sprintf("page-%d-enhanced.png", page.PageNumber))
+	if err := os.WriteFile(imgPath, data, 0600); err != nil {
+		return "", fmt.Errorf("write enhanced page %d: %w", page.PageNumber, err)
+	}
+
+	return imgPath, nil
+}

--- a/workflow/errors.go
+++ b/workflow/errors.go
@@ -1,6 +1,6 @@
 // Package workflow implements the classification workflow for Herald.
-// It provides foundational types, prompt composition, and response parsing
-// used by the 3-node state graph (init → classify → enhance?).
+// It provides the 4-node state graph (init → classify → enhance? → finalize),
+// prompt composition, response parsing, and the top-level Execute function.
 package workflow
 
 import "errors"
@@ -11,4 +11,5 @@ var (
 	ErrRenderFailed     = errors.New("failed to render page images")
 	ErrClassifyFailed   = errors.New("classification failed")
 	ErrEnhanceFailed    = errors.New("enhancement failed")
+	ErrFinalizeFailed   = errors.New("finalize failed")
 )

--- a/workflow/finalize.go
+++ b/workflow/finalize.go
@@ -1,0 +1,73 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/formatting"
+)
+
+type finalizeResponse struct {
+	Classification string     `json:"classification"`
+	Confidence     Confidence `json:"confidence"`
+	Rationale      string     `json:"rationale"`
+}
+
+// FinalizeNode returns a state node that synthesizes the document-level
+// classification from all per-page findings. It performs a single Chat
+// inference (not Vision — no images needed) that reviews all page data
+// and produces the authoritative classification, confidence, and rationale.
+func FinalizeNode(rt *Runtime) state.StateNode {
+	return state.NewFunctionNode(func(ctx context.Context, s state.State) (state.State, error) {
+		cs, err := extractClassState(s)
+		if err != nil {
+			return s, fmt.Errorf("finalize: %w", err)
+		}
+
+		if err := synthesize(ctx, rt, cs); err != nil {
+			return s, fmt.Errorf("finalize: %w", err)
+		}
+
+		rt.Logger.InfoContext(
+			ctx, "finalize node complete",
+			"classification", cs.Classification,
+			"confidence", cs.Confidence,
+		)
+
+		s = s.Set(KeyClassState, *cs)
+		return s, nil
+	})
+}
+
+func synthesize(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
+	a, err := agent.New(&rt.Agent)
+	if err != nil {
+		return fmt.Errorf("%w: create agent: %w", ErrFinalizeFailed, err)
+	}
+
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageFinalize, cs)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrFinalizeFailed, err)
+	}
+
+	resp, err := a.Chat(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("%w: chat call: %w", ErrFinalizeFailed, err)
+	}
+
+	parsed, err := formatting.Parse[finalizeResponse](resp.Content())
+	if err != nil {
+		return fmt.Errorf("%w: parse response: %w", ErrFinalizeFailed, err)
+	}
+
+	cs.Classification = parsed.Classification
+	cs.Confidence = parsed.Confidence
+	cs.Rationale = parsed.Rationale
+
+	return nil
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,0 +1,161 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	gaoconfig "github.com/JaimeStill/go-agents-orchestration/pkg/config"
+	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
+)
+
+// Execute runs the classification workflow for a single document. It creates
+// a temp directory for page images (cleaned up via defer), builds the state
+// graph (init → classify → enhance? → finalize), executes it, and extracts
+// the WorkflowResult from the final state.
+func Execute(ctx context.Context, rt *Runtime, documentID uuid.UUID) (*WorkflowResult, error) {
+	tempDir, err := os.MkdirTemp("", "herald-classify-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	graph, err := buildGraph(rt)
+	if err != nil {
+		return nil, fmt.Errorf("build graph: %w", err)
+	}
+
+	initialState := state.New(nil)
+	initialState = initialState.Set(KeyDocumentID, documentID)
+	initialState = initialState.Set(KeyTempDir, tempDir)
+
+	finalState, err := graph.Execute(ctx, initialState)
+	if err != nil {
+		return nil, fmt.Errorf("execute graph: %w", err)
+	}
+
+	return extractResult(finalState)
+}
+
+func buildGraph(rt *Runtime) (state.StateGraph, error) {
+	cfg := gaoconfig.DefaultGraphConfig("herald-classify")
+	cfg.Observer = "noop"
+
+	graph, err := state.NewGraph(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("init", InitNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("classify", ClassifyNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("enhance", EnhanceNode(rt)); err != nil {
+		return nil, err
+	}
+
+	if err := graph.AddNode("finalize", FinalizeNode(rt)); err != nil {
+		return nil, err
+	}
+
+	// init → classify (unconditional)
+	if err := graph.AddEdge("init", "classify", nil); err != nil {
+		return nil, err
+	}
+
+	// classify → enhance (when any page needs enhancement)
+	if err := graph.AddEdge("classify", "enhance", needsEnhance); err != nil {
+		return nil, err
+	}
+
+	// classify → finalize (when no enhancement needed)
+	if err := graph.AddEdge("classify", "finalize", state.Not(needsEnhance)); err != nil {
+		return nil, err
+	}
+
+	// enhance → finalize (unconditional)
+	if err := graph.AddEdge("enhance", "finalize", nil); err != nil {
+		return nil, err
+	}
+
+	if err := graph.SetEntryPoint("init"); err != nil {
+		return nil, err
+	}
+
+	if err := graph.SetExitPoint("finalize"); err != nil {
+		return nil, err
+	}
+
+	return graph, nil
+}
+
+func extractResult(s state.State) (*WorkflowResult, error) {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyClassState)
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return nil, fmt.Errorf("%s is not ClassificationState", KeyClassState)
+	}
+
+	docIDVal, ok := s.Get(KeyDocumentID)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyDocumentID)
+	}
+
+	documentID, ok := docIDVal.(uuid.UUID)
+	if !ok {
+		return nil, fmt.Errorf("%s is not uuid.UUID", KeyDocumentID)
+	}
+
+	filenameVal, ok := s.Get(KeyFilename)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyFilename)
+	}
+
+	filename, ok := filenameVal.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s is not string", KeyFilename)
+	}
+
+	pageCountVal, ok := s.Get(KeyPageCount)
+	if !ok {
+		return nil, fmt.Errorf("missing %s in final state", KeyPageCount)
+	}
+
+	pageCount, ok := pageCountVal.(int)
+	if !ok {
+		return nil, fmt.Errorf("%s is not int", KeyPageCount)
+	}
+
+	return &WorkflowResult{
+		DocumentID:  documentID,
+		Filename:    filename,
+		PageCount:   pageCount,
+		State:       cs,
+		CompletedAt: time.Now(),
+	}, nil
+}
+
+func needsEnhance(s state.State) bool {
+	val, ok := s.Get(KeyClassState)
+	if !ok {
+		return false
+	}
+
+	cs, ok := val.(ClassificationState)
+	if !ok {
+		return false
+	}
+
+	return cs.NeedsEnhance()
+}


### PR DESCRIPTION
## Summary

Complete the classification workflow with the remaining nodes, state graph assembly, and top-level Execute function.

Closes #41

## Changes

- **EnhanceSettings type**: Replace `Enhance bool` + `Enhancements string` on `ClassificationPage` with `Enhancements *EnhanceSettings` carrying typed rendering parameters (brightness, contrast, saturation as `*int`). Add `Enhance()` convenience method. Single source of truth — nil means no enhancement needed.
- **Enhance node** (`workflow/enhance.go`): Hybrid rendering + inference node. Re-renders flagged pages using structured settings mapped to document-context's ImageMagick filters, reclassifies each enhanced image via vision, clears enhancements after processing.
- **Finalize node** (`workflow/finalize.go`): Document-level classification synthesis via `agent.Chat` (not Vision). Single inference reviewing all per-page findings to produce authoritative classification, confidence, and rationale.
- **Graph assembly and Execute** (`workflow/workflow.go`): 4-node state graph (init → classify → enhance? → finalize) with conditional edge using `NeedsEnhance()`. `Execute` creates temp directory with deferred cleanup, builds graph, runs it, extracts `WorkflowResult`.
- **Prompt spec updates**: Classify spec outputs structured `enhancements` object (or null). Enhance spec outputs only `markings_found` + `rationale`.
- **Tests updated**: All types tests updated for new `EnhanceSettings` shape, added `TestEnhance` and `TestEnhanceSettingsJSON`, added finalize stage to prompts mock.