### PR TITLE
pkg/web/ template and static file infrastructure

### DIFF
--- a/.claude/context/guides/.archive/62-pkg-web-infrastructure.md
+++ b/.claude/context/guides/.archive/62-pkg-web-infrastructure.md
@@ -1,0 +1,220 @@
+# 62 — pkg/web/ Template and Static File Infrastructure
+
+## Problem Context
+
+The web app module (#64) needs Go-side infrastructure for template rendering, static file serving, and SPA routing. The `pkg/web/` package provides these capabilities, ported from the proven `~/code/agent-lab/pkg/web/` patterns.
+
+## Architecture Approach
+
+Direct port of three files from agent-lab with Herald's module path. The existing `pkg/web/doc.go` placeholder is removed. Herald's `pkg/routes` package already has the `Route` type needed by `static.go`.
+
+## Implementation
+
+### Step 1: Remove placeholder
+
+Delete `pkg/web/doc.go`.
+
+### Step 2: Create `pkg/web/views.go`
+
+```go
+package web
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+)
+
+type ViewDef struct {
+	Route    string
+	Template string
+	Title    string
+	Bundle   string
+}
+
+type ViewData struct {
+	Title    string
+	Bundle   string
+	BasePath string
+	Data     any
+}
+
+type TemplateSet struct {
+	views    map[string]*template.Template
+	basePath string
+}
+
+func NewTemplateSet(layoutFS, viewFS embed.FS, layoutGlob, viewSubdir, basePath string, views []ViewDef) (*TemplateSet, error) {
+	layouts, err := template.ParseFS(layoutFS, layoutGlob)
+	if err != nil {
+		return nil, err
+	}
+
+	viewSub, err := fs.Sub(viewFS, viewSubdir)
+	if err != nil {
+		return nil, err
+	}
+
+	viewTemplates := make(map[string]*template.Template, len(views))
+	for _, p := range views {
+		t, err := layouts.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("clone layouts for %s: %w", p.Template, err)
+		}
+		_, err = t.ParseFS(viewSub, p.Template)
+		if err != nil {
+			return nil, fmt.Errorf("parse template: %s: %w", p.Template, err)
+		}
+		viewTemplates[p.Template] = t
+	}
+
+	return &TemplateSet{
+		views:    viewTemplates,
+		basePath: basePath,
+	}, nil
+}
+
+func (ts *TemplateSet) ErrorHandler(layout string, view ViewDef, status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		data := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+		}
+		if err := ts.Render(w, layout, view.Template, data); err != nil {
+			http.Error(w, http.StatusText(status), status)
+		}
+	}
+}
+
+func (ts *TemplateSet) PageHandler(layout string, view ViewDef) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+		}
+		if err := ts.Render(w, layout, view.Template, data); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func (ts *TemplateSet) Render(w http.ResponseWriter, layoutName, viewPath string, data ViewData) error {
+	t, ok := ts.views[viewPath]
+	if !ok {
+		return fmt.Errorf("template not found: %s", viewPath)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	return t.ExecuteTemplate(w, layoutName, data)
+}
+```
+
+### Step 3: Create `pkg/web/static.go`
+
+```go
+package web
+
+import (
+	"bytes"
+	"embed"
+	"io/fs"
+	"net/http"
+	"time"
+
+	"github.com/JaimeStill/herald/pkg/routes"
+)
+
+func DistServer(fsys embed.FS, subdir, urlPrefix string) http.HandlerFunc {
+	sub, err := fs.Sub(fsys, subdir)
+	if err != nil {
+		panic("failed to create sub-filesystem: " + err.Error())
+	}
+	server := http.StripPrefix(urlPrefix, http.FileServer(http.FS(sub)))
+	return func(w http.ResponseWriter, r *http.Request) {
+		server.ServeHTTP(w, r)
+	}
+}
+
+func PublicFile(fsys embed.FS, subdir, filename string) http.HandlerFunc {
+	path := subdir + "/" + filename
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := fsys.ReadFile(path)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeContent(w, r, filename, time.Time{}, bytes.NewReader(data))
+	}
+}
+
+func PublicFileRoutes(fsys embed.FS, subdir string, files ...string) []routes.Route {
+	routeList := make([]routes.Route, len(files))
+	for i, file := range files {
+		routeList[i] = routes.Route{
+			Method:  "GET",
+			Pattern: "/" + file,
+			Handler: PublicFile(fsys, subdir, file),
+		}
+	}
+	return routeList
+}
+
+func ServeEmbeddedFile(data []byte, contentType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}
+}
+```
+
+### Step 4: Create `pkg/web/router.go`
+
+```go
+package web
+
+import "net/http"
+
+type Router struct {
+	mux      *http.ServeMux
+	fallback http.HandlerFunc
+}
+
+func NewRouter() *Router {
+	return &Router{mux: http.NewServeMux()}
+}
+
+func (r *Router) SetFallback(handler http.HandlerFunc) {
+	r.fallback = handler
+}
+
+func (r *Router) Handle(pattern string, handler http.Handler) {
+	r.mux.Handle(pattern, handler)
+}
+
+func (r *Router) HandleFunc(pattern string, handler http.HandlerFunc) {
+	r.mux.HandleFunc(pattern, handler)
+}
+
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_, pattern := r.mux.Handler(req)
+	if pattern == "" && r.fallback != nil {
+		r.fallback.ServeHTTP(w, req)
+		return
+	}
+	r.mux.ServeHTTP(w, req)
+}
+```
+
+## Validation Criteria
+
+- [ ] `pkg/web/doc.go` placeholder removed
+- [ ] `pkg/web/views.go` compiles with `TemplateSet`, `ViewDef`, `ViewData`, `NewTemplateSet()`, `PageHandler()`, `ErrorHandler()`, `Render()`
+- [ ] `pkg/web/static.go` compiles with `DistServer()`, `PublicFile()`, `PublicFileRoutes()`, `ServeEmbeddedFile()`
+- [ ] `pkg/web/router.go` compiles with `Router`, `NewRouter()`, `SetFallback()`, `Handle()`, `HandleFunc()`, `ServeHTTP()`
+- [ ] `go vet ./...` passes
+- [ ] `go build ./...` compiles cleanly

--- a/.claude/context/sessions/62-pkg-web-infrastructure.md
+++ b/.claude/context/sessions/62-pkg-web-infrastructure.md
@@ -1,0 +1,33 @@
+# 62 — pkg/web/ Template and Static File Infrastructure
+
+## Summary
+
+Ported the `pkg/web/` package from agent-lab to Herald, providing template pre-parsing, static file serving, and SPA-compatible routing. Removed the placeholder `doc.go` and created three files: `views.go`, `static.go`, and `router.go`.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Port approach | Direct port with import path change only | agent-lab patterns are proven; the issue explicitly calls for this approach |
+| Test scope | Router, ServeEmbeddedFile, type construction | TemplateSet/DistServer/PublicFile require embed.FS which can't be constructed in tests; real integration tested when web/app uses the package |
+
+## Files Modified
+
+- `pkg/web/doc.go` — removed (placeholder)
+- `pkg/web/views.go` — created (TemplateSet, ViewDef, ViewData, NewTemplateSet, PageHandler, ErrorHandler, Render)
+- `pkg/web/static.go` — created (DistServer, PublicFile, PublicFileRoutes, ServeEmbeddedFile)
+- `pkg/web/router.go` — created (Router, NewRouter, SetFallback, Handle, HandleFunc, ServeHTTP)
+- `tests/web/router_test.go` — created (4 tests)
+- `tests/web/views_test.go` — created (2 tests)
+- `tests/web/static_test.go` — created (2 tests)
+
+## Patterns Established
+
+- `pkg/web/` is the Go-side web infrastructure package — template rendering, static assets, and routing live here
+- Package doc comment is on `views.go` (the primary file) since `doc.go` was removed
+
+## Validation Results
+
+- `go vet ./...` passes
+- `go build ./...` compiles cleanly
+- All 19 test packages pass (8 web tests added)

--- a/.claude/plans/transient-stirring-kahan.md
+++ b/.claude/plans/transient-stirring-kahan.md
@@ -1,0 +1,30 @@
+# 62 — pkg/web/ Template and Static File Infrastructure
+
+## Context
+
+Issue #62 is the first sub-issue of Objective #57 (Web Client Foundation). It establishes the Go-side web infrastructure that the web app module (#64) will depend on. The `pkg/web/` package provides template pre-parsing, static file serving, and a router wrapper — all ported from the proven `~/code/agent-lab/pkg/web/` package.
+
+## Approach
+
+Direct port of three files from agent-lab with Herald-specific import path adjustments. The API surface, behavior, and structure remain identical — agent-lab's patterns are proven and Herald's issue explicitly calls for this approach.
+
+## Files
+
+### Remove
+- `pkg/web/doc.go` — placeholder, replaced by the real package
+
+### Create
+- **`pkg/web/views.go`** — `TemplateSet` (pre-parsed template cache with layout inheritance), `ViewDef`, `ViewData`, `PageHandler()`, `ErrorHandler()`, `Render()`
+- **`pkg/web/static.go`** — `DistServer()`, `PublicFile()`, `PublicFileRoutes()`, `ServeEmbeddedFile()`
+- **`pkg/web/router.go`** — `Router` wrapper around `http.ServeMux` with optional fallback handler
+
+### Adaptations from agent-lab
+1. **Import path**: `github.com/JaimeStill/agent-lab/pkg/routes` → `github.com/JaimeStill/herald/pkg/routes`
+2. **No godoc comments** in the guide (added in Phase 7)
+3. Herald's `pkg/routes/route.go` already has the identical `Route` type — no changes needed there
+
+## Verification
+
+- `go vet ./...` passes
+- `go build ./...` compiles cleanly
+- Package is importable and types are accessible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.57.62
+- Add `pkg/web/` template and static file infrastructure — TemplateSet with layout inheritance, embedded filesystem serving, and SPA-compatible router with fallback (#62)
+
 ## v0.2.0
 
 ### Agent Configuration

--- a/pkg/web/doc.go
+++ b/pkg/web/doc.go
@@ -1,1 +1,0 @@
-package web

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -1,0 +1,40 @@
+package web
+
+import "net/http"
+
+// Router wraps http.ServeMux with optional fallback handling for unmatched routes.
+// Use SetFallback to configure SPA catch-all behavior.
+type Router struct {
+	mux      *http.ServeMux
+	fallback http.HandlerFunc
+}
+
+// NewRouter creates a Router with default ServeMux behavior.
+func NewRouter() *Router {
+	return &Router{mux: http.NewServeMux()}
+}
+
+// SetFallback configures the handler for unmatched routes.
+func (r *Router) SetFallback(handler http.HandlerFunc) {
+	r.fallback = handler
+}
+
+// Handle registers a handler for the given pattern.
+func (r *Router) Handle(pattern string, handler http.Handler) {
+	r.mux.Handle(pattern, handler)
+}
+
+// HandleFunc registers a handler function for the given pattern.
+func (r *Router) HandleFunc(pattern string, handler http.HandlerFunc) {
+	r.mux.HandleFunc(pattern, handler)
+}
+
+// ServeHTTP implements http.Handler with optional fallback for unmatched routes.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_, pattern := r.mux.Handler(req)
+	if pattern == "" && r.fallback != nil {
+		r.fallback.ServeHTTP(w, req)
+		return
+	}
+	r.mux.ServeHTTP(w, req)
+}

--- a/pkg/web/static.go
+++ b/pkg/web/static.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"bytes"
+	"embed"
+	"io/fs"
+	"net/http"
+	"time"
+
+	"github.com/JaimeStill/herald/pkg/routes"
+)
+
+// DistServer returns a handler that serves files from an embedded filesystem.
+// It strips the URL prefix and serves from the specified subdirectory.
+func DistServer(fsys embed.FS, subdir, urlPrefix string) http.HandlerFunc {
+	sub, err := fs.Sub(fsys, subdir)
+	if err != nil {
+		panic("failed to create sub-filesystem: " + err.Error())
+	}
+	server := http.StripPrefix(urlPrefix, http.FileServer(http.FS(sub)))
+	return func(w http.ResponseWriter, r *http.Request) {
+		server.ServeHTTP(w, r)
+	}
+}
+
+// PublicFile returns a handler that serves a single file from an embedded filesystem.
+func PublicFile(fsys embed.FS, subdir, filename string) http.HandlerFunc {
+	path := subdir + "/" + filename
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := fsys.ReadFile(path)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeContent(w, r, filename, time.Time{}, bytes.NewReader(data))
+	}
+}
+
+// PublicFileRoutes generates routes for serving multiple files at root-level URLs.
+func PublicFileRoutes(fsys embed.FS, subdir string, files ...string) []routes.Route {
+	routeList := make([]routes.Route, len(files))
+	for i, file := range files {
+		routeList[i] = routes.Route{
+			Method:  "GET",
+			Pattern: "/" + file,
+			Handler: PublicFile(fsys, subdir, file),
+		}
+	}
+	return routeList
+}
+
+// ServeEmbeddedFile returns a handler that serves raw bytes with the specified content type.
+func ServeEmbeddedFile(data []byte, contentType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}
+}

