### PR TITLE
Add query builder JOIN support and document classification view

### DIFF
--- a/.claude/context/guides/.archive/53-query-builder-join-support.md
+++ b/.claude/context/guides/.archive/53-query-builder-join-support.md
@@ -1,0 +1,296 @@
+# 53 - Query Builder JOIN Support and Document Classification View
+
+## Problem Context
+
+The Phase 3 web client needs to display documents alongside their classification metadata and filter by classification fields. Currently, `Document` and `Classification` are separate types in separate packages with no joined view. A SQL LEFT JOIN populates nullable classification fields on `Document` without introducing circular dependencies.
+
+## Architecture Approach
+
+Adapt the S2VA `ProjectionMap.Join()` context-switching pattern: `Join()` switches `currentAlias` so subsequent `Project()` calls map to the joined table. A new `From()` method returns the base table reference plus all accumulated JOIN clauses — backward compatible (returns `Table()` when no joins exist). The `Builder` switches from `Table()` to `From()` in all build methods.
+
+## Implementation
+
+### Step 1: Extend `ProjectionMap` with JOIN support
+
+**File:** `pkg/query/projection.go`
+
+Add the `joinClause` struct and new fields to `ProjectionMap`:
+
+```go
+type JoinClause struct {
+	Index    int
+	JoinType string
+	Schema   string
+	Table    string
+	Alias    string
+	On       string
+}
+
+type ProjectionMap struct {
+	schema       string
+	table        string
+	alias        string
+	currentAlias string
+	columns      map[string]string
+	columnList   []string
+	joins map[string]JoinClause
+}
+```
+
+The `joins` map is keyed by alias for easy lookup.
+
+Update `NewProjectionMap` to initialize `currentAlias` and the joins map:
+
+```go
+func NewProjectionMap(schema, table, alias string) *ProjectionMap {
+	return &ProjectionMap{
+		schema:       schema,
+		table:        table,
+		alias:        alias,
+		currentAlias: alias,
+		columns:      make(map[string]string),
+		columnList:   make([]string, 0),
+		joins:        make(map[string]JoinClause),
+	}
+}
+```
+
+Update `Project` to use `currentAlias`:
+
+```go
+func (p *ProjectionMap) Project(column, viewName string) *ProjectionMap {
+	qualified := fmt.Sprintf("%s.%s", p.currentAlias, column)
+	p.columns[viewName] = qualified
+	p.columnList = append(p.columnList, qualified)
+	return p
+}
+```
+
+Add `Join` and `From` methods:
+
+```go
+// Join adds a JOIN clause and switches the projection context to the joined table.
+// Subsequent Project calls will use the joined table's alias.
+func (p *ProjectionMap) Join(schema, table, alias, joinType, on string) *ProjectionMap {
+	p.joins[alias] = JoinClause{
+		Index:    len(p.joins),
+		JoinType: joinType,
+		Schema:   schema,
+		Table:    table,
+		Alias:    alias,
+		On:       on,
+	}
+	p.currentAlias = alias
+	return p
+}
+
+// Joins returns all join clauses sorted by insertion order.
+func (p *ProjectionMap) Joins() []JoinClause {
+	return slices.SortedFunc(maps.Values(p.joins), func(a, b JoinClause) int {
+		return a.Index - b.Index
+	})
+}
+
+// From returns the full FROM clause including the base table and all JOIN clauses.
+// When no joins exist, this returns the same value as Table().
+func (p *ProjectionMap) From() string {
+	joins := p.Joins()
+	if len(joins) == 0 {
+		return p.Table()
+	}
+
+	var b strings.Builder
+	b.WriteString(p.Table())
+	for _, j := range joins {
+		fmt.Fprintf(&b, " %s %s.%s %s ON %s", j.JoinType, j.Schema, j.Table, j.Alias, j.On)
+	}
+	return b.String()
+}
+```
+
+### Step 2: Update `Builder` to use `From()`
+
+**File:** `pkg/query/builder.go`
+
+Replace `b.projection.Table()` with `b.projection.From()` in all five build methods:
+
+In `Build()`:
+```go
+// change: b.projection.Table()  →  b.projection.From()
+sql := fmt.Sprintf(
+    "SELECT %s FROM %s%s%s",
+    b.projection.Columns(),
+    b.projection.From(),
+    where,
+    orderBy,
+)
+```
+
+In `BuildCount()`:
+```go
+sql := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", b.projection.From(), where)
+```
+
+In `BuildPage()`:
+```go
+sql := fmt.Sprintf(
+    "SELECT %s FROM %s%s%s LIMIT %d OFFSET %d",
+    b.projection.Columns(),
+    b.projection.From(),
+    where,
+    orderBy,
+    pageSize,
+    offset,
+)
+```
+
+In `BuildSingle()`:
+```go
+sql := fmt.Sprintf(
+    "SELECT %s FROM %s WHERE %s = $1",
+    b.projection.Columns(),
+    b.projection.From(),
+    col,
+)
+```
+
+In `BuildSingleOrNull()`:
+```go
+sql := fmt.Sprintf(
+    "SELECT %s FROM %s%s LIMIT 1",
+    b.projection.Columns(),
+    b.projection.From(),
+    where,
+)
+```
+
+### Step 3: Extend `Document` struct
+
+**File:** `internal/documents/document.go`
+
+Add three nullable fields after `UpdatedAt`:
+
+```go
+type Document struct {
+	ID               uuid.UUID  `json:"id"`
+	ExternalID       int        `json:"external_id"`
+	ExternalPlatform string     `json:"external_platform"`
+	Filename         string     `json:"filename"`
+	ContentType      string     `json:"content_type"`
+	SizeBytes        int64      `json:"size_bytes"`
+	PageCount        *int       `json:"page_count"`
+	StorageKey       string     `json:"storage_key"`
+	Status           string     `json:"status"`
+	UploadedAt       time.Time  `json:"uploaded_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Classification   *string    `json:"classification,omitempty"`
+	Confidence       *string    `json:"confidence,omitempty"`
+	ClassifiedAt     *time.Time `json:"classified_at,omitempty"`
+}
+```
+
+### Step 4: Extend projection, scan, and filters
+
+**File:** `internal/documents/mapping.go`
+
+Extend the `projection` variable with the LEFT JOIN and three additional columns:
+
+```go
+var projection = query.
+	NewProjectionMap("public", "documents", "d").
+	Project("id", "ID").
+	Project("external_id", "ExternalID").
+	Project("external_platform", "ExternalPlatform").
+	Project("filename", "Filename").
+	Project("content_type", "ContentType").
+	Project("size_bytes", "SizeBytes").
+	Project("page_count", "PageCount").
+	Project("storage_key", "StorageKey").
+	Project("status", "Status").
+	Project("uploaded_at", "UploadedAt").
+	Project("updated_at", "UpdatedAt").
+	Join("public", "classifications", "c", "LEFT JOIN", "d.id = c.document_id").
+	Project("classification", "Classification").
+	Project("confidence", "Confidence").
+	Project("classified_at", "ClassifiedAt")
+```
+
+Extend `scanDocument` to scan 14 columns:
+
+```go
+func scanDocument(s repository.Scanner) (Document, error) {
+	var d Document
+	err := s.Scan(
+		&d.ID,
+		&d.ExternalID,
+		&d.ExternalPlatform,
+		&d.Filename,
+		&d.ContentType,
+		&d.SizeBytes,
+		&d.PageCount,
+		&d.StorageKey,
+		&d.Status,
+		&d.UploadedAt,
+		&d.UpdatedAt,
+		&d.Classification,
+		&d.Confidence,
+		&d.ClassifiedAt,
+	)
+	return d, err
+}
+```
+
+Add `Classification` and `Confidence` to the `Filters` struct:
+
+```go
+type Filters struct {
+	Status           *string `json:"status,omitempty"`
+	Filename         *string `json:"filename,omitempty"`
+	ExternalID       *int    `json:"external_id,omitempty"`
+	ExternalPlatform *string `json:"external_platform,omitempty"`
+	ContentType      *string `json:"content_type,omitempty"`
+	StorageKey       *string `json:"storage_key,omitempty"`
+	Classification   *string `json:"classification,omitempty"`
+	Confidence       *string `json:"confidence,omitempty"`
+}
+```
+
+Add the two new filters to `Apply`:
+
+```go
+func (f Filters) Apply(b *query.Builder) *query.Builder {
+	return b.
+		WhereEquals("Status", f.Status).
+		WhereContains("Filename", f.Filename).
+		WhereEquals("ExternalID", f.ExternalID).
+		WhereEquals("ExternalPlatform", f.ExternalPlatform).
+		WhereEquals("ContentType", f.ContentType).
+		WhereContains("StorageKey", f.StorageKey).
+		WhereEquals("Classification", f.Classification).
+		WhereEquals("Confidence", f.Confidence)
+}
+```
+
+Add query parameter parsing in `FiltersFromQuery`:
+
+```go
+// add at the end, before the return
+if cl := values.Get("classification"); cl != "" {
+    f.Classification = &cl
+}
+
+if co := values.Get("confidence"); co != "" {
+    f.Confidence = &co
+}
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go test ./tests/...` passes
+- [ ] Existing builder tests still pass (backward compatible — `From()` returns `Table()` when no joins)
+- [ ] `GET /api/documents` returns documents with `classification`, `confidence`, `classified_at` fields
+- [ ] Unclassified documents return `null`/omitted for classification fields
+- [ ] `GET /api/documents?classification=SECRET` filters by classification level
+- [ ] `GET /api/documents?confidence=HIGH` filters by confidence
+- [ ] `GET /api/documents/{id}` returns document with classification fields

--- a/.claude/context/sessions/53-query-builder-join-support.md
+++ b/.claude/context/sessions/53-query-builder-join-support.md
@@ -1,0 +1,36 @@
+# 53 - Query Builder JOIN Support and Document Classification View
+
+## Summary
+
+Extended the query builder with JOIN support using a context-switching pattern adapted from S2VA's .NET `ProjectionMap.Join()`. Updated the documents domain to include classification metadata via LEFT JOIN, enabling the web client to display and filter documents with their classification status.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| JOIN storage | `map[string]JoinClause` with `Index` field | Map gives O(1) lookup by alias, `Index` preserves insertion order for deterministic SQL via `slices.SortedFunc(maps.Values(...))` |
+| Context switching | `currentAlias` field on `ProjectionMap` | After `Join()`, subsequent `Project()` calls map to the joined table's alias automatically — matches S2VA pattern |
+| `From()` vs `Table()` | `From()` composes `Table()` + join clauses; backward compatible | When no joins exist, `From()` returns `Table()` — all existing code works unchanged |
+| `JoinClause` exported | Exported struct with exported fields | Enables consumers to inspect join metadata via `Joins()` accessor |
+| Filter case sensitivity | Kept `WhereEquals` as case-sensitive | Filters will be populated from fetched DB values in the web client, so case will already match |
+
+## Files Modified
+
+- `pkg/query/projection.go` — Added `JoinClause` type, `Join()`, `Joins()`, `From()` methods, `currentAlias`/`joins` fields
+- `pkg/query/builder.go` — Replaced `Table()` with `From()` in all 5 build methods
+- `internal/documents/document.go` — Added `Classification`, `Confidence`, `ClassifiedAt` nullable fields
+- `internal/documents/mapping.go` — Extended projection with LEFT JOIN, extended `scanDocument` to 14 columns, added classification filters
+- `tests/query/query_test.go` — Added 10 JOIN tests (From, context switching, Joins ordering, builder methods, joined column filters)
+
+## Patterns Established
+
+- **ProjectionMap JOIN pattern**: `Join(schema, table, alias, joinType, on)` switches `currentAlias` so subsequent `Project()` calls automatically bind to the joined table. Multi-table projections are built with a single fluent chain.
+- **Ordered map iteration**: `slices.SortedFunc(maps.Values(m), cmpFunc)` for deterministic iteration of map values by an `Index` field — avoids parallel bookkeeping with a separate order slice.
+- **Cross-domain view via LEFT JOIN**: Domains add nullable fields populated by JOINs rather than importing peer packages, avoiding circular dependencies.
+
+## Validation Results
+
+- `go vet ./...` — pass
+- `go test ./tests/...` — all 18 packages pass
+- `go mod tidy` — no changes
+- Manual verification: `GET /api/documents` returns classification fields, filtering by `?confidence=HIGH` works correctly

--- a/.claude/plans/snug-crunching-hopper.md
+++ b/.claude/plans/snug-crunching-hopper.md
@@ -1,0 +1,60 @@
+# Plan: Issue #53 — Query Builder JOIN Support and Document Classification View
+
+## Context
+
+The Phase 3 web client needs to display documents alongside their classification metadata (classification level, confidence, timestamp) and support filtering by those fields. Currently, `Document` and `Classification` are separate types in separate packages with no joined view. A SQL LEFT JOIN approach avoids circular dependencies — the documents domain defines its own nullable fields populated by the join.
+
+This adapts the S2VA `ProjectionMap.Join()` context-switching pattern: after `Join()`, subsequent `Project()` calls map to the joined table's alias automatically.
+
+## Approach
+
+### Step 1: Extend `ProjectionMap` with JOIN support
+
+**File:** `pkg/query/projection.go`
+
+Add context-switching JOIN capability matching the S2VA pattern:
+
+- `joinClause` struct with `joinType`, `schema`, `table`, `alias`, `on` fields
+- `currentAlias` field on `ProjectionMap` — initialized to base alias, switched after each `Join()`
+- `joins` slice on `ProjectionMap` to accumulate join clauses
+- Modify `Project()` to use `currentAlias` instead of `alias`
+- `Join(schema, table, alias, joinType, on string) *ProjectionMap` — stores join clause, switches `currentAlias`, returns self for chaining
+- `From() string` — returns `Table()` + all join clauses appended. When no joins exist, equals `Table()` (backward compatible)
+
+### Step 2: Update `Builder` to use `From()`
+
+**File:** `pkg/query/builder.go`
+
+Replace all 5 `b.projection.Table()` calls with `b.projection.From()`:
+- `Build()` (line 80)
+- `BuildCount()` (line 91)
+- `BuildPage()` (line 104)
+- `BuildSingle()` (line 120)
+- `BuildSingleOrNull()` (line 132)
+
+### Step 3: Extend `Document` struct
+
+**File:** `internal/documents/document.go`
+
+Add three nullable fields (all `json:",omitempty"`):
+- `Classification *string`
+- `Confidence *string`
+- `ClassifiedAt *time.Time`
+
+### Step 4: Extend projection, scan, and filters
+
+**File:** `internal/documents/mapping.go`
+
+- Extend `projection` with `.Join("public", "classifications", "c", "LEFT JOIN", "d.id = c.document_id")` followed by `.Project("classification", "Classification")`, `.Project("confidence", "Confidence")`, `.Project("classified_at", "ClassifiedAt")`
+- Extend `scanDocument` to scan 14 columns (11 base + 3 nullable from join)
+- Add `Classification *string` and `Confidence *string` to `Filters` struct
+- Add query parameter parsing for `classification` and `confidence` in `FiltersFromQuery`
+- Add `WhereEquals` calls for both new filters in `Filters.Apply()`
+
+## Verification
+
+- `go vet ./...` passes
+- `go test ./tests/...` passes (existing + new tests for JOIN SQL generation)
+- `GET /api/documents` returns documents with classification fields (null for unclassified)
+- `GET /api/documents?classification=SECRET` filters correctly
+- `GET /api/documents/{id}` returns document with classification fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0-dev.27.53
+
+- Add query builder JOIN support with context-switching ProjectionMap pattern, ordered JoinClause map, and From() method for multi-table queries (#53)
+- Extend Document struct with classification metadata (classification, confidence, classified_at) via LEFT JOIN on classifications table (#53)
+- Add classification and confidence filters to document queries (#53)
+
 ## v0.2.0-dev.27.51
 
 - Parallelize classify and enhance workflow nodes with bounded errgroup concurrency, removing sequential context accumulation in favor of independent per-page analysis (#51)

--- a/_project/api/documents/README.md
+++ b/_project/api/documents/README.md
@@ -25,6 +25,8 @@ Returns a paginated list of documents with optional filters.
 | external_id | integer | no | Filter by external ID (exact match) |
 | external_platform | string | no | Filter by external platform (exact match) |
 | content_type | string | no | Filter by content type (exact match) |
+| classification | string | no | Filter by classification level (exact match) |
+| confidence | string | no | Filter by confidence (exact match: HIGH, MEDIUM, LOW) |
 
 ### Responses
 
@@ -41,7 +43,7 @@ curl -s "$HERALD_API_BASE/api/documents" | jq .
 ### Full Example
 
 ```bash
