### PR TITLE
Add Go web app module, server integration, and dev experience

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,23 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+bin = "./bin/server"
+cmd = "go build -o ./bin/server ./cmd/server"
+delay = 1000
+exclude_dir = [
+  "app/client",
+  "app/scripts",
+  "app/plugins",
+  "app/node_modules"
+]
+include_dir = ["cmd", "internal", "pkg", "app"]
+include_ext = ["go", "html", "js", "css"]
+kill_delay = 500
+send_interrupt = true
+
+[log]
+time = false
+
+[misc]
+clean_on_exit = true

--- a/.claude/context/guides/.archive/64-go-web-app-module.md
+++ b/.claude/context/guides/.archive/64-go-web-app-module.md
@@ -1,0 +1,220 @@
+# 64 — Go Web App Module, Server Integration, and Dev Experience
+
+## Problem Context
+
+The web client foundation (#57) has two completed dependencies: `pkg/web/` (#62) provides Go-side template/asset serving infrastructure, and the client build system (#63) delivers a Lit 3.x SPA at `app/` with bundled output in `app/dist/`. This issue wires the two together — embedding built assets in the Go binary, serving the SPA shell via templates, mounting the app module alongside the API, and configuring the two-terminal dev workflow (Bun watch + Air).
+
+## Architecture Approach
+
+Follow agent-lab's `web/app/app.go` pattern directly. The `app/` directory becomes a Go package (`package app`) that embeds its own `dist/` and `server/` subdirectories. A single `NewModule(basePath)` factory creates a `*module.Module` that the server mounts at `/app`. All routes under `/app/*` fall through to the SPA shell template — the client-side History API router handles view switching.
+
+Key adaptation from agent-lab: no `public/` embed (no favicon assets yet), and use `web.DistServer()` helper from `pkg/web/static.go` instead of raw `http.FileServer`.
+
+## Implementation
+
+### Step 1: Create `app/server/layouts/app.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <base href="{{ .BasePath }}/">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ .Title }} - Herald</title>
+  <link rel="stylesheet" href="dist/{{ .Bundle }}.css">
+</head>
+
+<body>
+  <header class="app-header">
+    <a href="" class="brand">Herald</a>
+    <nav>
+      <a href="">Documents</a>
+      <a href="prompts">Prompts</a>
+    </nav>
+  </header>
+  <main id="app-content">
+    {{ block "content" . }}{{ end }}
+  </main>
+
+  <script type="module" src="dist/{{ .Bundle }}.js"></script>
+</body>
+
+</html>
+```
+
+Nav links use relative URLs (resolved against `<base href>`). Review view is omitted from nav — accessed via document cards.
+
+### Step 2: Create `app/server/views/shell.html`
+
+```
+{{ define "content" }}{{ end }}
+```
+
+Empty content block. The client-side router mounts Lit components into `#app-content`.
+
+### Step 3: Create `app/app.go`
+
+```go
+package app
+
+import (
+	"embed"
+	"net/http"
+
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+//go:embed dist/*
+var distFS embed.FS
+
+//go:embed server/layouts/*
+var layoutFS embed.FS
+
+//go:embed server/views/*
+var viewFS embed.FS
+
+var views = []web.ViewDef{
+	{Route: "/{path...}", Template: "shell.html", Title: "Herald", Bundle: "app"},
+}
+
+func NewModule(basePath string) (*module.Module, error) {
+	ts, err := web.NewTemplateSet(
+		layoutFS,
+		viewFS,
+		"server/layouts/*.html",
+		"server/views",
+		basePath,
+		views,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	router := buildRouter(ts)
+	return module.New(basePath, router), nil
+}
+
+func buildRouter(ts *web.TemplateSet) http.Handler {
+	r := web.NewRouter()
+
+	r.Handle("GET /dist/", web.DistServer(distFS, "dist", "/dist/"))
+	r.SetFallback(ts.PageHandler("app.html", views[0]))
+
+	return r
+}
+```
+
+Key decisions:
+- `/dist/` route registered first as a concrete match, fallback catches everything else (SPA catch-all)
+- Uses `web.DistServer` for static asset serving with proper prefix stripping
+- Uses `r.SetFallback` instead of registering `/{path...}` — the `web.Router` fallback mechanism handles unmatched routes cleanly
+
+### Step 4: Modify `cmd/server/modules.go`
+
+Add `app` import and `App` field to `Modules` struct. Create and mount the app module.
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/JaimeStill/herald/app"
+	"github.com/JaimeStill/herald/internal/api"
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/module"
+)
+
+type Modules struct {
+	API *module.Module
+	App *module.Module
+}
+
+func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modules, error) {
+	apiModule, err := api.NewModule(cfg, infra)
+	if err != nil {
+		return nil, err
+	}
+
+	appModule, err := app.NewModule("/app")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Modules{
+		API: apiModule,
+		App: appModule,
+	}, nil
+}
+
+func (m *Modules) Mount(router *module.Router) {
+	router.Mount(m.API)
+	router.Mount(m.App)
+}
+```
+
+The `buildRouter` function is unchanged — omitted for brevity.
+
+### Step 5: Create `.air.toml`
+
+**Pre-requisite:** Install Air as a global Go binary:
+
+```bash
+go install github.com/air-verse/air@latest
+```
+
+```toml
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./bin/server"
+  cmd = "go build -o ./bin/server ./cmd/server"
+  delay = 1000
+  exclude_dir = ["bin", "tmp", "node_modules", "app/client", "app/scripts", "app/plugins", "app/node_modules", "tests", "_project", ".claude"]
+  exclude_regex = ["_test\\.go$"]
+  include_dir = ["cmd", "internal", "pkg", "app"]
+  include_ext = ["go", "html", "js", "css"]
+  kill_delay = 500
+  send_interrupt = true
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = true
+```
+
+Watch scope includes `app/` (catches `app.go`, `server/` templates, and `dist/` output). Excludes client source directories since Bun handles those — only the build output (`dist/`) triggers a Go rebuild.
+
+### Step 6: Modify `.mise.toml`
+
+Add two tasks at the end of the file:
+
+```toml
+[tasks."web:build"]
+description = "Build the web client"
+run = "cd app && bun run build"
+
+[tasks."web:watch"]
+description = "Watch and rebuild the web client"
+run = "cd app && bun run watch"
+```
+
+## Validation Criteria
+
+- [ ] `go build ./cmd/server` compiles with embedded web assets
+- [ ] `go vet ./...` passes
+- [ ] `GET /app/` serves HTML shell with `<base href="/app/">`, CSS link, JS script
+- [ ] `GET /app/dist/app.js` serves bundled JavaScript with correct MIME type
+- [ ] `GET /app/dist/app.css` serves extracted global CSS
+- [ ] Client-side routing works for `/app/`, `/app/prompts`, `/app/review/test-id`
+- [ ] Unmatched `/app/foo` routes fall through to shell template (SPA fallback)
+- [ ] API module continues to work at `/api/*` alongside web app at `/app/*`
+- [ ] `mise run web:build` and `mise run web:watch` tasks work
+- [ ] Air rebuilds Go server when `app/dist/` files change

--- a/.claude/context/sessions/64-go-web-app-module.md
+++ b/.claude/context/sessions/64-go-web-app-module.md
@@ -1,0 +1,37 @@
+# 64 — Go Web App Module, Server Integration, and Dev Experience
+
+## Summary
+
+Wired the Go web app module that embeds and serves the Lit 3.x client built in #63, using the `pkg/web/` infrastructure from #62. The app module mounts at `/app` alongside the existing API module at `/api`. Configured Air for Go hot reload and added mise tasks for the two-terminal dev workflow.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Static asset serving | `web.DistServer()` helper | Reuses existing `pkg/web/static.go` infrastructure instead of raw `http.FileServer` |
+| SPA fallback | `web.Router.SetFallback()` | Cleaner than registering `/{path...}` — uses the built-in unmatched route mechanism |
+| No public/ embed | Omitted | Herald has no favicon/manifest assets yet — can add later without structural changes |
+| Air exclude strategy | `exclude_dir` for client subdirs | `include_dir` only supports top-level dirs; excluding `app/client`, `app/scripts`, `app/plugins`, `app/node_modules` prevents unnecessary Go rebuilds on client source changes |
+
+## Files Modified
+
+- `app/app.go` — Created: Go embedding module with `NewModule` factory
+- `app/server/layouts/app.html` — Created: HTML shell template with base href, nav, content container
+- `app/server/views/shell.html` — Created: Empty content block for client-side routing
+- `cmd/server/modules.go` — Modified: Added App module creation and mounting
+- `.air.toml` — Created: Air hot reload configuration
+- `.mise.toml` — Modified: Added `web:build` and `web:watch` tasks
+- `tests/app/app_test.go` — Created: Tests for module creation, template rendering, asset serving, SPA fallback
+
+## Patterns Established
+
+- **Web app module pattern**: `app/app.go` with `//go:embed` directives + `NewModule(basePath)` factory, `app/server/layouts/` for Go HTML templates, `app/server/views/` for content blocks
+- **Two-terminal dev workflow**: `bun run watch` (client rebuild) + `air` (Go rebuild on dist/ changes)
+- **Module.Serve test pattern**: Tests must include the module prefix in request URLs (e.g., `/app/dist/app.js` not `/dist/app.js`) since `Module.Serve` strips the prefix
+
+## Validation Results
+
+- `go build ./cmd/server` — compiles successfully
+- `go vet ./...` — passes
+- `go test ./tests/...` — 20/20 packages pass (4 new app tests)
+- Manual verification: shell template renders at `/app/`, static assets serve, SPA fallback works, Air hot reload triggers on `dist/` changes

--- a/.claude/plans/eager-watching-flurry.md
+++ b/.claude/plans/eager-watching-flurry.md
@@ -1,0 +1,91 @@
+# 64 — Go Web App Module, Server Integration, and Dev Experience
+
+## Context
+
+Issue #64 is the integration layer for the web client foundation (#57). Dependencies #62 (`pkg/web/`) and #63 (client build + design + app) are merged. The client lives at `app/` with built output in `app/dist/` (`app.js`, `app.css`). The `pkg/web/` infrastructure (TemplateSet, Router, DistServer) is ready. This issue wires the Go embedding, HTML shell template, server module mounting, and Air/mise dev workflow.
+
+## Implementation
+
+### Step 1: HTML Shell Template — `app/server/layouts/app.html`
+
+New file. Go HTML template serving as the SPA shell. Adapted from agent-lab's `web/app/server/layouts/app.html`:
+
+- `<base href="{{ .BasePath }}/">` for portable URL generation
+- `<link>` to `dist/{{ .Bundle }}.css`
+- App header with nav links matching client routes: Documents (default `/app/`), Prompts (`/app/prompts`), Review omitted from nav (accessed via document cards)
+- `<main id="app-content">` container — client router mounts views here
+- `<script type="module">` for `dist/{{ .Bundle }}.js`
+- No favicon/public files (Herald doesn't have them yet — can add later)
+
+### Step 2: Shell View Template — `app/server/views/shell.html`
+
+New file. Empty content block — client-side router takes over:
+```
+{{ define "content" }}{{ end }}
+```
+
+### Step 3: Go Embedding Module — `app/app.go`
+
+New file. `package app` — follows agent-lab's `web/app/app.go` pattern:
+
+- `//go:embed dist/*` — bundled JS/CSS
+- `//go:embed server/layouts/*` — layout templates
+- `//go:embed server/views/*` — view templates
+- Single `ViewDef`: catch-all `/{path...}` → `shell.html`, title "Herald", bundle "app"
+- `NewModule(basePath string) (*module.Module, error)`:
+  1. Create `TemplateSet` from embedded layouts/views
+  2. Build `web.Router` with catch-all page handler + `/dist/` file server
+  3. Return `module.New(basePath, router)`
+- No `public/` embed (no favicon assets yet)
+
+Key difference from agent-lab: no `publicFS`/`publicFiles` since Herald doesn't have favicon files. The `DistServer` call uses `web.DistServer(distFS, "dist", "/dist/")` rather than agent-lab's raw `http.FileServer` — uses the existing helper from `pkg/web/static.go`.
+
+### Step 4: Server Integration — `cmd/server/modules.go`
+
+Modify existing file:
+
+- Add `App *module.Module` to `Modules` struct
+- In `NewModules()`: create app module via `app.NewModule("/app")`
+- In `Mount()`: mount `m.App` alongside `m.API`
+- Add import for `"github.com/JaimeStill/herald/app"`
+
+### Step 5: Air Configuration — `.air.toml`
+
+New file. Configures Air for Go hot reload:
+
+- **Watch**: `cmd/`, `internal/`, `pkg/`, `app/dist/`, `app/server/`, `app/app.go`
+- **Exclude**: `app/client/`, `app/scripts/`, `app/plugins/`, `app/node_modules/`
+- **Build command**: `go build -o ./bin/server ./cmd/server`
+- **Run binary**: `./bin/server`
+- **Extensions**: `.go`, `.html`, `.js`, `.css`
+
+### Step 6: Mise Tasks — `.mise.toml`
+
+Add two tasks to existing file:
+
+- `web:build` — `cd app && bun run build`
+- `web:watch` — `cd app && bun run watch`
+
+## Files
+
+| File | Action |
+|------|--------|
+| `app/server/layouts/app.html` | Create |
+| `app/server/views/shell.html` | Create |
+| `app/app.go` | Create |
+| `cmd/server/modules.go` | Modify |
+| `.air.toml` | Create |
+| `.mise.toml` | Modify |
+
+## Validation Criteria
+
+- `go build ./cmd/server` compiles with embedded web assets
+- `go vet ./...` passes
+- `GET /app/` serves HTML shell with correct `<base href>`, CSS, and JS references
+- `GET /app/dist/app.js` serves bundled JavaScript
+- `GET /app/dist/app.css` serves extracted global CSS
+- Client-side routing works for `/app/`, `/app/prompts`, `/app/review/:id`
+- Unmatched `/app/*` routes fall through to shell template (SPA fallback)
+- API module continues to work at `/api/*`
+- `mise run web:build` and `mise run web:watch` tasks work
+- Air rebuilds Go server when `app/dist/` files change

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,3 @@
-#:tombi schema.strict = false
-
 [tasks.dev]
 description = "Run the server in development mode"
 run = "go run ./cmd/server"
@@ -27,3 +25,11 @@ run = "go run ./cmd/migrate -down"
 [tasks."migrate:version"]
 description = "Print current migration version"
 run = "go run ./cmd/migrate -version"
+
+[tasks."web:build"]
+description = "Build the web client"
+run = "cd app && bun run build"
+
+[tasks."web:watch"]
+description = "Watch and rebuild the web client"
+run = "cd app && bun run watch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.57.64
+- Add Go web app module with embedded client assets, SPA shell template, server integration alongside API module, Air hot reload configuration, and mise dev workflow tasks (#64)
+
 ## v0.3.0-dev.57.63
 - Add client-side web application foundation — Bun build pipeline with CSS module plugin (`*.module.css` → `CSSStyleSheet`), CSS cascade layer design system with dark/light theme, History API router, `Result<T>` API layer with SSE streaming, and placeholder views for all routes (#63)
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,53 @@
+// Package app provides the web application module with embedded templates and assets.
+// It serves the Lit 3.x SPA shell via Go templates and delivers bundled static assets.
+package app
+
+import (
+	"embed"
+	"net/http"
+
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+//go:embed dist/*
+var distFS embed.FS
+
+//go:embed server/layouts/*
+var layoutFS embed.FS
+
+//go:embed server/views/*
+var viewFS embed.FS
+
+var views = []web.ViewDef{
+	{Route: "/{path...}", Template: "shell.html", Title: "Herald", Bundle: "app"},
+}
+
+// NewModule creates the web app module configured for the given base path.
+// All routes under the base path serve the SPA shell template, with /dist/
+// serving embedded static assets (JS, CSS).
+func NewModule(basePath string) (*module.Module, error) {
+	ts, err := web.NewTemplateSet(
+		layoutFS,
+		viewFS,
+		"server/layouts/*.html",
+		"server/views",
+		basePath,
+		views,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	router := buildRouter(ts)
+	return module.New(basePath, router), nil
+}
+
+func buildRouter(ts *web.TemplateSet) http.Handler {
+	r := web.NewRouter()
+
+	r.Handle("GET /dist/", web.DistServer(distFS, "dist", "/dist/"))
+	r.SetFallback(ts.PageHandler("app.html", views[0]))
+
+	return r
+}

--- a/app/server/layouts/app.html
+++ b/app/server/layouts/app.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <base href="{{ .BasePath }}/">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ .Title }} - Herald</title>
+  <link rel="stylesheet" href="dist/{{ .Bundle }}.css">
+</head>
+
+<body>
+  <header class="app-header">
+    <a href="" class="brand">Herald</a>
+    <nav>
+      <a href="prompts">Prompts</a>
+    </nav>
+  </header>
+  <main id="app-content">
+    {{ block "content" . }}{{ end }}
+  </main>
+
+  <script type="module" src="dist/{{ .Bundle }}.js"></script>
+</body>
+
+</html>

--- a/app/server/views/shell.html
+++ b/app/server/views/shell.html
@@ -1,0 +1,1 @@
+{{ define "content" }}{{ end }}

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/JaimeStill/herald/app"
 	"github.com/JaimeStill/herald/internal/api"
 	"github.com/JaimeStill/herald/internal/config"
 	"github.com/JaimeStill/herald/internal/infrastructure"
@@ -12,6 +13,7 @@ import (
 
 type Modules struct {
 	API *module.Module
+	App *module.Module
 }
 
 func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modules, error) {
@@ -20,13 +22,20 @@ func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modu
 		return nil, err
 	}
 
+	appModule, err := app.NewModule("/app")
+	if err != nil {
+		return nil, err
+	}
+
 	return &Modules{
 		API: apiModule,
+		App: appModule,
 	}, nil
 }
 
 func (m *Modules) Mount(router *module.Router) {
 	router.Mount(m.API)
+	router.Mount(m.App)
 }
 
 func buildRouter(infra *infrastructure.Infrastructure) *module.Router {

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -1,0 +1,111 @@
+package app_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/JaimeStill/herald/app"
+)
+
+func TestNewModule(t *testing.T) {
+	m, err := app.NewModule("/app")
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+	if m.Prefix() != "/app" {
+		t.Errorf("prefix: got %q, want %q", m.Prefix(), "/app")
+	}
+}
+
+func TestShellTemplate(t *testing.T) {
+	m, err := app.NewModule("/app")
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/app/", nil)
+	m.Serve(rec, req)
+
+	body := rec.Body.String()
+
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"base href", `<base href="/app/">`},
+		{"css link", `dist/app.css`},
+		{"js script", `dist/app.js`},
+		{"title", `Herald`},
+		{"app content", `id="app-content"`},
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(body, check.content) {
+			t.Errorf("shell template missing %s: want %q in body", check.name, check.content)
+		}
+	}
+}
+
+func TestDistAssetServing(t *testing.T) {
+	m, err := app.NewModule("/app")
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"javascript", "/app/dist/app.js"},
+		{"css", "/app/dist/app.css"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", tt.path, nil)
+			m.Serve(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status: got %d, want 200", rec.Code)
+			}
+			if rec.Body.Len() == 0 {
+				t.Error("expected non-empty response body")
+			}
+		})
+	}
+}
+
+func TestSPAFallback(t *testing.T) {
+	m, err := app.NewModule("/app")
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+
+	paths := []string{
+		"/app/",
+		"/app/prompts",
+		"/app/review/some-doc-id",
+		"/app/unknown/nested/path",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", path, nil)
+			m.Serve(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status: got %d, want 200", rec.Code)
+			}
+
+			body := rec.Body.String()
+			if !strings.Contains(body, `<base href="/app/">`) {
+				t.Error("SPA fallback did not render shell template")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wire the Go embedding layer for the Lit 3.x SPA client alongside the existing API module. The app module at `/app` embeds `dist/` assets and `server/` templates, serves a shell HTML template with SPA fallback for client-side routing, and delivers bundled JS/CSS via `DistServer`. Configures Air hot reload and mise tasks for the two-terminal dev workflow.

Closes #64

## Changes

- `app/app.go` — Go embedding module with `NewModule("/app")` factory, `DistServer` for `/dist/`, and `SetFallback` SPA catch-all
- `app/server/layouts/app.html` — HTML shell template with `<base href>`, nav links, and content container
- `app/server/views/shell.html` — Empty content block for client-side routing
- `cmd/server/modules.go` — Mount app module alongside API module
- `.air.toml` — Air hot reload watching `cmd/`, `internal/`, `pkg/`, `app/` (excluding client source dirs)
- `.mise.toml` — Add `web:build` and `web:watch` tasks
- `tests/app/app_test.go` — Tests for module creation, template rendering, asset serving, SPA fallback