### PR TITLE
Transition to Objective #27 — Classifications Domain

### DIFF
--- a/.claude/plans/snuggly-gliding-tide.md
+++ b/.claude/plans/snuggly-gliding-tide.md
@@ -1,0 +1,116 @@
+# Objective Planning Session — #27 Classifications Domain (Merged)
+
+## Context
+
+Objective #26 (Classification Workflow) is 100% complete — all 5 sub-issues closed. The next objective (#27 Classifications Domain) and #28 (Classification HTTP Endpoints) were originally scoped as separate objectives but should have been one. This session merges #28's scope into #27, deletes #28, transitions out of #26, and decomposes the merged objective into sub-issues.
+
+## Step 0: Transition Closeout
+
+### Status Assessment
+- **Objective #26 — Classification Workflow**: 5/5 sub-issues closed (100%)
+  - #37 Prompts domain extensions — CLOSED
+  - #38 Workflow foundation — CLOSED
+  - #39 Init node — CLOSED
+  - #40 Classify node — CLOSED
+  - #41 Enhance/finalize/graph/Execute — CLOSED
+- No incomplete work to carry forward or move to backlog
+
+### Actions
+1. Close objective #26
+2. Update `_project/phase.md` — mark #26 as Complete, remove #28 row
+3. Update issue #27 body — incorporate #28's scope (handler, routes, API wiring, Cartographer docs)
+4. Close and delete issue #28
+5. Delete `_project/objective.md` (previous objective)
+
+## Step 1: Merged Objective Scope
+
+**Objective #27 — Classifications Domain** now covers the full classifications vertical: persistence layer, business operations (classify/validate/adjust), HTTP endpoints, API wiring, and documentation.
+
+### Architecture Decisions
+
+1. **`Classify` lives on the System interface**: The `classifications.repo` holds `*workflow.Runtime` as a constructor dependency. `Classify(ctx, documentID)` internally calls `workflow.Execute()`, stores the result, and transitions document status. The handler just calls `sys.Classify(ctx, documentID)` — thin and consistent with documents/prompts patterns.
+
+2. **Validate and Update are alternatives, not sequential**: Both transition document status `review → complete`. Validate = human agrees with AI classification. Update = human manually sets `classification` and `rationale` (overwrites the AI values). Re-classification (another `Classify` call) resets validation fields via upsert semantics.
+
+3. **No migration needed**: Update overwrites the existing `classification` and `rationale` columns directly — no separate `adjusted_classification`/`adjustment_rationale` columns.
+
+4. **Workflow runtime assembly in `api.NewDomain`**: Construction order is `documents.System → prompts.System → workflow.Runtime → classifications.System → Domain`. The `workflow.Runtime` is an ephemeral construction dependency, not stored on Domain.
+
+## Step 3: Sub-Issue Decomposition
+
+### Sub-Issue 1: Classifications domain — types, system, and repository
+
+**Scope**: Everything in `internal/classifications/`. Complete data layer with no HTTP surface.
+
+**Files created**:
+- `internal/classifications/classification.go` — `Classification`, `ValidateCommand`, `UpdateCommand`
+- `internal/classifications/system.go` — `System` interface
+- `internal/classifications/errors.go` — sentinel errors + `MapHTTPStatus`
+- `internal/classifications/mapping.go` — projection, defaultSort, Filters, FiltersFromQuery, scanClassification
+- `internal/classifications/repository.go` — `repo` struct, `New(db, rt, logger, pagination) System`
+- Remove `internal/classifications/doc.go` (stub)
+
+**System interface**:
+```go
+type System interface {
+    Handler() *Handler
+    List(ctx, page, filters) (*PageResult[Classification], error)
+    Find(ctx, id) (*Classification, error)
+    FindByDocument(ctx, documentID) (*Classification, error)
+    Classify(ctx, documentID) (*Classification, error)
+    Validate(ctx, id, cmd ValidateCommand) (*Classification, error)
+    Update(ctx, id, cmd UpdateCommand) (*Classification, error)
+    Delete(ctx, id) error
+}
+```
+
+**Key operations**:
+- `Classify`: calls `workflow.Execute()` → collects all `MarkingsFound` from pages (deduped) → upserts via `ON CONFLICT (document_id) DO UPDATE` (resets validation fields) → transitions document `pending → review` in same TX
+- `Validate`: sets `validated_by`/`validated_at` → transitions document `review → complete`
+- `Update`: overwrites `classification` and `rationale` with human-provided values → transitions document `review → complete`
+
+**Tests**: `tests/classifications/classifications_test.go` — error mapping, filter parsing, filter application (same scope as documents/prompts domain tests)
+
+**Labels**: `feature`
+**Dependencies**: None (workflow package already complete)
+
+---
+
+### Sub-Issue 2: Classifications handler, API wiring, and API Cartographer docs
+
+**Scope**: HTTP layer, route registration, Domain wiring, API documentation.
+
+**Files created/modified**:
+- `internal/classifications/handler.go` — `Handler`, `NewHandler`, `Routes()`, all endpoint methods
+- `internal/api/domain.go` — add `Classifications classifications.System`, assemble `workflow.Runtime` in `NewDomain`
+- `internal/api/routes.go` — register classifications routes
+- `_project/api/classifications/README.md` — API Cartographer docs
+- `_project/api/classifications/classifications.http` — `.http` request file
+
+**Routes**:
+```
+GET    /classifications                     — paginated list with filters
+GET    /classifications/{id}                — find by ID
+GET    /classifications/document/{id}       — find by document
+POST   /classifications/search               — search with JSON body
+POST   /classifications/{documentId}        — classify single document
+POST   /classifications/{id}/validate       — mark validated
+PUT    /classifications/{id}                — update classification manually
+DELETE /classifications/{id}                — delete classification
+```
+
+**Tests**: `tests/classifications/handler_test.go` — mock System pattern from `tests/documents/handler_test.go` and `tests/prompts/handler_test.go`
+
+**Labels**: `feature`
+**Dependencies**: Sub-issue 1
+
+## `_project/objective.md` Content
+
+After sub-issue creation, create `_project/objective.md` documenting the merged objective with scope, sub-issues table, and architecture decisions listed above.
+
+## Execution Order
+
+1. Transition closeout (close #26, update phase.md, merge #28 into #27, delete #28)
+2. Create sub-issues, link to #27
+3. Add sub-issues to project board, assign Phase 2
+4. Create `_project/objective.md`

--- a/_project/README.md
+++ b/_project/README.md
@@ -202,13 +202,12 @@ Azure PostgreSQL with golang-migrate. Core tables:
 **documents** -- Registration records with metadata and blob reference. Status tracks a document's position in the classification lifecycle, not operational concerns. `pending` means inference hasn't completed; `review` means inference produced a result awaiting human validation; `complete` means the classification has been validated or adjusted. Errors during inference leave the document in `pending` — error handling and observability are separate concerns.
 - id, external_id, external_platform, filename, content_type, size_bytes, page_count, storage_key, status (pending/review/complete), uploaded_at, updated_at
 
-**classifications** -- 1:1 with documents, overwritten on re-classification. Workflow metadata is stored as flattened columns rather than JSONB.
-- id, document_id (unique FK), classification, confidence, markings_found (JSONB), rationale, agent_config, classified_at
-- Flattened workflow metadata columns (exact schema TBD during Phase 2 when workflow output shape is concrete)
-- validated_by, validated_at, adjusted_classification, adjustment_rationale
+**classifications** -- 1:1 with documents, overwritten on re-classification. Workflow metadata is stored as flattened columns rather than JSONB. Human review is either validate (agree with AI) or update (overwrite classification and rationale). Both transition the document to `complete`.
+- id, document_id (unique FK), classification, confidence, markings_found (JSONB), rationale, classified_at, model_name, provider_name
+- validated_by, validated_at
 
 **prompts** -- Named instruction overrides per workflow stage. Stores the tunable instruction layer; the output format layer is hard-coded in `workflow/prompts.go` and composed at execution time.
-- id, name (unique), stage (init/classify/enhance), instructions, description
+- id, name (unique), stage (classify/enhance/finalize), instructions, description, active
 
 ### Web Client
 

--- a/_project/objective.md
+++ b/_project/objective.md
@@ -1,39 +1,32 @@
-# Objective #26 — Classification Workflow
+# Objective #27 — Classifications Domain
 
 **Phase:** [Phase 2 — Classification Engine](phase.md)
-**Issue:** [#26](https://github.com/JaimeStill/herald/issues/26)
+**Issue:** [#27](https://github.com/JaimeStill/herald/issues/27)
 **Milestone:** v0.2.0 - Classification Engine
 
 ## Scope
 
-Implement the `workflow/` package containing the 4-node state graph (init → classify → enhance? → finalize), all node implementations, prompt composition, and response parsing. The workflow adapts classify-docs' sequential page-by-page context accumulation pattern (96.3% accuracy) into a go-agents-orchestration state graph. The classify node handles per-page analysis; a dedicated finalize node synthesizes the document-level classification from all page findings.
+Implement the full classifications vertical — persistence layer, business operations (classify/validate/update), HTTP endpoints, API wiring, and documentation. The classifications domain stores, queries, validates, and updates classification results produced by the workflow engine. It manages document status transitions through the classification lifecycle (pending → review → complete).
 
-**Out of scope**: Database persistence of classification results, HTTP endpoints, document status transitions.
+This objective merges the scope originally split across #27 (Classifications Domain) and #28 (Classification HTTP Endpoints) into a single cohesive objective.
+
+**Out of scope**: Batch classification endpoint (client-orchestrated), SSE/streaming progress (Phase 3).
 
 ## Sub-Issues
 
 | # | Sub-Issue | Status | Dependencies |
 |---|-----------|--------|--------------|
-| [#37](https://github.com/JaimeStill/herald/issues/37) | Prompts domain extensions — instructions, specifications, and hardcoded defaults | Open | — |
-| [#38](https://github.com/JaimeStill/herald/issues/38) | Workflow foundation — types, runtime, errors, and parsing | Open | #37 |
-| [#39](https://github.com/JaimeStill/herald/issues/39) | Init node — concurrent page rendering with temp storage | Open | #38 |
-| [#40](https://github.com/JaimeStill/herald/issues/40) | Classify node — sequential page-by-page context accumulation | Open | #38 |
-| [#41](https://github.com/JaimeStill/herald/issues/41) | Enhance node, finalize node, graph assembly, and Execute function | Open | #39, #40 |
+| [#47](https://github.com/JaimeStill/herald/issues/47) | Classifications domain — types, system, and repository | Open | — |
+| [#48](https://github.com/JaimeStill/herald/issues/48) | Classifications handler, API wiring, and API Cartographer docs | Open | #47 |
 
 ## Architecture Decisions
 
-1. **Prompts domain owns all prompt content**: The prompts domain is the single source of truth for both tunable instructions (DB overrides or hardcoded defaults) and immutable specifications (output schema + behavioral constraints). `Instructions(ctx, stage)` always returns a non-null string. `Spec(ctx, stage)` returns the read-only specification. The workflow composes both into the final system prompt.
+1. **`Classify` lives on the System interface**: The `classifications.repo` holds `*workflow.Runtime` as a constructor dependency. `Classify(ctx, documentID)` internally calls `workflow.Execute()`, stores the result, and transitions document status. The handler calls `sys.Classify(ctx, documentID)` — thin and consistent with documents/prompts patterns.
 
-2. **Specifications replace "output format"**: The immutable traits of each prompt stage are called "specifications" — they define the expected JSON output structure and behavioral constraints that the workflow parser depends on. Exposed via `GET /api/prompts/{stage}/spec` as read-only context for prompt authors crafting instructions.
+2. **Validate and Update are alternatives, not sequential**: Both transition document status `review → complete`. Validate = human agrees with AI classification. Update = human manually overwrites `classification` and `rationale`. Re-classification (another `Classify` call) resets validation fields via upsert semantics.
 
-3. **Request-bound temp storage**: Page images are rendered to a temp directory (created by `Execute`, cleaned up via defer) rather than held as base64 data URIs in memory. `PageImage` stores a file path. Classify/enhance nodes encode to data URI just-in-time per page, keeping memory usage proportional to one page at a time.
+3. **No additional migration**: Update overwrites the existing `classification` and `rationale` columns directly — no separate adjustment columns needed.
 
-4. **Concurrent rendering, sequential classification**: The init node renders pages concurrently (ImageMagick is CPU-heavy, bounded concurrency via `errgroup.SetLimit`). The classify node processes pages sequentially for context accumulation — each page's findings feed the next page's prompt. Preserves the 96.3% accuracy pattern from classify-docs while optimizing the rendering bottleneck.
+4. **Workflow runtime assembly in `api.NewDomain`**: Construction order is `documents.System → prompts.System → workflow.Runtime → classifications.System → Domain`. The `workflow.Runtime` is an ephemeral construction dependency, not stored on Domain.
 
-5. **Inline sequential processing**: Herald implements the classify-docs `ProcessWithContext` pattern inline. A simple `for range pages` loop with state accumulation is clearer for a single workflow.
-
-6. **Per-page analysis, document-level synthesis**: The classify node only populates `ClassificationPage` fields per page. A dedicated finalize node performs a single inference to synthesize the document-level `ClassificationState` (classification, confidence, rationale) from all page findings. This eliminates incremental anchoring bias and ensures finalize sees all evidence — including any enhanced pages — holistically.
-
-7. **Single exit point**: Finalize is always the terminal node. The conditional edge on `ClassificationState.NeedsEnhance()` determines whether enhance runs before finalize, but both paths converge to finalize. Initially, classify never sets `Enhance: true`, so enhance is skipped.
-
-8. **Per-request agent creation**: Each `Execute` call creates a fresh `agent.Agent` from the config. Stateless agent design — no lifecycle management.
+5. **Upsert semantics on Classify**: `ON CONFLICT (document_id) DO UPDATE` overwrites all inference fields and resets `validated_by`/`validated_at` to NULL.

--- a/_project/phase.md
+++ b/_project/phase.md
@@ -23,9 +23,8 @@ Build the classification engine that reads security markings from PDF documents 
 |---|-----------|--------|--------------|
 | [#24](https://github.com/JaimeStill/herald/issues/24) | Agent Configuration and Database Schema | Complete | — |
 | [#25](https://github.com/JaimeStill/herald/issues/25) | Prompts Domain | Complete | #24 |
-| [#26](https://github.com/JaimeStill/herald/issues/26) | Classification Workflow | Open | #24, #25 |
+| [#26](https://github.com/JaimeStill/herald/issues/26) | Classification Workflow | Complete | #24, #25 |
 | [#27](https://github.com/JaimeStill/herald/issues/27) | Classifications Domain | Open | #24, #26 |
-| [#28](https://github.com/JaimeStill/herald/issues/28) | Classification HTTP Endpoints | Open | #25, #27 |
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

- Close Objective #26 (Classification Workflow) — all 5 sub-issues complete
- Merge #28 (Classification HTTP Endpoints) scope into #27 (Classifications Domain) and delete #28
- Create sub-issues #47 and #48 under Objective #27
- Correct `_project/README.md` database schema to match actual migration

## Changes

- `_project/phase.md` — mark #26 Complete, remove deleted #28 row
- `_project/objective.md` — replace #26 content with #27 (merged scope, 2 sub-issues, architecture decisions)
- `_project/README.md` — fix classifications table schema (model_name/provider_name, no adjustment columns), update prompts stages and active column

Closes #26