### PR TITLE
Add web development skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,6 +36,14 @@ Lower-level packages (`pkg/`) define contracts (interfaces). Higher-level packag
 
 API Cartographer maintenance is an AI responsibility. After an implementation plan is accepted, the AI generates or updates the corresponding `_project/api/<group>/README.md` and `.http` file before transitioning control to the developer. See `.claude/skills/api-cartographer/SKILL.md` for conventions.
 
+### Web Development Skill Maintenance
+
+After implementing changes that revise or enhance the web development architecture (new component patterns, service infrastructure changes, design system updates, build system modifications), update `.claude/skills/web-development/SKILL.md` and its `references/` to reflect current conventions. The skill is the source of truth for all subsequent web client work.
+
+### Frontend Design
+
+Use the `frontend-design` skill (Anthropic built-in) when planning web client view interfaces. This applies to any objective focused on building out view UIs (documents view, prompts view, review view, etc.). The frontend-design skill provides design quality guidance that complements the web-development skill's architectural patterns.
+
 ### Testing
 
 All test authorship is an AI responsibility. Tests live in `tests/` mirroring the source structure. Black-box only (`package <name>_test`). Table-driven for parameterized cases. No test code in implementation guides.

--- a/.claude/context/sessions/65-web-development-skill.md
+++ b/.claude/context/sessions/65-web-development-skill.md
@@ -1,0 +1,32 @@
+# 65 - Web Development Skill
+
+## Summary
+
+Created the Herald-specific web development Claude skill documenting Lit component patterns, service infrastructure, CSS architecture, API layer, router, build system, and Go integration conventions established by the Phase 3 foundation sub-issues (#62–#64). The skill uses progressive disclosure — a lean SKILL.md (155 lines) with 7 topic-specific reference files for detailed code examples.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Skill structure | SKILL.md + 7 reference files | Progressive disclosure keeps the always-loaded SKILL.md under 500 lines while providing full code examples on demand per topic |
+| Reference organization | By concern (components, services, css, api, router, build, go-integration) | Maps directly to architectural boundaries — when working on CSS, load the CSS reference |
+| What stays in SKILL.md | Architecture overview, naming conventions, anti-patterns, template pattern summaries | These are short, always-relevant, and needed regardless of which specific area you're working in |
+| CLAUDE.md additions | Skill maintenance responsibility + frontend-design skill reference | Ensures the skill stays current as architecture evolves, and that view interface planning uses the frontend-design skill |
+
+## Files Modified
+
+- `.claude/skills/web-development/SKILL.md` — created (155 lines)
+- `.claude/skills/web-development/references/components.md` — created (204 lines)
+- `.claude/skills/web-development/references/services.md` — created (95 lines)
+- `.claude/skills/web-development/references/css.md` — created (141 lines)
+- `.claude/skills/web-development/references/api.md` — created (128 lines)
+- `.claude/skills/web-development/references/router.md` — created (76 lines)
+- `.claude/skills/web-development/references/build.md` — created (84 lines)
+- `.claude/skills/web-development/references/go-integration.md` — created (114 lines)
+- `.claude/CLAUDE.md` — updated (added Web Development Skill Maintenance + Frontend Design under AI Responsibilities)
+
+## Patterns Established
+
+- **Skill progressive disclosure**: SKILL.md as lean overview + `references/` directory with per-concern detail files. Each reference is self-contained and loaded on demand.
+- **Skill maintenance as AI responsibility**: CLAUDE.md now mandates updating the web-development skill whenever the web architecture changes.
+- **Frontend-design skill integration**: CLAUDE.md directs use of Anthropic's frontend-design skill for view interface planning tasks.

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: web-development
+description: >
+  REQUIRED for web client development with Lit. Use when creating views,
+  components, elements, services, or styling with CSS layers.
+  Triggers: app/client/, LitElement, @customElement, @provide, @consume,
+  SignalWatcher, design/tokens, "create component", "add view", "add service".
+  File patterns: app/**/*.ts, app/**/*.css, app/**/*.go, pkg/web/*.go
+---
+
+# Web Development with Lit
+
+## When This Skill Applies
+
+- Creating or modifying web client code in `app/client/`
+- Implementing Lit components (views, stateful components, elements)
+- Working with services and context-based dependency injection
+- Styling with CSS cascade layers and design tokens
+- Integrating Go server with Lit client (`app/app.go`, `app/server/`)
+- Build system work (`app/scripts/`, `app/plugins/`)
+
+## Architecture Overview
+
+### Hard Boundary Principle
+
+**Go owns data and routing, Lit owns presentation entirely.**
+
+- Go serves a single HTML shell for all `/app/*` routes
+- Client-side router handles view mounting
+- No server-side view awareness for client routes
+
+### Three-Tier Component Hierarchy
+
+Each tier has a specific role. Violating the boundaries (e.g., a pure element directly calling an API) creates hidden dependencies that make components harder to test and reuse.
+
+| Tier | Role | Tools | Example |
+|------|------|-------|---------|
+| View | Provide services, route-level | `@provide`, `SignalWatcher` | `hd-documents-view` |
+| Stateful Component | Consume services, coordinate UI | `@consume`, event handlers | `hd-document-list` |
+| Pure Element | Props in, events out | `@property`, `CustomEvent` | `hd-document-card` |
+
+## Reference Guide
+
+Each topic below has a dedicated reference with full code examples and detailed patterns. Read the relevant reference when working in that area.
+
+### Components — [references/components.md](references/components.md)
+
+Three component tiers with complete examples: View components create and `@provide` services via `SignalWatcher(LitElement)`. Stateful components `@consume` services and coordinate UI. Pure elements accept `@property` data and emit `CustomEvent` upward. Every component uses `*.module.css` imports for styles (producing `CSSStyleSheet` directly — no `unsafeCSS()`).
+
+### Services — [references/services.md](references/services.md)
+
+Each domain has a single `service.ts` exporting a context, interface, and factory function. State lives in `Signal.State` signals. Views create services via factory and `@provide` them; descendants `@consume`. The `SignalWatcher` mixin drives re-renders when signals change.
+
+### CSS — [references/css.md](references/css.md)
+
+Three cascade layers (`tokens, reset, theme`), design tokens as CSS custom properties (penetrate shadow DOM naturally), component styles via `*.module.css` → `CSSStyleSheet`, global CSS via side-effect import, and app-shell scroll architecture (body never scrolls, views own scroll regions).
+
+### API — [references/api.md](references/api.md)
+
+`Result<T>` discriminated union, `request<T>()` generic fetch wrapper (base `/api`), `stream()` SSE client with `AbortController` cancellation, and `PageResult<T>`/`PageRequest`/`toQueryString` pagination helpers. Located at `app/client/core/api.ts`.
+
+### Router — [references/router.md](references/router.md)
+
+History API router at `app/client/router/`. Route definitions map path patterns to component tag names. Dynamic `:paramName` segments, catch-all `'*'`, `navigate()` for programmatic routing. Router sets path/query params as HTML attributes on mounted components.
+
+### Build — [references/build.md](references/build.md)
+
+Native `Bun.build()` API (no Vite). CSS modules plugin at `app/plugins/css-modules.ts` intercepts `*.module.css` and emits `CSSStyleSheet`. Two-terminal dev workflow: `bun run watch` rebuilds client assets, `air` rebuilds Go on dist/ changes. Output: fixed `app.js` + `app.css` for stable `go:embed`.
+
+### Go Integration — [references/go-integration.md](references/go-integration.md)
+
+Single shell pattern: `app/app.go` embeds `dist/*`, `server/layouts/*`, `server/views/*`. Catch-all `/{path...}` route serves the HTML shell. Template variables: `{{ .BasePath }}`, `{{ .Title }}`, `{{ .Bundle }}`. `<base href>` tag enables client-side router path resolution.
+
+## Template Patterns
+
+These patterns recur across all component tiers and are worth keeping top of mind.
+
+**Render methods** — extract complex template logic into private `renderXxx()` methods. Use `nothing` from Lit (not empty string) for conditional non-rendering.
+
+**Form handling** — extract values via `FormData` on submit rather than tracking controlled inputs. Cast with `data.get('name') as string`.
+
+**Host attribute reflection** — reflect `@state()` to host attributes via `updated()` + `toggleAttribute()` so CSS can drive layout changes without JavaScript.
+
+**Object URL lifecycle** — revoke blob URLs in `disconnectedCallback` to prevent memory leaks. Use a `Map<File, string>` cache pattern.
+
+See [references/components.md](references/components.md) for full code examples of each pattern.
+
+## Naming Conventions
+
+### Components
+
+- **Prefix**: `hd-` (Herald)
+- **Views**: `hd-<domain>-view` (e.g., `hd-documents-view`)
+- **Stateful components**: `hd-<domain>-<name>` (e.g., `hd-document-list`)
+- **Pure elements**: `hd-<name>` (e.g., `hd-document-card`)
+- **Avoid HTMLElement conflicts**: Use `heading` not `title`, `configId` not `id`
+
+### File Structure
+
+Each view lives in its own subdirectory with a barrel export:
+
+```
+views/documents/
+├── index.ts                     # barrel export
+├── documents-view.ts            # @customElement('hd-documents-view')
+├── documents-view.module.css    # component styles
+├── service.ts                   # domain service + context + factory
+└── document-card.ts             # pure element (co-located if small)
+```
+
+Shared components go in `app/client/components/` with the same pattern.
+
+### Path Alias
+
+`@app/*` resolves to `app/client/*` (configured in `tsconfig.json`):
+
+```typescript
+import { request } from '@app/core';
+import { navigate } from '@app/router';
+```
+
+### HTMLElementTagNameMap
+
+Every component declares its tag in the global interface for type safety:
+
+```typescript
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-documents-view': DocumentsView;
+  }
+}
+```
+
+## Anti-Patterns
+
+### Avoid
+
+- Creating custom elements for native HTML (buttons, inputs, badges) — use CSS classes
+- Using `unsafeCSS()` — Herald's `*.module.css` plugin produces `CSSStyleSheet` directly
+- Storing service references in `@state()` — use `@consume` for context injection
+- Skipping `SignalWatcher` mixin when consuming signal-based services (reactivity won't work)
+- Using `height: 100%` in flex containers — use `flex: 1` with `min-height: 0`
+- Forgetting `min-height: 0` on flex children that need scroll boundaries
+- Using inline `style` attributes — use CSS classes and custom properties
+- Accessing `this.id` or `this.title` on components — conflicts with `HTMLElement` built-ins
+- Importing `*.module.css` with `?inline` suffix — Herald uses the naming convention, not query params
+
+### Prefer
+
+- Native HTML elements with CSS classes for simple UI
+- `@provide`/`@consume` over prop drilling through intermediate components
+- `nothing` from Lit for conditional non-rendering
+- FormData extraction over controlled inputs for form handling
+- `disconnectedCallback` cleanup for blob URLs and event listeners
+- Event delegation at the list level over individual handlers on each item

--- a/.claude/skills/web-development/references/api.md
+++ b/.claude/skills/web-development/references/api.md
@@ -1,0 +1,128 @@
+# API Layer
+
+Located at `app/client/core/api.ts`. All exports are re-exported from `app/client/core/index.ts`.
+
+## Result Type
+
+Discriminated union for consistent error handling across all API calls:
+
+```typescript
+type Result<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+```
+
+Check `result.ok` before accessing `result.data`. TypeScript narrows the type automatically.
+
+## request()
+
+Generic fetch wrapper with base endpoint `/api`:
+
+```typescript
+async function request<T>(
+  path: string,
+  init?: RequestInit,
+  parse?: (res: Response) => Promise<T>
+): Promise<Result<T>>
+```
+
+Behavior:
+- Prepends `/api` to the path
+- Non-2xx responses extract the body as the error message
+- 204 responses return `undefined` as data
+- Custom `parse` hook for non-JSON responses (default: `res.json()`)
+
+### Usage Examples
+
+```typescript
+// GET (default)
+const result = await request<Document[]>('/documents');
+
+// POST with JSON body
+const result = await request<Document>('/documents', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(command),
+});
+
+// POST with FormData (file upload — no Content-Type header, browser sets boundary)
+const form = new FormData();
+form.append('file', file);
+const result = await request<Document>('/documents', {
+  method: 'POST',
+  body: form,
+});
+
+// DELETE
+const result = await request<void>(`/documents/${id}`, { method: 'DELETE' });
+```
+
+## stream()
+
+SSE client for classification progress. Returns an `AbortController` for cancellation.
+
+```typescript
+function stream(
+  path: string,
+  callbacks: {
+    onMessage: (data: string) => void;
+    onError?: (err: string) => void;
+    onComplete?: () => void;
+  }
+): AbortController
+```
+
+Behavior:
+- Parses SSE `data:` lines
+- Recognizes `[DONE]` as the completion signal
+- Calls `onComplete` when the stream ends normally
+- Calls `onError` on fetch failure or stream errors
+
+### Usage Example
+
+```typescript
+const controller = stream(`/classifications/${documentId}/stream`, {
+  onMessage(data) {
+    const event = JSON.parse(data);
+    // Update progress UI
+  },
+  onError(err) {
+    console.error('Stream error:', err);
+  },
+  onComplete() {
+    // Classification finished, refresh data
+  },
+});
+
+// Cancel if needed
+controller.abort();
+```
+
+## Pagination Helpers
+
+```typescript
+interface PageResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
+interface PageRequest {
+  page?: number;
+  page_size?: number;
+  search?: string;
+  sort?: string;
+}
+
+function toQueryString(params: PageRequest): string
+```
+
+### Usage
+
+```typescript
+const params: PageRequest = { page: 1, page_size: 20, search: 'classified' };
+const qs = toQueryString(params); // "?page=1&page_size=20&search=classified"
+const result = await request<PageResult<Document>>(`/documents${qs}`);
+```

--- a/.claude/skills/web-development/references/build.md
+++ b/.claude/skills/web-development/references/build.md
@@ -1,0 +1,84 @@
+# Build System
+
+Native `Bun.build()` API — no Vite or Webpack. Single entry point produces fixed-name outputs for stable `go:embed` globs.
+
+## Commands
+
+```bash
+bun run build    # Single build: client/app.ts → dist/app.js + dist/app.css
+bun run watch    # Watch client/ for .ts/.css changes, rebuild with 150ms debounce
+```
+
+## Build Script
+
+`app/scripts/build.ts`:
+
+```typescript
+import { litCSSModulePlugin } from '../plugins/css-modules';
+
+const result = await Bun.build({
+  entrypoints: ['client/app.ts'],
+  outdir: 'dist',
+  naming: 'app.[ext]',
+  plugins: [litCSSModulePlugin],
+  minify: false,
+});
+```
+
+- Single entry point: `client/app.ts`
+- Output: `dist/app.js` + `dist/app.css` (fixed names)
+- CSS modules plugin transforms `*.module.css` → `CSSStyleSheet`
+- Non-module CSS extracted automatically to `app.css`
+
+## CSS Modules Plugin
+
+`app/plugins/css-modules.ts` intercepts `*.module.css` imports:
+
+1. `onResolve` — redirects `*.module.css` to the `lit-css` namespace
+2. `onLoad` — reads the CSS file, wraps content in `new CSSStyleSheet()` + `replaceSync()`
+
+The result is a JavaScript module that exports a `CSSStyleSheet` object, which Lit accepts directly in `static styles`.
+
+Non-module CSS (`import './design/index.css'`) is never intercepted — it flows to Bun's default pipeline and gets extracted to `dist/app.css`.
+
+## Watch Script
+
+`app/scripts/watch.ts` uses Node's `fs.watch` with a 150ms debounce. Triggers a full rebuild on any `.ts` or `.css` change in `client/`.
+
+## Dev Workflow
+
+Two terminals, clean separation of concerns:
+
+| Terminal | Command | Watches | Rebuilds |
+|----------|---------|---------|----------|
+| 1 | `bun run watch` | `app/client/**/*.{ts,css}` | Client assets → `dist/` |
+| 2 | `air` | Go + `dist/` + templates | Go binary → restart server |
+
+Air's `.air.toml` configuration:
+- **Includes**: `cmd/`, `internal/`, `pkg/`, `app/` (Go files, templates, dist output)
+- **Excludes**: `app/client`, `app/scripts`, `app/plugins`, `app/node_modules`
+- **Extensions**: `.go`, `.html`, `.js`, `.css`
+
+This separation means Bun handles TypeScript/CSS compilation and Air handles Go compilation + server restart. Changes to client source trigger Bun → writes to `dist/` → Air detects dist change → restarts server.
+
+## Path Alias
+
+`@app/*` resolves to `app/client/*` via `tsconfig.json` paths:
+
+```json
+{
+  "compilerOptions": {
+    "paths": { "@app/*": ["./client/*"] }
+  }
+}
+```
+
+Use for all cross-directory imports within the client source.
+
+## TypeScript Configuration
+
+Key settings in `tsconfig.json`:
+- `target: "es2024"` — modern JavaScript output
+- `experimentalDecorators: true` — required for Lit decorators
+- `useDefineForClassFields: false` — required for Lit reactivity (class fields must use [[Set]] semantics)
+- `moduleResolution: "bundler"` — matches Bun's resolution strategy

--- a/.claude/skills/web-development/references/components.md
+++ b/.claude/skills/web-development/references/components.md
@@ -1,0 +1,204 @@
+# Component Patterns
+
+Herald uses a three-tier component hierarchy. Each tier has a distinct responsibility, and crossing boundaries (e.g., a pure element calling an API) creates hidden coupling that makes components harder to test and reuse.
+
+## View Component (provides services)
+
+Views are route-level components. They create services and make them available to their subtree via `@provide`. `SignalWatcher` ensures the view re-renders when signal state changes.
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { provide } from '@lit/context';
+import { SignalWatcher } from '@lit-labs/signals';
+import { documentServiceContext, createDocumentService, DocumentService } from './service';
+import styles from './documents-view.module.css';
+
+@customElement('hd-documents-view')
+export class DocumentsView extends SignalWatcher(LitElement) {
+  static styles = styles;
+
+  @provide({ context: documentServiceContext })
+  private documentService: DocumentService = createDocumentService();
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.documentService.list();
+  }
+
+  render() {
+    return html`<hd-document-list></hd-document-list>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-documents-view': DocumentsView;
+  }
+}
+```
+
+## Stateful Component (consumes services)
+
+Stateful components receive services via `@consume` and coordinate UI interactions. They bridge the service layer with pure elements.
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { SignalWatcher } from '@lit-labs/signals';
+import { documentServiceContext, DocumentService } from './service';
+import styles from './document-list.module.css';
+
+@customElement('hd-document-list')
+export class DocumentList extends SignalWatcher(LitElement) {
+  static styles = styles;
+
+  @consume({ context: documentServiceContext })
+  private documentService!: DocumentService;
+
+  private handleDelete(e: CustomEvent<{ id: string }>) {
+    this.documentService.delete(e.detail.id);
+  }
+
+  private renderDocuments() {
+    return this.documentService.documents.get().map(
+      (doc) => html`
+        <hd-document-card
+          .document=${doc}
+          @delete=${this.handleDelete}
+        ></hd-document-card>
+      `
+    );
+  }
+
+  render() {
+    return html`<div class="grid">${this.renderDocuments()}</div>`;
+  }
+}
+```
+
+## Pure Element (stateless)
+
+Pure elements receive data via properties and communicate upward through events. They have no knowledge of services or application state.
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { Document } from '../types';
+import styles from './document-card.module.css';
+
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  static styles = styles;
+
+  @property({ type: Object }) document!: Document;
+
+  private handleDelete() {
+    this.dispatchEvent(new CustomEvent('delete', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  render() {
+    return html`
+      <div class="card">
+        <h3>${this.document.filename}</h3>
+        <p>${this.document.status}</p>
+        <button @click=${this.handleDelete}>Delete</button>
+      </div>
+    `;
+  }
+}
+```
+
+## Template Patterns
+
+### Render Methods
+
+Extract complex template logic into private `renderXxx()` methods. Use `nothing` from Lit for conditional non-rendering — it produces no DOM output, unlike an empty string which creates a text node.
+
+```typescript
+import { nothing } from 'lit';
+
+private renderError() {
+  const error = this.service.error.get();
+  if (!error) return nothing;
+  return html`<div class="error">${error}</div>`;
+}
+
+render() {
+  return html`
+    ${this.renderError()}
+    ${this.renderContent()}
+  `;
+}
+```
+
+### Form Handling
+
+Extract values via FormData on submit rather than tracking controlled inputs:
+
+```typescript
+private handleSubmit(e: Event) {
+  e.preventDefault();
+  const form = e.target as HTMLFormElement;
+  const data = new FormData(form);
+  this.service.save({
+    name: data.get('name') as string,
+  });
+}
+
+render() {
+  return html`
+    <form @submit=${this.handleSubmit}>
+      <input name="name" .value=${this.item.name} required />
+      <button type="submit">Save</button>
+    </form>
+  `;
+}
+```
+
+### Host Attribute Reflection
+
+Reflect component state to the host element so CSS can drive layout changes without JavaScript:
+
+```typescript
+@state() private expanded = false;
+
+updated(changed: Map<string, unknown>) {
+  if (changed.has('expanded')) {
+    this.toggleAttribute('expanded', this.expanded);
+  }
+}
+```
+
+```css
+:host { grid-template-rows: auto auto 1fr; }
+:host([expanded]) { grid-template-rows: auto 1fr 1fr; }
+```
+
+### Object URL Lifecycle
+
+Revoke blob URLs in `disconnectedCallback` to prevent memory leaks:
+
+```typescript
+private imageUrls = new Map<File, string>();
+
+disconnectedCallback() {
+  super.disconnectedCallback();
+  this.imageUrls.forEach((url) => URL.revokeObjectURL(url));
+  this.imageUrls.clear();
+}
+
+private getImageUrl(file: File): string {
+  let url = this.imageUrls.get(file);
+  if (!url) {
+    url = URL.createObjectURL(file);
+    this.imageUrls.set(file, url);
+  }
+  return url;
+}
+```

--- a/.claude/skills/web-development/references/css.md
+++ b/.claude/skills/web-development/references/css.md
@@ -1,0 +1,141 @@
+# CSS Architecture
+
+## Cascade Layers
+
+Herald uses three layers with explicit precedence. Tokens are lowest priority (easily overridden), theme is highest (final say on body-level styling).
+
+```css
+/* design/index.css */
+@layer tokens, reset, theme;
+
+@import url(./core/tokens.css);
+@import url(./core/reset.css);
+@import url(./core/theme.css);
+@import url(./app/app.css);
+```
+
+`app.css` is unlayered (highest implicit priority) and handles the application shell layout.
+
+## Design Tokens
+
+CSS custom properties in `:root` with light/dark mode via `prefers-color-scheme`:
+
+**Spacing** — 0.25rem base unit:
+`--space-1` (0.25rem), `--space-2` (0.5rem), `--space-3` (0.75rem), `--space-4` (1rem), `--space-5` (1.25rem), `--space-6` (1.5rem), `--space-8` (2rem), `--space-10` (2.5rem), `--space-12` (3rem), `--space-16` (4rem)
+
+**Typography**:
+`--text-xs` (0.75rem), `--text-sm` (0.875rem), `--text-base` (1rem), `--text-lg` (1.125rem), `--text-xl` (1.25rem), `--text-2xl` (1.5rem), `--text-3xl` (1.875rem), `--text-4xl` (2.25rem)
+
+**Fonts**:
+`--font-sans` (system-ui stack), `--font-mono` (ui-monospace stack)
+
+**Colors** (dark mode default, light mode via media query):
+- Backgrounds: `--bg`, `--bg-1`, `--bg-2`
+- Text: `--color`, `--color-1`, `--color-2`
+- Border: `--divider`
+- Semantic: `--blue`, `--green`, `--red`, `--yellow`, `--orange` — each has a `-bg` variant for backgrounds
+
+**Radii**: `--radius-sm` (0.25rem), `--radius-md` (0.5rem), `--radius-lg` (0.75rem)
+
+**Shadows**: `--shadow-sm`, `--shadow-md`, `--shadow-lg`
+
+Tokens penetrate shadow DOM boundaries because CSS custom properties inherit naturally. This is how component styles access the design system without workarounds.
+
+## Component Styles via CSS Modules
+
+Component CSS uses the `*.module.css` naming convention. The Bun plugin at `app/plugins/css-modules.ts` transforms these into `CSSStyleSheet` objects that Lit accepts directly in `static styles`:
+
+```typescript
+import styles from './documents-view.module.css';
+
+static styles = styles;
+```
+
+This produces native `CSSStyleSheet` objects — no `unsafeCSS()` wrapper needed (unlike agent-lab's `?inline` pattern).
+
+The TypeScript declaration at `app/client/css.d.ts` enables the import:
+
+```typescript
+declare module '*.module.css' {
+  const styles: CSSStyleSheet;
+  export default styles;
+}
+```
+
+### Component CSS Patterns
+
+Use `:host` for component-level layout and design tokens for all values:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+
+h3 { color: var(--color); }
+p { color: var(--color-1); }
+```
+
+## Global CSS
+
+Side-effect imports (no module suffix) flow through Bun's default pipeline and are extracted to `dist/app.css`:
+
+```typescript
+// app.ts entry point
+import './design/index.css';
+```
+
+Only the entry point imports global CSS. Components never import global stylesheets.
+
+## App-Shell Scroll Architecture
+
+Body fills viewport and never scrolls. Views manage their own scroll regions. This prevents competing scrollbars and gives each view full control over its layout.
+
+```css
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100svh;
+  margin: 0;
+  overflow: hidden;
+}
+
+#app-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#app-content > * {
+  flex: 1;
+  min-height: 0;
+}
+```
+
+View pattern for scrollable content — the critical pieces are `flex: 1`, `min-height: 0`, and `overflow-y: auto` on the scrollable child:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+}
+
+.scrollable {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+```
+
+Without `min-height: 0` on flex children, content overflows instead of scrolling. This is the most common CSS bug in the application.

--- a/.claude/skills/web-development/references/go-integration.md
+++ b/.claude/skills/web-development/references/go-integration.md
@@ -1,0 +1,114 @@
+# Go Integration
+
+The Go server embeds compiled client assets and serves a single HTML shell. The client-side router handles all view rendering.
+
+## Module Registration
+
+`app/app.go` exports `NewModule(basePath)` which creates an `http.Handler` mounted at the given path (e.g., `/app`):
+
+```go
+package app
+
+import (
+  "embed"
+  "net/http"
+
+  "github.com/JaimeStill/herald/pkg/module"
+  "github.com/JaimeStill/herald/pkg/web"
+)
+
+//go:embed dist/*
+var distFS embed.FS
+
+//go:embed server/layouts/*
+var layoutFS embed.FS
+
+//go:embed server/views/*
+var viewFS embed.FS
+
+var views = []web.ViewDef{
+  {Route: "/{path...}", Template: "shell.html", Title: "Herald", Bundle: "app"},
+}
+
+func NewModule(basePath string) (*module.Module, error) {
+  ts, err := web.NewTemplateSet(layoutFS, viewFS, "server/layouts/*.html", "server/views", basePath, views)
+  if err != nil {
+    return nil, err
+  }
+
+  router := buildRouter(ts)
+  return module.New(basePath, router), nil
+}
+
+func buildRouter(ts *web.TemplateSet) http.Handler {
+  r := web.NewRouter()
+  r.Handle("GET /dist/", web.DistServer(distFS, "dist", "/dist/"))
+  r.SetFallback(ts.PageHandler("app.html", views[0]))
+  return r
+}
+```
+
+Key points:
+- Three `embed.FS`: bundled assets (`dist/*`), layout templates (`server/layouts/*`), view templates (`server/views/*`)
+- Catch-all `/{path...}` route serves the HTML shell for all client paths
+- Static assets served from `/dist/` via `DistServer`
+- Module registered in `cmd/server/` alongside the API module
+
+## Shell Template
+
+`app/server/layouts/app.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <base href="{{ .BasePath }}/">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ .Title }} - Herald</title>
+  <link rel="stylesheet" href="dist/{{ .Bundle }}.css">
+</head>
+<body>
+  <header class="app-header">
+    <a href="" class="brand">Herald</a>
+    <nav>
+      <a href="prompts">Prompts</a>
+    </nav>
+  </header>
+  <main id="app-content">
+    {{ block "content" . }}{{ end }}
+  </main>
+  <script type="module" src="dist/{{ .Bundle }}.js"></script>
+</body>
+</html>
+```
+
+Template variables:
+- `{{ .BasePath }}` — module mount path (e.g., `/app`)
+- `{{ .Title }}` — page title from `ViewDef`
+- `{{ .Bundle }}` — bundle name (`app` → `dist/app.js`, `dist/app.css`)
+
+The `<base href>` tag is critical — the client-side router reads it to resolve relative paths correctly.
+
+## View Template
+
+`app/server/views/shell.html`:
+
+```html
+{{ define "content" }}{{ end }}
+```
+
+Empty content block — the client-side router mounts views into `#app-content` dynamically.
+
+## Adding Navigation Links
+
+Header navigation lives in the layout template. Add new links in the `<nav>` element:
+
+```html
+<nav>
+  <a href="prompts">Prompts</a>
+  <a href="new-route">New Route</a>
+</nav>
+```
+
+Links use relative paths (resolved against `<base href>`). The client-side router intercepts anchor clicks for SPA navigation.

--- a/.claude/skills/web-development/references/router.md
+++ b/.claude/skills/web-development/references/router.md
@@ -1,0 +1,76 @@
+# Router
+
+History API router at `app/client/router/`. Handles client-side navigation within the SPA.
+
+## Route Definitions
+
+```typescript
+// router/routes.ts
+const routes: Record<string, RouteConfig> = {
+  '': { component: 'hd-documents-view', title: 'Documents' },
+  'prompts': { component: 'hd-prompts-view', title: 'Prompts' },
+  'review/:documentId': { component: 'hd-review-view', title: 'Review' },
+  '*': { component: 'hd-not-found-view', title: 'Not Found' },
+};
+```
+
+- Empty string `''` = root route
+- `:paramName` syntax for dynamic segments
+- `'*'` = catch-all 404
+
+### Adding a New Route
+
+1. Add entry to `routes` in `router/routes.ts`
+2. Create the view component in `views/<domain>/`
+3. Import the view in `views/index.ts` barrel
+
+## Navigation
+
+```typescript
+import { navigate } from '@app/router';
+
+// Programmatic navigation
+navigate('prompts');
+navigate(`review/${documentId}`);
+
+// Template links (router intercepts anchor clicks)
+html`<a href="prompts">Prompts</a>`
+```
+
+## Parameter Passing
+
+The router sets path params and query params as HTML attributes on the mounted component. Components receive them via `@property()`:
+
+```typescript
+// Route: 'review/:documentId'
+// URL: /app/review/abc-123?tab=markings
+
+@property({ type: String }) documentId?: string;  // "abc-123"
+```
+
+Query params are also set as attributes on the component.
+
+## Route Types
+
+```typescript
+// router/types.ts
+interface RouteConfig {
+  component: string;      // Custom element tag name
+  title: string;          // Page title
+}
+
+interface RouteMatch {
+  config: RouteConfig;
+  params: Record<string, string>;   // Path params
+  query: Record<string, string>;    // Query string params
+}
+```
+
+## How It Works
+
+1. Router reads `<base href>` from the HTML shell for basePath
+2. On navigation, strips basePath and matches against route patterns
+3. Exact match first, then segment-by-segment pattern matching
+4. Creates the custom element by tag name, sets params as attributes
+5. Replaces container (`#app-content`) innerHTML with the new element
+6. Updates `document.title` and pushes to history

--- a/.claude/skills/web-development/references/services.md
+++ b/.claude/skills/web-development/references/services.md
@@ -1,0 +1,95 @@
+# Service Infrastructure
+
+Each domain has a single `service.ts` that exports three things: a context key, an interface, and a factory function. This co-location keeps the service contract, creation, and dependency injection in one place.
+
+## Consolidated Service File
+
+```typescript
+// documents/service.ts
+import { createContext } from '@lit/context';
+import { Signal } from '@lit-labs/signals';
+import { request, type PageResult, toQueryString, type PageRequest } from '@app/core';
+
+export interface DocumentService {
+  documents: Signal.State<Document[]>;
+  loading: Signal.State<boolean>;
+  error: Signal.State<string | null>;
+
+  list(params?: PageRequest): void;
+  find(id: string): void;
+  upload(file: File): void;
+  delete(id: string): void;
+}
+
+export const documentServiceContext = createContext<DocumentService>('document-service');
+
+export function createDocumentService(): DocumentService {
+  const documents = new Signal.State<Document[]>([]);
+  const loading = new Signal.State<boolean>(false);
+  const error = new Signal.State<string | null>(null);
+
+  return {
+    documents,
+    loading,
+    error,
+
+    async list(params) {
+      loading.set(true);
+      const qs = params ? toQueryString(params) : '';
+      const result = await request<PageResult<Document>>(`/documents${qs}`);
+      if (result.ok) {
+        documents.set(result.data.data);
+      } else {
+        error.set(result.error);
+      }
+      loading.set(false);
+    },
+
+    async find(id) { /* ... */ },
+    async upload(file) { /* ... */ },
+    async delete(id) { /* ... */ },
+  };
+}
+```
+
+## How Services Flow Through the Hierarchy
+
+1. **View creates** the service via factory and `@provide`s it:
+
+```typescript
+@provide({ context: documentServiceContext })
+private documentService: DocumentService = createDocumentService();
+```
+
+2. **Stateful components** `@consume` the service from context:
+
+```typescript
+@consume({ context: documentServiceContext })
+private documentService!: DocumentService;
+```
+
+3. **Pure elements** never touch services — they receive data via `@property` and emit events upward.
+
+## Signal Reactivity
+
+`Signal.State` values are read with `.get()` and written with `.set()`. The `SignalWatcher` mixin on view and stateful components ensures Lit re-renders when any signal read during `render()` changes.
+
+Without `SignalWatcher`, signal changes will not trigger re-renders — this is a common mistake.
+
+```typescript
+// Reading in templates (inside SignalWatcher component)
+${this.service.loading.get() ? html`<p>Loading...</p>` : nothing}
+
+// Writing in service methods
+loading.set(true);
+documents.set(result.data.data);
+```
+
+## Service Conventions
+
+- One `service.ts` per domain (documents, prompts, classifications)
+- Context string keys are kebab-case: `'document-service'`, `'prompt-service'`
+- Factory functions are `createXxxService()` — pure functions, no side effects until called
+- Signals expose `.get()` for reading and `.set()` for writing
+- Error state is `Signal.State<string | null>` — `null` means no error
+- Loading state gates UI to prevent stale data display


### PR DESCRIPTION
## Summary

Create Herald-specific Lit web development Claude skill documenting conventions established by the Phase 3 foundation sub-issues (#62–#64). Uses progressive disclosure — lean SKILL.md (155 lines) with 7 topic-specific reference files for detailed code examples on demand.

Closes #65

## Changes

- `.claude/skills/web-development/SKILL.md` — architecture overview, naming conventions, anti-patterns, links to references
- `references/components.md` — three-tier hierarchy (view/stateful/pure), template patterns
- `references/services.md` — Signal.State + @lit/context service infrastructure
- `references/css.md` — cascade layers, design tokens, CSS modules, scroll architecture
- `references/api.md` — Result<T>, request(), stream(), pagination helpers
- `references/router.md` — route definitions, navigation, parameter passing
- `references/build.md` — Bun.build, CSS modules plugin, dev workflow
- `references/go-integration.md` — shell pattern, embedding, templates
- `.claude/CLAUDE.md` — added Web Development Skill Maintenance and Frontend Design under AI Responsibilities