-curl -s "$HERALD_API_BASE/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf" | jq .
+curl -s "$HERALD_API_BASE/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf&classification=SECRET&confidence=HIGH" | jq .
 ```
 
 ---
@@ -95,6 +97,8 @@ Content-Type: `application/json`
 | external_platform | string | no | Filter by external platform |
 | content_type | string | no | Filter by content type |
 | storage_key | string | no | Filter by storage key (contains) |
+| classification | string | no | Filter by classification level |
+| confidence | string | no | Filter by confidence (HIGH, MEDIUM, LOW) |
 
 ### Responses
 
@@ -126,7 +130,9 @@ curl -s -X POST "$HERALD_API_BASE/api/documents/search" \
     "external_id": 12345,
     "external_platform": "HQ",
     "content_type": "application/pdf",
-    "storage_key": "documents/"
+    "storage_key": "documents/",
+    "classification": "SECRET",
+    "confidence": "HIGH"
   }' | jq .
 ```
 

--- a/_project/api/documents/documents.http
+++ b/_project/api/documents/documents.http
@@ -5,7 +5,7 @@ GET {{HOST}}/api/documents HTTP/1.1
 
 ### List Documents with Filters
 
-GET {{HOST}}/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf HTTP/1.1
+GET {{HOST}}/api/documents?page=1&page_size=20&search=report&sort=-uploaded_at&status=pending&filename=quarterly&external_platform=HQ&content_type=application/pdf&classification=SECRET&confidence=HIGH HTTP/1.1
 
 
 ### Find Document