--- a/pkg/web/views.go
+++ b/pkg/web/views.go
@@ -1,0 +1,108 @@
+// Package web provides infrastructure for serving web pages with Go templates,
+// embedded static assets, and SPA-compatible routing.
+package web
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+)
+
+// ViewDef defines a page with its route, template file, title, and bundle name.
+type ViewDef struct {
+	Route    string
+	Template string
+	Title    string
+	Bundle   string
+}
+
+// ViewData contains the data passed to page templates during rendering.
+// BasePath enables portable URL generation in templates via {{ .BasePath }}.
+type ViewData struct {
+	Title    string
+	Bundle   string
+	BasePath string
+	Data     any
+}
+
+// TemplateSet holds pre-parsed templates and a base path for URL generation.
+// Templates are parsed once at startup, avoiding per-request overhead.
+type TemplateSet struct {
+	views    map[string]*template.Template
+	basePath string
+}
+
+// NewTemplateSet creates a TemplateSet by parsing layout templates and cloning
+// them for each view. The basePath is automatically included in ViewData for all
+// handlers. Pre-parsing at startup enables fail-fast behavior and eliminates
+// per-request template parsing overhead.
+func NewTemplateSet(layoutFS, viewFS embed.FS, layoutGlob, viewSubdir, basePath string, views []ViewDef) (*TemplateSet, error) {
+	layouts, err := template.ParseFS(layoutFS, layoutGlob)
+	if err != nil {
+		return nil, err
+	}
+
+	viewSub, err := fs.Sub(viewFS, viewSubdir)
+	if err != nil {
+		return nil, err
+	}
+
+	viewTemplates := make(map[string]*template.Template, len(views))
+	for _, p := range views {
+		t, err := layouts.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("clone layouts for %s: %w", p.Template, err)
+		}
+		_, err = t.ParseFS(viewSub, p.Template)
+		if err != nil {
+			return nil, fmt.Errorf("parse template: %s: %w", p.Template, err)
+		}
+		viewTemplates[p.Template] = t
+	}
+
+	return &TemplateSet{
+		views:    viewTemplates,
+		basePath: basePath,
+	}, nil
+}
+
+// ErrorHandler returns an HTTP handler that renders an error page with the given status code.
+func (ts *TemplateSet) ErrorHandler(layout string, view ViewDef, status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		data := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+		}
+		if err := ts.Render(w, layout, view.Template, data); err != nil {
+			http.Error(w, http.StatusText(status), status)
+		}
+	}
+}
+
+// PageHandler returns an HTTP handler that renders the given view.
+func (ts *TemplateSet) PageHandler(layout string, view ViewDef) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+		}
+		if err := ts.Render(w, layout, view.Template, data); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+// Render executes the named layout template with the given view data.
+func (ts *TemplateSet) Render(w http.ResponseWriter, layoutName, viewPath string, data ViewData) error {
+	t, ok := ts.views[viewPath]
+	if !ok {
+		return fmt.Errorf("template not found: %s", viewPath)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	return t.ExecuteTemplate(w, layoutName, data)
+}

--- a/tests/web/router_test.go
+++ b/tests/web/router_test.go
@@ -1,0 +1,72 @@
+package web_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+func TestRouterRegisteredRoute(t *testing.T) {
+	r := web.NewRouter()
+	r.HandleFunc("GET /hello", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/hello", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("registered route: got %d, want 200", rec.Code)
+	}
+}
+
+func TestRouterFallback(t *testing.T) {
+	r := web.NewRouter()
+	r.HandleFunc("GET /known", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.SetFallback(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/unknown", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("fallback: got %d, want %d", rec.Code, http.StatusTeapot)
+	}
+}
+
+func TestRouterNoFallback(t *testing.T) {
+	r := web.NewRouter()
+	r.HandleFunc("GET /known", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/unknown", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("no fallback: got %d, want 404", rec.Code)
+	}
+}
+
+func TestRouterHandle(t *testing.T) {
+	r := web.NewRouter()
+	r.Handle("GET /mux", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/mux", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("Handle: got %d, want %d", rec.Code, http.StatusAccepted)
+	}
+}

--- a/tests/web/static_test.go
+++ b/tests/web/static_test.go
@@ -1,0 +1,62 @@
+package web_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+func TestServeEmbeddedFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		contentType string
+	}{
+		{"json", []byte(`{"ok":true}`), "application/json"},
+		{"html", []byte(`<h1>hello</h1>`), "text/html"},
+		{"plain", []byte("hello"), "text/plain"},
+		{"empty", []byte{}, "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := web.ServeEmbeddedFile(tt.data, tt.contentType)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/file", nil)
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status: got %d, want 200", rec.Code)
+			}
+
+			ct := rec.Header().Get("Content-Type")
+			if ct != tt.contentType {
+				t.Errorf("content-type: got %q, want %q", ct, tt.contentType)
+			}
+
+			if rec.Body.String() != string(tt.data) {
+				t.Errorf("body: got %q, want %q", rec.Body.String(), string(tt.data))
+			}
+		})
+	}
+}
+
+func TestServeEmbeddedFileHeaders(t *testing.T) {
+	data := []byte("test content")
+	handler := web.ServeEmbeddedFile(data, "text/css")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/style.css", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Type") != "text/css" {
+		t.Errorf("content-type: got %q, want %q", rec.Header().Get("Content-Type"), "text/css")
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+}

