### PR TITLE
Parallelize classify and enhance workflow nodes

### DIFF
--- a/.claude/context/guides/.archive/51-parallelize-classify-enhance.md
+++ b/.claude/context/guides/.archive/51-parallelize-classify-enhance.md
@@ -1,0 +1,186 @@
+# 51 - Parallelize classify and enhance workflow nodes
+
+## Problem Context
+
+The classify and enhance workflow nodes process pages sequentially. Each page's vision model call takes ~13 seconds, so a 10-page document takes over 2 minutes for classify alone. Both nodes should be parallelized using bounded `errgroup` concurrency, matching the pattern already established in the init node's `renderPages`. With Azure rate limits at 800 RPM / 800K TPM, CPU cores remain the practical bottleneck — reuse the existing worker count calculation.
+
+## Architecture Approach
+
+Reuse the `renderWorkerCount` function (renamed to `workerCount`) for all bounded concurrency scenarios. Remove context accumulation from classify (promptState always nil). Compose prompts once before the errgroup to avoid data races. Each goroutine creates its own agent and writes to its own pre-allocated slice index.
+
+## Implementation
+
+### Step 1: Rename `renderWorkerCount` to `workerCount` in `internal/workflow/init.go`
+
+Rename the function and update the call site in `renderPages`:
+
+```go
+func workerCount(n int) int {
+	return max(min(runtime.NumCPU(), n), 1)
+}
+```
+
+Update the call in `renderPages`:
+
+```go
+g.SetLimit(workerCount(pageCount))
+```
+
+### Step 2: Parallelize classify node in `internal/workflow/classify.go`
+
+Replace the sequential `classifyPages` function with errgroup bounded concurrency. Remove context accumulation. Compose the prompt once before launching goroutines.
+
+Replace the existing `classifyPages` function with:
+
+```go
+func classifyPages(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageClassify, nil)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrClassifyFailed, err)
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workerCount(len(cs.Pages)))
+
+	for i := range cs.Pages {
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			a, err := agent.New(&rt.Agent)
+			if err != nil {
+				return fmt.Errorf("page %d: create agent: %w", i+1, err)
+			}
+
+			dataURI, err := encodePageImage(cs.Pages[i].ImagePath)
+			if err != nil {
+				return fmt.Errorf("page %d: %w", i+1, err)
+			}
+
+			resp, err := a.Vision(gctx, prompt, []string{dataURI})
+			if err != nil {
+				return fmt.Errorf("page %d: vision call: %w", i+1, err)
+			}
+
+			parsed, err := formatting.Parse[pageResponse](resp.Content())
+			if err != nil {
+				return fmt.Errorf("page %d: parse response: %w", i+1, err)
+			}
+
+			applyPageResponse(&cs.Pages[i], parsed)
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("%w: %w", ErrClassifyFailed, err)
+	}
+
+	return nil
+}
+```
+
+Remove the `classifyPage` function — its logic is inlined into the goroutine.
+
+Add the `errgroup` import:
+
+```go
+"golang.org/x/sync/errgroup"
+```
+
+Remove unused imports that are no longer needed: the `"os"` import stays (used by `encodePageImage`), but the `"github.com/JaimeStill/go-agents/pkg/agent"` import stays (used for per-goroutine agent creation). Remove the `"github.com/JaimeStill/document-context/pkg/document"` and `"github.com/JaimeStill/document-context/pkg/encoding"` imports — they are only used by `encodePageImage` which is still in this file. Actually, keep all existing imports and add `errgroup`.
+
+### Step 3: Parallelize enhance node in `internal/workflow/enhance.go`
+
+Replace the `enhancePages` function with errgroup bounded concurrency. Compose the prompt once before launching goroutines. Each goroutine opens its own PDF handle.
+
+Replace the existing `enhancePages` function with:
+
+```go
+func enhancePages(ctx context.Context, rt *Runtime, cs *ClassificationState, tempDir string) error {
+	pdfPath := filepath.Join(tempDir, sourcePDF)
+	enhanced := cs.EnhancePages()
+
+	prompt, err := ComposePrompt(ctx, rt.Prompts, prompts.StageEnhance, cs)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrEnhanceFailed, err)
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workerCount(len(enhanced)))
+
+	for _, i := range enhanced {
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			pdfDoc, err := document.OpenPDF(pdfPath)
+			if err != nil {
+				return fmt.Errorf("page %d: open pdf: %w", cs.Pages[i].PageNumber, err)
+			}
+			defer pdfDoc.Close()
+
+			a, err := agent.New(&rt.Agent)
+			if err != nil {
+				return fmt.Errorf("page %d: create agent: %w", cs.Pages[i].PageNumber, err)
+			}
+
+			imgPath, err := rerender(pdfDoc, &cs.Pages[i], tempDir)
+			if err != nil {
+				return fmt.Errorf("page %d: %w", cs.Pages[i].PageNumber, err)
+			}
+			cs.Pages[i].ImagePath = imgPath
+
+			dataURI, err := encodePageImage(imgPath)
+			if err != nil {
+				return fmt.Errorf("page %d: %w", cs.Pages[i].PageNumber, err)
+			}
+
+			resp, err := a.Vision(gctx, prompt, []string{dataURI})
+			if err != nil {
+				return fmt.Errorf("page %d: vision call: %w", cs.Pages[i].PageNumber, err)
+			}
+
+			parsed, err := formatting.Parse[enhanceResponse](resp.Content())
+			if err != nil {
+				return fmt.Errorf("page %d: parse response: %w", cs.Pages[i].PageNumber, err)
+			}
+
+			cs.Pages[i].MarkingsFound = parsed.MarkingsFound
+			cs.Pages[i].Rationale = parsed.Rationale
+			cs.Pages[i].Enhancements = nil
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("%w: %w", ErrEnhanceFailed, err)
+	}
+
+	return nil
+}
+```
+
+Update the `enhancePage` function signature — remove `a agent.Agent` and `pdfDoc document.Document` parameters since these are now created per-goroutine. Actually, the `enhancePage` function is no longer needed — its logic is inlined into the goroutine closure. Remove it.
+
+Add the `errgroup` import:
+
+```go
+"golang.org/x/sync/errgroup"
+```
+
+## Validation Criteria
+
+- [ ] `renderWorkerCount` renamed to `workerCount` in `init.go` and call site updated
+- [ ] `classifyPages` uses errgroup with bounded concurrency
+- [ ] Context accumulation removed from classify (promptState always nil)
+- [ ] Each classify goroutine creates its own agent
+- [ ] `enhancePages` uses errgroup with bounded concurrency
+- [ ] Each enhance goroutine opens its own PDF handle
+- [ ] Each enhance goroutine creates its own agent
+- [ ] Prompt composed once before errgroup in both nodes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./tests/...` passes

--- a/.claude/context/sessions/51-parallelize-classify-enhance.md
+++ b/.claude/context/sessions/51-parallelize-classify-enhance.md
@@ -1,0 +1,35 @@
+# 51 - Parallelize classify and enhance workflow nodes
+
+## Summary
+
+Replaced sequential processing in the classify and enhance workflow nodes with bounded `errgroup` concurrency. Removed context accumulation from classify (each page is now classified independently). Both nodes compose prompts once before launching goroutines and create per-goroutine agents. The enhance node opens per-goroutine PDF handles for concurrency safety. Reuses the existing `workerCount` function (renamed from `renderWorkerCount`) for all bounded concurrency scenarios.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Concurrency limit | Reuse CPU-based `workerCount` | Azure rate limits (800 RPM / 800K TPM) are generous; image encoding is CPU-bound; no new config needed |
+| Context accumulation | Removed (promptState always nil) | Shifts synthesis entirely to finalize node; enables independent parallel page classification |
+| `workerCount` location | Moved to `workflow.go` | Shared across init, classify, and enhance nodes — no longer render-specific |
+| Prompt composition | Once before errgroup | Avoids data races from concurrent reads/writes to ClassificationState |
+| Per-goroutine PDF handles | Each enhance goroutine opens its own | PDF handles are not concurrency-safe |
+
+## Files Modified
+
+- `internal/workflow/workflow.go` — Added `workerCount` (renamed from `renderWorkerCount`)
+- `internal/workflow/init.go` — Removed `renderWorkerCount`, updated call to `workerCount`
+- `internal/workflow/classify.go` — Parallel errgroup, removed context accumulation, removed `classifyPage`
+- `internal/workflow/enhance.go` — Parallel errgroup, pre-composed prompt, per-goroutine PDF + agent, removed `enhancePage`
+- `_project/README.md` — Updated classify/enhance node descriptions, classification approach decision
+
+## Patterns Established
+
+- **Shared `workerCount`**: All bounded concurrency in the workflow package uses `workerCount(n)` from `workflow.go`
+- **Pre-composed prompts**: When goroutines share the same prompt, compose it once before the errgroup to avoid data races
+
+## Validation Results
+
+- `go vet ./...` — pass
+- `go test ./tests/...` — all 18 suites pass
+- `go mod tidy` — no changes
+- Manual testing: 6-page document classified correctly in ~16s (classify node) vs ~78s estimated sequential

--- a/.claude/plans/lucky-popping-twilight.md
+++ b/.claude/plans/lucky-popping-twilight.md
@@ -1,0 +1,43 @@
+# Plan: Parallelize classify and enhance workflow nodes (#51)
+
+## Context
+
+Testing the classify endpoint on a 1-page document took ~40 seconds across 3 LLM round-trips. Each page's vision call takes ~13 seconds, so sequential processing would take 2+ minutes for a 10-page document. LLM calls are network-bound, not CPU-bound, so they parallelize well within Azure API rate limits. The init node already uses `errgroup` bounded concurrency for CPU-bound ImageMagick rendering — both classify and enhance should follow the same pattern for inference calls.
+
+## Approach
+
+Reuse the existing `workerCount` pattern (`max(min(NumCPU, pageCount), 1)`) for inference concurrency. Even though LLM calls are network-bound, the image encoding work (file I/O, base64) is CPU-bound, and Azure rate limits (800 RPM / 800K TPM) are generous enough that CPU cores remain the practical bottleneck. No new config or Runtime fields needed.
+
+### 1. Rename `workerCount` to `workerCount` (`internal/workflow/init.go`)
+
+The function now applies to all bounded concurrency scenarios (rendering, classify, enhance), not just rendering. Rename it and update the call site in `renderPages`.
+
+### 2. Parallelize classify node (`internal/workflow/classify.go`)
+
+- **Remove context accumulation**: `promptState` is always `nil` — no prior page findings injected. This shifts synthesis responsibility entirely to the finalize node (which already handles it).
+- **Compose prompt once** before the errgroup (same prompt for all pages since state is nil).
+- **Each goroutine**: create agent via `agent.New` → encode image → vision call → write to `pages[i]`.
+- **Bounded concurrency**: `errgroup.SetLimit(workerCount(len(cs.Pages)))`.
+- Pre-allocated slice indices — each goroutine writes to its own index (no mutex needed).
+
+### 2. Parallelize enhance node (`internal/workflow/enhance.go`)
+
+- **Compose prompt once** before the errgroup (snapshot of current `cs` state — avoids data race from concurrent reads/writes during goroutine execution).
+- **Each goroutine**: open its own PDF handle → rerender → encode → vision call with pre-composed prompt → update `pages[i]` → close PDF handle.
+- **Each goroutine creates its own agent** via `agent.New`.
+- **Bounded concurrency**: `errgroup.SetLimit(workerCount(len(enhanced)))`.
+- PDF handles opened per-goroutine since they are not concurrency-safe.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/workflow/init.go` | Rename `renderWorkerCount` → `workerCount` and update call site |
+| `internal/workflow/classify.go` | Replace sequential loop with errgroup bounded concurrency, remove context accumulation, compose prompt once, per-goroutine agent creation |
+| `internal/workflow/enhance.go` | Replace sequential loop with errgroup bounded concurrency, compose prompt once, per-goroutine PDF handle + agent creation |
+
+## Validation
+
+- `go vet ./...` passes
+- `go test ./tests/...` passes
+- Manual testing with multi-page documents to verify correctness matches sequential results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0-dev.27.51
+
+- Parallelize classify and enhance workflow nodes with bounded errgroup concurrency, removing sequential context accumulation in favor of independent per-page analysis (#51)
+
 ## v0.2.0-dev.27.48
 
 - Add classifications handler with 8 HTTP endpoints (list, find, find-by-document, search, classify, validate, update, delete), API module wiring, and route registration (#48)

--- a/internal/workflow/init.go
+++ b/internal/workflow/init.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/google/uuid"
 
@@ -135,7 +134,7 @@ func renderPages(ctx context.Context, tempDir string) ([]ClassificationPage, err
 	pages := make([]ClassificationPage, pageCount)
 
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(renderWorkerCount(pageCount))
+	g.SetLimit(workerCount(pageCount))
 
 	for i, page := range allPages {
 		pageNum := i + 1
@@ -168,8 +167,4 @@ func renderPages(ctx context.Context, tempDir string) ([]ClassificationPage, err
 	}
 
 	return pages, nil
-}
-
-func renderWorkerCount(pageCount int) int {
-	return max(min(runtime.NumCPU(), pageCount), 1)
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -158,4 +159,8 @@ func needsEnhance(s state.State) bool {
 	}
 
 	return cs.NeedsEnhance()
+}
+
+func workerCount(pageCount int) int {
+	return max(min(runtime.NumCPU(), pageCount), 1)
 }


### PR DESCRIPTION
## Summary

Replace sequential processing in the classify and enhance workflow nodes with bounded `errgroup` concurrency, matching the pattern established in the init node. Each page's vision model call runs in parallel, reducing classify time from ~78s to ~16s for a 6-page document.

Closes #51

## Changes

- Classify node: parallel per-page analysis with bounded errgroup concurrency, context accumulation removed (each page classified independently)
- Enhance node: parallel processing with per-goroutine PDF handles and agents, prompt composed once before launching goroutines
- Rename `renderWorkerCount` → `workerCount` and move to `workflow.go` (shared across all nodes)
- Update `_project/README.md` to reflect parallel classification approach