### PR TITLE
Add SSE classification streaming endpoint

### DIFF
--- a/.claude/context/guides/.archive/71-sse-classification-streaming-endpoint.md
+++ b/.claude/context/guides/.archive/71-sse-classification-streaming-endpoint.md
@@ -1,0 +1,289 @@
+# 71 - SSE Classification Streaming Endpoint
+
+## Problem Context
+
+The existing `POST /api/classifications/{documentId}` endpoint runs the classification workflow synchronously and returns a JSON response. The web client needs real-time progress updates during classification. Per the consolidation note in `_project/objective.md`, the endpoint is modified in-place to return an SSE event stream instead of JSON — same URL, same method, streaming response.
+
+Depends on #70 (merged), which added `StreamingObserver`, `ExecutionEvent` types, and updated `workflow.Execute` to accept an `*StreamingObserver` parameter.
+
+## Architecture Approach
+
+The `Classify` method, handler, and route are modified in-place. The method signature changes to return a read-only event channel. The handler switches from JSON response to SSE streaming. The route stays `POST /{documentId}`.
+
+Two error paths:
+- **Pre-stream errors** (bad UUID, document not found): return JSON via `handlers.RespondError` before SSE headers are sent
+- **Mid-stream errors** (workflow failures): arrive as `error` event type on the channel
+
+The goroutine owns the workflow execution, DB persistence, and observer lifecycle. The handler only consumes events from the channel.
+
+## Implementation
+
+### Step 1: Update System interface
+
+**`internal/classifications/system.go`** — Change `Classify` return type. Add the `workflow` import.
+
+```go
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/JaimeStill/herald/internal/workflow"
+	"github.com/JaimeStill/herald/pkg/pagination"
+)
+```
+
+Change the `Classify` signature from:
+
+```go
+Classify(ctx context.Context, documentID uuid.UUID) (*Classification, error)
+```
+
+To:
+
+```go
+Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error)
+```
+
+### Step 2: Modify Classify in repository
+
+**`internal/classifications/repository.go`** — Rewrite the `Classify` method body. The method signature, upsert SQL, and `collectMarkings` helper are reused.
+
+Add a constant at the top of the file (after the import block):
+
+```go
+const streamBufferSize = 32
+```
+
+Replace the entire `Classify` method with:
+
+```go
+func (r *repo) Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error) {
+	if _, err := r.rt.Documents.Find(ctx, documentID); err != nil {
+		return nil, fmt.Errorf("document %s: %w", documentID, err)
+	}
+
+	observer := workflow.NewStreamingObserver(streamBufferSize)
+
+	go func() {
+		defer observer.Close()
+
+		result, err := workflow.Execute(ctx, r.rt, documentID, observer)
+		if err != nil {
+			observer.SendError(fmt.Errorf("classify document %s: %w", documentID, err), "")
+			return
+		}
+
+		markings := collectMarkings(result.State.Pages)
+		markingsJSON, err := json.Marshal(markings)
+		if err != nil {
+			observer.SendError(fmt.Errorf("marshal markings: %w", err), "")
+			return
+		}
+
+		upsertQ := `
+			INSERT INTO classifications(
+				document_id, classification, confidence, markings_found,
+				rationale, model_name, provider_name
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (document_id) DO UPDATE SET
+				classification = EXCLUDED.classification,
+				confidence = EXCLUDED.confidence,
+				markings_found = EXCLUDED.markings_found,
+				rationale = EXCLUDED.rationale,
+				classified_at = NOW(),
+				model_name = EXCLUDED.model_name,
+				provider_name = EXCLUDED.provider_name,
+				validated_by = NULL,
+				validated_at = NULL
+			RETURNING id, document_id, classification, confidence, markings_found,
+					  rationale, classified_at, model_name, provider_name,
+					  validated_by, validated_at`
+
+		upsertArgs := []any{
+			documentID,
+			result.State.Classification,
+			string(result.State.Confidence),
+			markingsJSON,
+			result.State.Rationale,
+			r.rt.Agent.Model.Name,
+			r.rt.Agent.Provider.Name,
+		}
+
+		c, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Classification, error) {
+			cl, err := repository.QueryOne(ctx, tx, upsertQ, upsertArgs, scanClassification)
+			if err != nil {
+				return Classification{}, fmt.Errorf("upsert classification: %w", err)
+			}
+
+			if err := repository.ExecExpectOne(
+				ctx, tx,
+				"UPDATE documents SET status = 'review', updated_at = NOW() WHERE id = $1",
+				documentID,
+			); err != nil {
+				return Classification{}, fmt.Errorf("update document status: %w", err)
+			}
+
+			return cl, nil
+		})
+
+		if err != nil {
+			observer.SendError(err, "")
+			return
+		}
+
+		r.logger.Info("document classified",
+			"id", c.ID,
+			"document_id", documentID,
+			"classification", c.Classification,
+			"confidence", c.Confidence,
+		)
+
+		classBytes, err := json.Marshal(c)
+		if err != nil {
+			observer.SendError(fmt.Errorf("marshal classification: %w", err), "")
+			return
+		}
+
+		var classMap map[string]any
+		if err := json.Unmarshal(classBytes, &classMap); err != nil {
+			observer.SendError(fmt.Errorf("unmarshal classification map: %w", err), "")
+			return
+		}
+
+		observer.SendComplete(classMap)
+	}()
+
+	return observer.Events(), nil
+}
+```
+
+### Step 3: Modify Classify handler
+
+**`internal/classifications/handler.go`** — Rewrite the `Classify` handler. Add `"fmt"` to imports. The `Routes()` method is unchanged.
+
+Replace the `Classify` method with:
+
+```go
+func (h *Handler) Classify(w http.ResponseWriter, r *http.Request) {
+	documentID, err := uuid.Parse(r.PathValue("documentId"))
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusBadRequest, ErrNotFound)
+		return
+	}
+
+	events, err := h.sys.Classify(r.Context(), documentID)
+	if err != nil {
+		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	for event := range events {
+		select {
+		case <-r.Context().Done():
+			return
+		default:
+		}
+
+		data, err := json.Marshal(event)
+		if err != nil {
+			h.logger.Error("failed to marshal event", "error", err)
+			continue
+		}
+
+		fmt.Fprintf(w, "event: %s\n", event.Type)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+```
+
+Add `"fmt"` to the import block (alongside existing `"encoding/json"`).
+
+### Step 4: Update API documentation
+
+**`_project/api/classifications/README.md`** — Replace the "Classify Document" section (lines 156-179) with:
+
+````markdown
+## Classify Document (SSE)
+
+`POST /api/classifications/{documentId}`
+
+Initiates the classification workflow for a document and streams progress events via Server-Sent Events. Runs the full workflow graph (init, classify, enhance?, finalize), then persists the classification result and transitions the document status to `review`. Re-classification overwrites any existing result and resets validation fields.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| documentId | uuid | Document UUID to classify |
+
+### SSE Event Types
+
+| Event | Description | Data Fields |
+|-------|-------------|-------------|
+| `node.start` | Workflow node begins execution | `node`, `iteration` |
+| `node.complete` | Workflow node finished successfully | `node`, `iteration` |
+| `error` | Error during workflow or persistence | `message`, optionally `node` |
+| `complete` | Classification finished and persisted | Full classification object |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | SSE event stream (Content-Type: text/event-stream) |
+| 404 | Document not found (JSON error, before stream starts) |
+
+### Example
+
+```bash
+curl -s -N -X POST "$HERALD_API_BASE/api/classifications/660e8400-e29b-41d4-a716-446655440000"
+````
+
+**`_project/api/classifications/classifications.http`** — Update the classify request section. Replace:
+
+```
+### Classify Document
+
+# Replace with a valid document ID
+
+@documentId = 660e8400-e29b-41d4-a716-446655440000
+
+POST {{HOST}}/api/classifications/{{documentId}} HTTP/1.1
+```
+
+With:
+
+```
+### Classify Document (SSE)
+
+# Replace with a valid document ID
+# Response is an SSE event stream (text/event-stream)
+
+@documentId = 660e8400-e29b-41d4-a716-446655440000
+
+POST {{HOST}}/api/classifications/{{documentId}} HTTP/1.1
+```
+
+## Validation Criteria
+
+- [ ] `Classify` method on System interface returns `(<-chan workflow.ExecutionEvent, error)`
+- [ ] `POST /api/classifications/{documentId}` returns SSE event stream
+- [ ] SSE headers set correctly (`text/event-stream`, `no-cache`, `keep-alive`)
+- [ ] Events formatted as `event: <type>\ndata: <json>\n\n`
+- [ ] Client disconnect (context cancellation) stops the workflow
+- [ ] Pre-stream errors return JSON error response (not SSE)
+- [ ] `_project/api/classifications/README.md` updated with SSE endpoint docs
+- [ ] `go vet ./...` passes

--- a/.claude/context/sessions/71-sse-classification-streaming-endpoint.md
+++ b/.claude/context/sessions/71-sse-classification-streaming-endpoint.md
@@ -1,0 +1,36 @@
+# 71 - SSE Classification Streaming Endpoint
+
+## Summary
+
+Modified the existing `POST /api/classifications/{documentId}` endpoint to return an SSE event stream instead of a JSON response. The `Classify` method, handler, and route were updated in-place — same URL, same method, streaming behavior. The StreamingObserver and ExecutionEvent types from #70 drive the event channel.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| In-place replacement | Modify `Classify` signature and handler rather than creating separate `ClassifyStream` | Single classify path — SSE subsumes the non-streaming case. Avoids maintaining two endpoints. |
+| Same URL and method | `POST /{documentId}` unchanged | Semantically correct (POST initiates a side effect). Client uses `fetch` + `ReadableStream`, not `EventSource` (which requires GET). |
+| Pre-flight validation | `r.rt.Documents.Find()` before goroutine launch | Synchronous document-not-found errors return JSON before SSE headers are sent. |
+| Stream buffer constant | `streamBufferSize = 32` package-level constant | Static value, same pattern as agent-lab's `defaultStreamBufferSize`. |
+| Complete event data | Serialized `Classification` struct as `map[string]any` | Client receives the persisted result in the completion event without a separate fetch. |
+
+## Files Modified
+
+- `internal/classifications/system.go` — `Classify` return type changed to `(<-chan workflow.ExecutionEvent, error)`
+- `internal/classifications/repository.go` — `Classify` rewritten: pre-flight validation, goroutine with observer, workflow execution, DB persistence, complete/error events
+- `internal/classifications/handler.go` — `Classify` handler rewritten: SSE headers, event loop with flush, context cancellation
+- `tests/classifications/handler_test.go` — Mock and `TestHandlerClassify` updated for SSE streaming (verifies headers, event parsing, pre-stream errors)
+- `_project/api/classifications/README.md` — Classify section updated with SSE event types and streaming curl example
+- `_project/api/classifications/classifications.http` — Classify request annotated as SSE response
+
+## Patterns Established
+
+- SSE streaming from a domain handler: set headers, flush, range over event channel, format `event: <type>\ndata: <json>\n\n`, flush per event, respect `r.Context().Done()`
+- Two-phase error handling: pre-stream errors return JSON, mid-stream errors arrive as SSE `error` events
+- Domain-level SSE: System method returns `<-chan EventType` — handler only consumes, goroutine owns lifecycle
+
+## Validation Results
+
+- `go vet ./...` passes
+- `go test ./tests/...` — all 20 packages pass
+- Manual curl test: full SSE stream with node.start, node.complete, and complete events confirmed against live Azure endpoint

--- a/.claude/plans/crispy-brewing-flute.md
+++ b/.claude/plans/crispy-brewing-flute.md
@@ -1,0 +1,97 @@
+# 71 - SSE Classification Streaming Endpoint
+
+## Context
+
+Issue #71, part of Objective #58 (SSE Classification Streaming). Depends on #70 (merged in PR #72), which added `StreamingObserver`, `ExecutionEvent` types, and updated `workflow.Execute` to accept an `*StreamingObserver` parameter.
+
+Per the consolidation note in `_project/objective.md`, the existing `POST /api/classifications/{documentId}` endpoint is modified in-place to return an SSE event stream instead of a JSON response. Same URL, same method — the behavior changes from synchronous JSON to streaming SSE.
+
+## Architecture Approach
+
+The SSE handler follows agent-lab's proven pattern (`internal/workflows/handler.go:71-116`): set SSE headers, flush, range over event channel, format as SSE, flush per event.
+
+**Two error paths:**
+- **Pre-stream errors** (document not found, parse failures): return JSON via `handlers.RespondError` — SSE headers haven't been sent yet
+- **Mid-stream errors** (workflow failures): arrive as `error` event type on the channel
+
+**Goroutine lifecycle:** `Classify` does pre-flight validation synchronously, then launches a goroutine that runs the workflow, persists the result (same upsert + status update logic), sends `complete` event with the classification data, and defers `observer.Close()`. The handler ranges over the channel and formats events as SSE.
+
+## Implementation
+
+### Step 1: Update System interface
+
+**`internal/classifications/system.go`** — Change `Classify` return type:
+
+```go
+Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error)
+```
+
+### Step 2: Modify Classify in repository
+
+**`internal/classifications/repository.go`** — Modify `Classify` in-place:
+
+1. Change return type to `(<-chan workflow.ExecutionEvent, error)`
+2. Pre-flight: validate document exists via `r.rt.Documents.Find(ctx, documentID)` — returns error synchronously (before SSE headers)
+3. Create `workflow.NewStreamingObserver(32)`
+4. Launch goroutine with `defer observer.Close()`:
+   - Call `workflow.Execute(ctx, r.rt, documentID, observer)`
+   - On error: `observer.SendError(err, "")`, return
+   - On success: collect markings, marshal, upsert classification (same SQL), update document status, then `observer.SendComplete(classMap)` with serialized `Classification`
+   - DB errors after workflow also go to `observer.SendError`
+5. Return `observer.Events(), nil`
+
+The `collectMarkings` helper and upsert SQL are reused — the DB persistence logic moves into the goroutine.
+
+### Step 3: Modify Classify handler
+
+**`internal/classifications/handler.go`** — Modify `Classify` handler in-place:
+
+1. Parse `documentId` path param — error returns JSON (pre-stream)
+2. Call `sys.Classify(r.Context(), documentID)` — error returns JSON (pre-stream)
+3. Set SSE headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`
+4. `w.WriteHeader(http.StatusOK)` + flush
+5. Range over events channel:
+   - Check `r.Context().Done()` for client disconnect
+   - Marshal event data to JSON
+   - Write `event: <type>\ndata: <json>\n\n`
+   - Flush after each event
+6. `Routes()` unchanged — same `{Method: "POST", Pattern: "/{documentId}", Handler: h.Classify}`
+
+### Step 4: Update API documentation
+
+**`_project/api/classifications/README.md`** — Update "Classify Document" section:
+- Same method/URL: `POST /api/classifications/{documentId}`
+- Response type changes from JSON to SSE event stream
+- Document event types: `node.start`, `node.complete`, `complete`, `error`
+- curl example with `--no-buffer` for streaming
+
+**`_project/api/classifications/classifications.http`** — Update classify request comment to note SSE response.
+
+## Key Files
+
+| File | Action |
+|------|--------|
+| `internal/classifications/system.go` | Modify (change `Classify` signature) |
+| `internal/classifications/repository.go` | Modify (rewrite `Classify` to SSE-based) |
+| `internal/classifications/handler.go` | Modify (rewrite handler, route unchanged) |
+| `_project/api/classifications/README.md` | Modify (replace classify section) |
+| `_project/api/classifications/classifications.http` | Modify (replace classify request) |
+
+## Reference Patterns
+
+- SSE handler: `~/code/agent-lab/internal/workflows/handler.go:71-116`
+- Async execution with observer: `~/code/agent-lab/internal/workflows/executor.go:173-228`
+- StreamingObserver API: `internal/workflow/observer.go` (NewStreamingObserver, Events, Close, SendComplete, SendError)
+- ExecutionEvent types: `internal/workflow/events.go` (NodeStart, NodeComplete, Complete, Error)
+
+## Validation Criteria
+
+- [ ] `Classify` method on System interface returns `(<-chan workflow.ExecutionEvent, error)`
+- [ ] `POST /api/classifications/{documentId}` returns SSE event stream
+- [ ] SSE headers set correctly (`text/event-stream`, `no-cache`, `keep-alive`)
+- [ ] Events formatted as `event: <type>\ndata: <json>\n\n`
+- [ ] Client disconnect (context cancellation) stops the workflow
+- [ ] Pre-stream errors return JSON error response (not SSE)
+- [ ] Same `POST /{documentId}` endpoint, now returns SSE
+- [ ] `_project/api/classifications/README.md` updated with SSE endpoint docs
+- [ ] `go vet ./...` passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.58.71
+- Add SSE classification streaming — modify `POST /api/classifications/{documentId}` to return an SSE event stream with real-time workflow progress (node.start, node.complete, complete, error events) and persisted classification result on completion (#71)
+
 ## v0.3.0-dev.58.70
 - Add workflow streaming observer with channel-based event emission, lean event type filtering (node.start, node.complete, complete, error), generic `FromMap[T]` map decoder, and `NewGraphWithDeps` observer injection (#70)
 

--- a/_project/api/classifications/README.md
+++ b/_project/api/classifications/README.md
@@ -153,11 +153,13 @@ curl -s -X POST "$HERALD_API_BASE/api/classifications/search" \
 
 ---
 
-## Classify Document
+## Classify Document (SSE)
 
 `POST /api/classifications/{documentId}`
 
-Executes the classification workflow for a single document. Runs the full workflow graph (init, classify, enhance?, finalize), upserts the classification result, and transitions the document status to `review`. Re-classification overwrites any existing result and resets validation fields.
+Initiates the classification workflow for a document and streams progress events via Server-Sent Events. Runs the full workflow graph (init, classify, enhance?, finalize), then persists the classification result and transitions the document status to `review`. Re-classification overwrites any existing result and resets validation fields.
+
+Pre-stream errors (invalid UUID, document not found) return a standard JSON error response. Once the stream begins, errors are delivered as SSE `error` events.
 
 ### Path Parameters
 
@@ -165,17 +167,26 @@ Executes the classification workflow for a single document. Runs the full workfl
 |-----------|------|-------------|
 | documentId | uuid | Document UUID to classify |
 
+### SSE Event Types
+
+| Event | Description | Data Fields |
+|-------|-------------|-------------|
+| `node.start` | Workflow node begins execution | `node`, `iteration` |
+| `node.complete` | Workflow node finished successfully | `node`, `iteration` |
+| `error` | Error during workflow or persistence | `message`, optionally `node` |
+| `complete` | Classification finished and persisted | Full classification object |
+
 ### Responses
 
 | Status | Description |
 |--------|-------------|
-| 201 | Classification created |
-| 404 | Document not found |
+| 200 | SSE event stream (Content-Type: text/event-stream) |
+| 404 | Document not found (JSON error, before stream starts) |
 
 ### Example
 
 ```bash
-curl -s -X POST "$HERALD_API_BASE/api/classifications/660e8400-e29b-41d4-a716-446655440000" | jq .
+curl -s -N -X POST "$HERALD_API_BASE/api/classifications/660e8400-e29b-41d4-a716-446655440000"
 ```
 
 ---

--- a/_project/api/classifications/classifications.http
+++ b/_project/api/classifications/classifications.http
@@ -53,9 +53,10 @@ Content-Type: application/json
 }
 
 
-### Classify Document
+### Classify Document (SSE)
 
 # Replace with a valid document ID
+# Response is an SSE event stream (text/event-stream)
 
 @documentId = 660e8400-e29b-41d4-a716-446655440000
 

--- a/internal/classifications/handler.go
+++ b/internal/classifications/handler.go
@@ -2,6 +2,7 @@ package classifications
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -122,8 +123,9 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
 	handlers.RespondJSON(w, http.StatusOK, result)
 }
 