@@ -42,7 +42,9 @@ Content-Type: application/json
   "page_size": 20,
   "search": "quarterly",
   "sort": "-uploaded_at",
-  "status": "pending"
+  "status": "pending",
+  "classification": "SECRET",
+  "confidence": "HIGH"
 }
 
 

--- a/internal/documents/document.go
+++ b/internal/documents/document.go
@@ -10,18 +10,23 @@ import (
 )
 
 // Document represents a registered document with its metadata and blob storage reference.
+// Classification, Confidence, and ClassifiedAt are populated via LEFT JOIN from the
+// classifications table and are nil for unclassified documents.
 type Document struct {
-	ID               uuid.UUID `json:"id"`
-	ExternalID       int       `json:"external_id"`
-	ExternalPlatform string    `json:"external_platform"`
-	Filename         string    `json:"filename"`
-	ContentType      string    `json:"content_type"`
-	SizeBytes        int64     `json:"size_bytes"`
-	PageCount        *int      `json:"page_count"`
-	StorageKey       string    `json:"storage_key"`
-	Status           string    `json:"status"`
-	UploadedAt       time.Time `json:"uploaded_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID               uuid.UUID  `json:"id"`
+	ExternalID       int        `json:"external_id"`
+	ExternalPlatform string     `json:"external_platform"`
+	Filename         string     `json:"filename"`
+	ContentType      string     `json:"content_type"`
+	SizeBytes        int64      `json:"size_bytes"`
+	PageCount        *int       `json:"page_count"`
+	StorageKey       string     `json:"storage_key"`
+	Status           string     `json:"status"`
+	UploadedAt       time.Time  `json:"uploaded_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Classification   *string    `json:"classification,omitempty"`
+	Confidence       *string    `json:"confidence,omitempty"`
+	ClassifiedAt     *time.Time `json:"classified_at,omitempty"`
 }
 
 // CreateCommand carries the data needed to upload and register a new document.