--- a/tests/web/views_test.go
+++ b/tests/web/views_test.go
@@ -1,0 +1,51 @@
+package web_test
+
+import (
+	"testing"
+
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+func TestViewDefFields(t *testing.T) {
+	view := web.ViewDef{
+		Route:    "/",
+		Template: "index.html",
+		Title:    "Home",
+		Bundle:   "app",
+	}
+
+	if view.Route != "/" {
+		t.Errorf("Route: got %q, want %q", view.Route, "/")
+	}
+	if view.Template != "index.html" {
+		t.Errorf("Template: got %q, want %q", view.Template, "index.html")
+	}
+	if view.Title != "Home" {
+		t.Errorf("Title: got %q, want %q", view.Title, "Home")
+	}
+	if view.Bundle != "app" {
+		t.Errorf("Bundle: got %q, want %q", view.Bundle, "app")
+	}
+}
+
+func TestViewDataFields(t *testing.T) {
+	data := web.ViewData{
+		Title:    "Test",
+		Bundle:   "app",
+		BasePath: "/app",
+		Data:     map[string]string{"key": "value"},
+	}
+
+	if data.Title != "Test" {
+		t.Errorf("Title: got %q, want %q", data.Title, "Test")
+	}
+	if data.BasePath != "/app" {
+		t.Errorf("BasePath: got %q, want %q", data.BasePath, "/app")
+	}
+	if data.Bundle != "app" {
+		t.Errorf("Bundle: got %q, want %q", data.Bundle, "app")
+	}
+	if data.Data == nil {
+		t.Error("Data: got nil, want non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

Port `pkg/web/` from agent-lab to provide Go-side web infrastructure for the embedded Lit SPA. Establishes template pre-parsing, static file serving, and SPA-compatible routing that the web app module (#64) depends on.

Closes #62

## Changes

- **`pkg/web/views.go`** — `TemplateSet` with layout inheritance, `ViewDef`/`ViewData` types, `PageHandler()`/`ErrorHandler()`/`Render()` methods
- **`pkg/web/static.go`** — `DistServer()`, `PublicFile()`, `PublicFileRoutes()`, `ServeEmbeddedFile()` for embedded filesystem serving
- **`pkg/web/router.go`** — `Router` wrapper around `http.ServeMux` with optional fallback handler for SPA catch-all
- Remove `pkg/web/doc.go` placeholder
- Add 8 unit tests covering router behavior, type construction, and embedded file serving