-// Classify executes the classification workflow for a document identified by the documentId path parameter.
-// Returns 201 with the classification result on success.
+// Classify initiates the classification workflow for a document and streams progress
+// via Server-Sent Events. Pre-stream errors (invalid UUID, document not found) return
+// JSON. Once streaming begins, errors arrive as SSE error events on the channel.
 func (h *Handler) Classify(w http.ResponseWriter, r *http.Request) {
 	documentID, err := uuid.Parse(r.PathValue("documentId"))
 	if err != nil {
@@ -131,13 +133,41 @@ func (h *Handler) Classify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c, err := h.sys.Classify(r.Context(), documentID)
+	events, err := h.sys.Classify(r.Context(), documentID)
 	if err != nil {
 		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
 		return
 	}
 
-	handlers.RespondJSON(w, http.StatusCreated, c)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	for event := range events {
+		select {
+		case <-r.Context().Done():
+			return
+		default:
+		}
+
+		data, err := json.Marshal(event)
+		if err != nil {
+			h.logger.Error("failed to marshal event", "error", err)
+			continue
+		}
+
+		fmt.Fprintf(w, "event: %s\n", event.Type)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
 }
 
 // Validate marks a classification as human-validated by decoding a ValidateCommand JSON body.

--- a/internal/classifications/repository.go
+++ b/internal/classifications/repository.go
@@ -21,6 +21,8 @@ import (
 	gaconfig "github.com/JaimeStill/go-agents/pkg/config"
 )
 
+const streamBufferSize = 32
+
 type repo struct {
 	db         *sql.DB
 	rt         *workflow.Runtime
@@ -111,19 +113,30 @@ func (r *repo) FindByDocument(ctx context.Context, documentID uuid.UUID) (*Class
 	return &c, nil
 }
 
-func (r *repo) Classify(ctx context.Context, documentID uuid.UUID) (*Classification, error) {
-	result, err := workflow.Execute(ctx, r.rt, documentID, nil)
-	if err != nil {
-		return nil, fmt.Errorf("classify document %s: %w", documentID, err)
+func (r *repo) Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error) {
+	if _, err := r.rt.Documents.Find(ctx, documentID); err != nil {
+		return nil, fmt.Errorf("document %s: %w", documentID, err)
 	}
 
-	markings := collectMarkings(result.State.Pages)
-	markingsJSON, err := json.Marshal(markings)
-	if err != nil {
-		return nil, fmt.Errorf("marshal markings: %w", err)
-	}
+	observer := workflow.NewStreamingObserver(streamBufferSize)
 
-	upsertQ := `
+	go func() {
+		defer observer.Close()
+
+		result, err := workflow.Execute(ctx, r.rt, documentID, observer)
+		if err != nil {
+			observer.SendError(fmt.Errorf("classify document: %s: %w", documentID, err), "")
+			return
+		}
+
+		markings := collectMarkings(result.State.Pages)
+		markingsJSON, err := json.Marshal(markings)
+		if err != nil {
+			observer.SendError(fmt.Errorf("marshal markings: %w", err), "")
+			return
+		}
+
+		upsertQ := `
 		INSERT INTO classifications(
 			document_id, classification, confidence, markings_found,
 			rationale, model_name, provider_name
@@ -143,44 +156,61 @@ func (r *repo) Classify(ctx context.Context, documentID uuid.UUID) (*Classificat
 				  rationale, classified_at, model_name, provider_name,
 				  validated_by, validated_at`
 
-	upsertArgs := []any{
-		documentID,
-		result.State.Classification,
-		string(result.State.Confidence),
-		markingsJSON,
-		result.State.Rationale,
-		r.rt.Agent.Model.Name,
-		r.rt.Agent.Provider.Name,
-	}
-
-	c, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Classification, error) {
-		cl, err := repository.QueryOne(ctx, tx, upsertQ, upsertArgs, scanClassification)
-		if err != nil {
-			return Classification{}, fmt.Errorf("upsert classification: %w", err)
-		}
-
-		if err := repository.ExecExpectOne(
-			ctx, tx,
-			"UPDATE documents SET status = 'review', updated_at = NOW() WHERE id = $1",
+		upsertArgs := []any{
 			documentID,
-		); err != nil {
-			return Classification{}, fmt.Errorf("update document status: %w", err)
+			result.State.Classification,
+			string(result.State.Confidence),
+			markingsJSON,
+			result.State.Rationale,
+			r.rt.Agent.Model.Name,
+			r.rt.Agent.Provider.Name,
 		}
 
-		return cl, nil
-	})
+		c, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Classification, error) {
+			cl, err := repository.QueryOne(ctx, tx, upsertQ, upsertArgs, scanClassification)
+			if err != nil {
+				return Classification{}, fmt.Errorf("upsert classification: %w", err)
+			}
 
-	if err != nil {
-		return nil, repository.MapError(err, ErrNotFound, ErrDuplicate)
-	}
+			if err := repository.ExecExpectOne(
+				ctx, tx,
+				"UPDATE documents SET status = 'review', updated_at = NOW() WHERE id = $1",
+				documentID,
+			); err != nil {
+				return Classification{}, fmt.Errorf("update document status: %w", err)
+			}
 
-	r.logger.Info("document classified",
-		"id", c.ID,
-		"document_id", documentID,
-		"classification", c.Classification,
-		"confidence", c.Confidence,
-	)
-	return &c, nil
+			return cl, nil
+		})
+
+		if err != nil {
+			observer.SendError(err, "")
+			return
+		}
+
+		r.logger.Info("document classified",
+			"id", c.ID,
+			"document_id", documentID,
+			"classification", c.Classification,
+			"confidence", c.Confidence,
+		)
+
+		classBytes, err := json.Marshal(c)
+		if err != nil {
+			observer.SendError(fmt.Errorf("marshal classification: %w", err), "")
+			return
+		}
+
+		var classMap map[string]any
+		if err := json.Unmarshal(classBytes, &classMap); err != nil {
+			observer.SendError(fmt.Errorf("unmarshal classification map: %w", err), "")
+			return
+		}
+
+		observer.SendComplete(classMap)
+	}()
+
+	return observer.Events(), nil
 }
 
 func (r *repo) Validate(ctx context.Context, id uuid.UUID, cmd ValidateCommand) (*Classification, error) {

--- a/internal/classifications/system.go
+++ b/internal/classifications/system.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/JaimeStill/herald/internal/workflow"
 	"github.com/JaimeStill/herald/pkg/pagination"
 )
 
@@ -20,7 +21,7 @@ type System interface {
 
 	Find(ctx context.Context, id uuid.UUID) (*Classification, error)
 	FindByDocument(ctx context.Context, documentID uuid.UUID) (*Classification, error)
-	Classify(ctx context.Context, documentID uuid.UUID) (*Classification, error)
+	Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error)
 	Validate(ctx context.Context, id uuid.UUID, cmd ValidateCommand) (*Classification, error)
 	Update(ctx context.Context, id uuid.UUID, cmd UpdateCommand) (*Classification, error)
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/tests/classifications/handler_test.go
+++ b/tests/classifications/handler_test.go
@@ -1,6 +1,7 @@
 package classifications_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -8,12 +9,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/JaimeStill/herald/internal/classifications"
+	"github.com/JaimeStill/herald/internal/workflow"
 	"github.com/JaimeStill/herald/pkg/pagination"
 )
 
@@ -21,7 +24,7 @@ type mockSystem struct {
 	listFn           func(ctx context.Context, page pagination.PageRequest, filters classifications.Filters) (*pagination.PageResult[classifications.Classification], error)
 	findFn           func(ctx context.Context, id uuid.UUID) (*classifications.Classification, error)
 	findByDocumentFn func(ctx context.Context, documentID uuid.UUID) (*classifications.Classification, error)
-	classifyFn       func(ctx context.Context, documentID uuid.UUID) (*classifications.Classification, error)
+	classifyFn       func(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error)
 	validateFn       func(ctx context.Context, id uuid.UUID, cmd classifications.ValidateCommand) (*classifications.Classification, error)
 	updateFn         func(ctx context.Context, id uuid.UUID, cmd classifications.UpdateCommand) (*classifications.Classification, error)
 	deleteFn         func(ctx context.Context, id uuid.UUID) error
@@ -43,7 +46,7 @@ func (m *mockSystem) FindByDocument(ctx context.Context, documentID uuid.UUID) (
 	return m.findByDocumentFn(ctx, documentID)
 }
 
-func (m *mockSystem) Classify(ctx context.Context, documentID uuid.UUID) (*classifications.Classification, error) {
+func (m *mockSystem) Classify(ctx context.Context, documentID uuid.UUID) (<-chan workflow.ExecutionEvent, error) {
 	return m.classifyFn(ctx, documentID)
 }
 
@@ -357,35 +360,74 @@ func TestHandlerSearch(t *testing.T) {
 }
 
 func TestHandlerClassify(t *testing.T) {
-	c := sampleClassification()
+	docID := uuid.MustParse("660e8400-e29b-41d4-a716-446655440000")
 
-	t.Run("classifies document", func(t *testing.T) {
+	t.Run("streams SSE events", func(t *testing.T) {
 		var capturedDocID uuid.UUID
 		sys := &mockSystem{
-			classifyFn: func(_ context.Context, docID uuid.UUID) (*classifications.Classification, error) {
-				capturedDocID = docID
-				return &c, nil
+			classifyFn: func(_ context.Context, id uuid.UUID) (<-chan workflow.ExecutionEvent, error) {
+				capturedDocID = id
+				ch := make(chan workflow.ExecutionEvent, 3)
+				ch <- workflow.ExecutionEvent{Type: workflow.NodeStart, Timestamp: time.Now(), Data: map[string]any{"node": "init", "iteration": 1}}
+				ch <- workflow.ExecutionEvent{Type: workflow.NodeComplete, Timestamp: time.Now(), Data: map[string]any{"node": "init", "iteration": 1}}
+				ch <- workflow.ExecutionEvent{Type: workflow.Complete, Timestamp: time.Now(), Data: map[string]any{"classification": "SECRET"}}
+				close(ch)
+				return ch, nil
 			},
 		}
 		mux := setupMux(newTestHandler(sys))
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/classifications/"+c.DocumentID.String(), nil)
+		req := httptest.NewRequest("POST", "/classifications/"+docID.String(), nil)
 		mux.ServeHTTP(rec, req)
 
-		if rec.Code != http.StatusCreated {
-			t.Fatalf("status = %d, want 201", rec.Code)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
 		}
-		if capturedDocID != c.DocumentID {
-			t.Errorf("documentId = %v, want %v", capturedDocID, c.DocumentID)
+		if capturedDocID != docID {
+			t.Errorf("documentId = %v, want %v", capturedDocID, docID)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+			t.Errorf("Content-Type = %q, want text/event-stream", ct)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("Cache-Control = %q, want no-cache", cc)
 		}
 
-		var got classifications.Classification
-		if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-			t.Fatalf("decode: %v", err)
+		// Parse SSE events from response body
+		var events []struct {
+			eventType string
+			data      string
 		}
-		if got.Classification != "SECRET" {
-			t.Errorf("classification = %q, want SECRET", got.Classification)
+		scanner := bufio.NewScanner(rec.Body)
+		var currentType, currentData string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: ") {
+				currentType = strings.TrimPrefix(line, "event: ")
+			} else if strings.HasPrefix(line, "data: ") {
+				currentData = strings.TrimPrefix(line, "data: ")
+			} else if line == "" && currentType != "" {
+				events = append(events, struct {
+					eventType string
+					data      string
+				}{currentType, currentData})
+				currentType = ""
+				currentData = ""
+			}
+		}
+
+		if len(events) != 3 {
+			t.Fatalf("event count = %d, want 3", len(events))
+		}
+		if events[0].eventType != "node.start" {
+			t.Errorf("event[0].type = %q, want node.start", events[0].eventType)
+		}
+		if events[1].eventType != "node.complete" {
+			t.Errorf("event[1].type = %q, want node.complete", events[1].eventType)
+		}
+		if events[2].eventType != "complete" {
+			t.Errorf("event[2].type = %q, want complete", events[2].eventType)
 		}
 	})
 
@@ -402,9 +444,9 @@ func TestHandlerClassify(t *testing.T) {
 		}
 	})
 
-	t.Run("system error maps to status", func(t *testing.T) {
+	t.Run("pre-stream error returns JSON", func(t *testing.T) {
 		sys := &mockSystem{
-			classifyFn: func(_ context.Context, _ uuid.UUID) (*classifications.Classification, error) {
+			classifyFn: func(_ context.Context, _ uuid.UUID) (<-chan workflow.ExecutionEvent, error) {
 				return nil, classifications.ErrNotFound
 			},
 		}
@@ -416,6 +458,9 @@ func TestHandlerClassify(t *testing.T) {
 
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Errorf("Content-Type = %q, want application/json for pre-stream error", ct)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Modifies the existing `POST /api/classifications/{documentId}` endpoint to return an SSE event stream instead of a JSON response. The `Classify` method, handler, and route are updated in-place — same URL, same method, streaming behavior. Consolidates to a single SSE-based classify path per the objective.md consolidation note.

Closes #71

## Changes

- Change `Classify` return type on System interface to `(<-chan workflow.ExecutionEvent, error)`
- Rewrite `Classify` in repository: pre-flight document validation, goroutine with StreamingObserver, workflow execution, DB persistence, complete/error event emission
- Rewrite `Classify` handler: SSE headers, event loop with per-event flush, context cancellation for client disconnect
- Update mock and `TestHandlerClassify` tests for SSE streaming (header verification, event parsing, pre-stream error behavior)
- Update API Cartographer docs with SSE event types and streaming curl example