--- a/pkg/query/builder.go
+++ b/pkg/query/builder.go
@@ -77,7 +77,7 @@ func (b *Builder) Build() (string, []any) {
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %s%s%s",
 		b.projection.Columns(),
-		b.projection.Table(),
+		b.projection.From(),
 		where,
 		orderBy,
 	)
@@ -88,7 +88,7 @@ func (b *Builder) Build() (string, []any) {
 // BuildCount returns a COUNT(*) query with the current conditions.
 func (b *Builder) BuildCount() (string, []any) {
 	where, args, _ := b.buildWhere(1)
-	sql := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", b.projection.Table(), where)
+	sql := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", b.projection.From(), where)
 	return sql, args
 }
 
@@ -101,7 +101,7 @@ func (b *Builder) BuildPage(page, pageSize int) (string, []any) {
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %s%s%s LIMIT %d OFFSET %d",
 		b.projection.Columns(),
-		b.projection.Table(),
+		b.projection.From(),
 		where,
 		orderBy,
 		pageSize,
@@ -117,7 +117,7 @@ func (b *Builder) BuildSingle(idField string, id any) (string, []any) {
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %s WHERE %s = $1",
 		b.projection.Columns(),
-		b.projection.Table(),
+		b.projection.From(),
 		col,
 	)
 	return sql, []any{id}
@@ -129,7 +129,7 @@ func (b *Builder) BuildSingleOrNull() (string, []any) {
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %s%s LIMIT 1",
 		b.projection.Columns(),
-		b.projection.Table(),
+		b.projection.From(),
 		where,
 	)
 	return sql, args

--- a/pkg/query/projection.go
+++ b/pkg/query/projection.go
@@ -3,41 +3,103 @@ package query
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 )
+
+// JoinClause describes a SQL JOIN between two tables.
+// Index preserves insertion order for deterministic SQL generation.
+type JoinClause struct {
+	Index    int
+	JoinType string
+	Schema   string
+	Table    string
+	Alias    string
+	On       string
+}
 
 // ProjectionMap maps view property names to qualified column references (alias.column).
 // It defines the table, alias, and column mappings for SQL query construction.
 type ProjectionMap struct {
-	schema     string
-	table      string
-	alias      string
-	columns    map[string]string
-	columnList []string
+	schema       string
+	table        string
+	alias        string
+	currentAlias string
+	columns      map[string]string
+	columnList   []string
+	joins        map[string]JoinClause
 }
 
 // NewProjectionMap creates a ProjectionMap for the given schema, table, and alias.
 func NewProjectionMap(schema, table, alias string) *ProjectionMap {
 	return &ProjectionMap{
-		schema:     schema,
-		table:      table,
-		alias:      alias,
-		columns:    make(map[string]string),
-		columnList: make([]string, 0),
+		schema:       schema,
+		table:        table,
+		alias:        alias,
+		currentAlias: alias,
+		columns:      make(map[string]string),
+		columnList:   make([]string, 0),
+		joins:        make(map[string]JoinClause),
 	}
 }
 
 // Project adds a column mapping from database column to view property name.
 func (p *ProjectionMap) Project(column, viewName string) *ProjectionMap {
-	qualified := fmt.Sprintf("%s.%s", p.alias, column)
+	qualified := fmt.Sprintf("%s.%s", p.currentAlias, column)
 	p.columns[viewName] = qualified
 	p.columnList = append(p.columnList, qualified)
+	return p
+}
+
+// Join adds a JOIN clause and switches the projection context to the joined table.
+// Subsequent Project calls map columns to the joined table's alias.
+func (p *ProjectionMap) Join(schema, table, alias, joinType, on string) *ProjectionMap {
+	p.joins[alias] = JoinClause{
+		Index:    len(p.joins),
+		JoinType: joinType,
+		Schema:   schema,
+		Table:    table,
+		Alias:    alias,
+		On:       on,
+	}
+	p.currentAlias = alias
 	return p
 }
 
 // Alias returns the table alias.
 func (p *ProjectionMap) Alias() string {
 	return p.alias
+}
+
+// From returns the full FROM clause including the base table and all JOIN clauses.
+// When no joins exist, this returns the same value as Table().
+func (p *ProjectionMap) From() string {
+	joins := p.Joins()
+	if len(joins) == 0 {
+		return p.Table()
+	}
+
+	var b strings.Builder
+	b.WriteString(p.Table())
+	for _, j := range joins {
+		fmt.Fprintf(
+			&b, " %s %s.%s %s ON %s",
+			j.JoinType,
+			j.Schema,
+			j.Table,
+			j.Alias,
+			j.On,
+		)
+	}
+	return b.String()
+}
+
+// Joins returns all join clauses sorted by insertion order.
+func (p *ProjectionMap) Joins() []JoinClause {
+	return slices.SortedFunc(maps.Values(p.joins), func(a, b JoinClause) int {
+		return a.Index - b.Index
+	})
 }
 
 // Table returns the fully qualified table reference with alias (schema.table alias).


### PR DESCRIPTION
## Summary

Extend the query builder with JOIN support using a context-switching ProjectionMap pattern adapted from S2VA, and update the documents domain to include classification metadata via LEFT JOIN. This enables the web client to display and filter documents alongside their classification status, confidence, and timestamp.

Closes #53

## Changes

- Add `JoinClause` type with `Index` field for ordered iteration of `map[string]JoinClause` via `slices.SortedFunc(maps.Values(...))`
- Add `Join()` method on `ProjectionMap` — stores join clause and switches `currentAlias` so subsequent `Project()` calls map to the joined table
- Add `Joins()` accessor returning `[]JoinClause` sorted by insertion order
- Add `From()` method composing `Table()` with all JOIN clauses (backward compatible — returns `Table()` when no joins)
- Update all 5 `Builder` methods (`Build`, `BuildCount`, `BuildPage`, `BuildSingle`, `BuildSingleOrNull`) to use `From()` instead of `Table()`
- Extend `Document` struct with nullable `Classification`, `Confidence`, `ClassifiedAt` fields populated via LEFT JOIN
- Add `classification` and `confidence` filter parameters to document queries
- Add 10 JOIN tests covering projection, context switching, ordering, and builder integration
- Update API Cartographer docs with new filter parameters