### PR TITLE
Add document types, services, and SSE stream enhancement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,7 +50,7 @@ All test authorship is an AI responsibility. Tests live in `tests/` mirroring th
 
 ### Documentation
 
-Godoc comments on exported types, functions, and methods are an AI responsibility. Added after implementation, not in guides.
+Godoc comments on exported Go types, functions, and methods are an AI responsibility. JSDoc comments on exported TypeScript types, interfaces, service objects, and public functions are an AI responsibility. Both are added after implementation, not in guides.
 
 ## Development
 

--- a/.claude/context/guides/.archive/74-document-types-service-sse-stream.md
+++ b/.claude/context/guides/.archive/74-document-types-service-sse-stream.md
@@ -1,0 +1,556 @@
+# 74 - Document types, service, and SSE stream enhancement
+
+## Problem Context
+
+First sub-issue of Objective #59 (Document Management View). The web client currently has placeholder views with no data layer. This task establishes the foundational infrastructure that all subsequent view components depend on: enhanced SSE streaming to support the classification endpoint's `event:` + `data:` format with POST method, TypeScript domain types mirroring Go API response shapes, and stateless services that mirror the Go API domain architecture.
+
+This also establishes two key client-side conventions:
+
+1. **Domain directory convention**: Types and services live in their own domain directories (`documents/`, `classifications/`) separate from view components (`views/`).
+2. **Service/state separation**: Services are stateless API wrappers that mirror Go domains. State orchestration (signals, context, reactive coordination) lives adjacent to the views/components that need it and is delivered in later sub-issues.
+
+## Architecture Approach
+
+**Services** — stateless objects that mirror Go API domain structure. Each service has a `base` path constant and methods that map directly to server endpoints. Methods return `Result<T>` for request-response, `AbortController` for streaming. No signals, no context, no state.
+
+**Types** — domain interfaces in their own directories, mirroring Go struct shapes. `ExecutionEvent` lives in `core/` as SSE streaming infrastructure.
+
+**State** — deferred to view assembly tasks (#75–#77). Components call services directly and manage their own state. Shared reactive data (e.g., document list) uses `Signal.State` via `@lit/context`. Local concerns (classify progress, errors) use `@state()`. No state orchestration layer between services and components.
+
+## Implementation
+
+### Step 1: Enhance `stream()` and add `ExecutionEvent` in `core/api.ts`
+
+In `app/client/core/api.ts`, add the `ExecutionEvent` interface after the `Result` type:
+
+```typescript
+export interface ExecutionEvent {
+  type: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+```
+
+Replace the `StreamOptions` interface:
+
+```typescript
+export interface StreamOptions {
+  onEvent: (type: string, data: string) => void;
+  onError?: (error: string) => void;
+  onComplete?: () => void;
+  signal?: AbortSignal;
+}
+```
+
+Replace the `stream()` function:
+
+```typescript
+export function stream(
+  path: string,
+  options: StreamOptions,
+  init?: RequestInit,
+): AbortController {
+  const controller = new AbortController();
+  const signal = options.signal ?? controller.signal;
+
+  fetch(`${BASE}${path}`, { ...init, signal })
+    .then(async (res) => {
+      if (!res.ok) {
+        const text = await res.text();
+        options.onError?.(text || res.statusText);
+        return;
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) {
+        options.onError?.('No response body');
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let currentEvent = 'message';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
+            const data = line.slice(6).trim();
+            options.onEvent(currentEvent, data);
+            currentEvent = 'message';
+          }
+        }
+      }
+
+      options.onComplete?.();
+    })
+    .catch((err: Error) => {
+      if (err.name !== 'AbortError') {
+        options.onError?.(err.message);
+      }
+    });
+
+  return controller;
+}
+```
+
+Key changes from existing code:
+- `onMessage` → `onEvent(type, data)` with event type tracking
+- Added `init?: RequestInit` parameter, merged via `{ ...init, signal }`
+- Removed `[DONE]` sentinel — completion on reader `done`
+- Tracks `currentEvent` from `event:` lines, pairs with next `data:` line, resets to `'message'`
+
+### Step 2: Update `core/index.ts` barrel
+
+In `app/client/core/index.ts`, add `ExecutionEvent` to the type re-export:
+
+```typescript
+export { request, stream, toQueryString } from './api';
+export type { Result, StreamOptions, ExecutionEvent, PageResult, PageRequest } from './api';
+```
+
+### Step 3: Create `documents/document.ts`
+
+Create `app/client/documents/document.ts`:
+
+```typescript
+export type DocumentStatus = 'pending' | 'review' | 'complete';
+
+export interface Document {
+  id: string;
+  external_id: number;
+  external_platform: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  page_count: number | null;
+  storage_key: string;
+  status: DocumentStatus;
+  uploaded_at: string;
+  updated_at: string;
+  classification?: string;
+  confidence?: string;
+  classified_at?: string;
+}
+```
+
+### Step 4: Create `classifications/classification.ts`
+
+Create `app/client/classifications/classification.ts`:
+
+```typescript
+export interface Classification {
+  id: string;
+  document_id: string;
+  classification: string;
+  confidence: string;
+  markings_found: string[];
+  rationale: string;
+  classified_at: string;
+  model_name: string;
+  provider_name: string;
+  validated_by?: string;
+  validated_at?: string;
+}
+```
+
+### Step 5: Create `prompts/prompt.ts`
+
+Create `app/client/prompts/prompt.ts`:
+
+```typescript
+export type PromptStage = 'classify' | 'enhance' | 'finalize';
+
+export interface Prompt {
+  id: string;
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+  active: boolean;
+}
+
+export interface StageContent {
+  stage: PromptStage;
+  content: string;
+}
+
+export interface CreatePromptCommand {
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+}
+
+export interface UpdatePromptCommand {
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+}
+```
+
+### Step 6: Create `storage/blob.ts`
+
+Create `app/client/storage/blob.ts`:
+
+```typescript
+export interface BlobMeta {
+  name: string;
+  content_type: string;
+  content_length: number;
+  last_modified: string;
+  etag: string;
+  created_at: string;
+}
+
+export interface BlobList {
+  blobs: BlobMeta[];
+  next_marker?: string;
+}
+```
+
+### Step 7: Create `documents/service.ts`
+
+Create `app/client/documents/service.ts`:
+
+Stateless service object mirroring the Go `documents` handler. Every handler method has a corresponding service method. Base path captured once. Returns `Result<T>` — no signals, no state.
+
+```typescript
+import {
+  request, toQueryString,
+  type Result, type PageResult, type PageRequest,
+} from '@app/core';
+import type { Document } from './document';
+
+const base = '/documents';
+
+export const DocumentService = {
+  async list(params?: PageRequest): Promise<Result<PageResult<Document>>> {
+    return await request<PageResult<Document>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  async find(id: string): Promise<Result<Document>> {
+    return await request<Document>(`${base}/${id}`);
+  },
+
+  async search(body: PageRequest): Promise<Result<PageResult<Document>>> {
+    return await request<PageResult<Document>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  async upload(
+    file: File,
+    externalId: number,
+    platform: string,
+  ): Promise<Result<Document>> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('external_id', String(externalId));
+    form.append('external_platform', platform);
+
+    return await request<Document>(base, {
+      method: 'POST',
+      body: form,
+    });
+  },
+
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};
+```
+
+### Step 6: Create `classifications/service.ts`
+
+Create `app/client/classifications/service.ts`:
+
+Stateless service object mirroring the Go `classifications` handler. The `classify` method returns the `AbortController` from `stream()` — the caller provides `StreamOptions` callbacks, giving the state layer full control over SSE event processing.
+
+```typescript
+import {
+  request, stream, toQueryString,
+  type Result, type PageResult, type PageRequest, type StreamOptions,
+} from '@app/core';
+import type { Classification } from './classification';
+
+export interface ValidateCommand {
+  validated_by: string;
+}
+
+export interface UpdateCommand {
+  classification: string;
+  rationale: string;
+  updated_by: string;
+}
+
+const base = '/classifications';
+
+export const ClassificationService = {
+  async list(params?: PageRequest): Promise<Result<PageResult<Classification>>> {
+    return await request<PageResult<Classification>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  async find(id: string): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}`);
+  },
+
+  async findByDocument(documentId: string): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/document/${documentId}`);
+  },
+
+  async search(body: PageRequest): Promise<Result<PageResult<Classification>>> {
+    return await request<PageResult<Classification>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  classify(documentId: string, options: StreamOptions): AbortController {
+    return stream(`${base}/${documentId}`, options, { method: 'POST' });
+  },
+
+  async validate(id: string, command: ValidateCommand): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  async update(id: string, command: UpdateCommand): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};
+```
+
+### Step 8: Create `prompts/service.ts`
+
+Create `app/client/prompts/service.ts`:
+
+Stateless service object mirroring the Go `prompts` handler. All 11 handler methods mapped.
+
+```typescript
+import {
+  request, toQueryString,
+  type Result, type PageResult, type PageRequest,
+} from '@app/core';
+import type { Prompt, StageContent, PromptStage, CreatePromptCommand, UpdatePromptCommand } from './prompt';
+
+const base = '/prompts';
+
+export const PromptService = {
+  async list(params?: PageRequest): Promise<Result<PageResult<Prompt>>> {
+    return await request<PageResult<Prompt>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  async stages(): Promise<Result<PromptStage[]>> {
+    return await request<PromptStage[]>(`${base}/stages`);
+  },
+
+  async find(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}`);
+  },
+
+  async instructions(stage: PromptStage): Promise<Result<StageContent>> {
+    return await request<StageContent>(`${base}/${stage}/instructions`);
+  },
+
+  async spec(stage: PromptStage): Promise<Result<StageContent>> {
+    return await request<StageContent>(`${base}/${stage}/spec`);
+  },
+
+  async create(command: CreatePromptCommand): Promise<Result<Prompt>> {
+    return await request<Prompt>(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  async update(id: string, command: UpdatePromptCommand): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+
+  async search(body: PageRequest): Promise<Result<PageResult<Prompt>>> {
+    return await request<PageResult<Prompt>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  async activate(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}/activate`, {
+      method: 'POST',
+    });
+  },
+
+  async deactivate(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}/deactivate`, {
+      method: 'POST',
+    });
+  },
+};
+```
+
+### Step 9: Create `storage/service.ts`
+
+Create `app/client/storage/service.ts`:
+
+Stateless service object mirroring the Go `storage` handler. The `download` method uses a custom `parse` callback to return a `Blob` instead of JSON, and constructs a download URL for direct browser use.
+
+```typescript
+import {
+  request,
+  type Result,
+} from '@app/core';
+import type { BlobMeta, BlobList } from './blob';
+
+export interface StorageListParams {
+  prefix?: string;
+  marker?: string;
+  max_results?: number;
+}
+
+const base = '/storage';
+
+export const StorageService = {
+  async list(params?: StorageListParams): Promise<Result<BlobList>> {
+    const entries = Object.entries(params ?? {})
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+
+    const qs = entries.length > 0 ? `?${entries.join('&')}` : '';
+    return await request<BlobList>(`${base}${qs}`);
+  },
+
+  async find(key: string): Promise<Result<BlobMeta>> {
+    return await request<BlobMeta>(`${base}/${key}`);
+  },
+
+  async download(key: string): Promise<Result<Blob>> {
+    return await request<Blob>(
+      `${base}/download/${key}`,
+      undefined,
+      (res) => res.blob(),
+    );
+  },
+};
+```
+
+### Step 10: Create domain barrel exports
+
+Create `app/client/documents/index.ts`:
+
+```typescript
+export * from './document';
+export { DocumentService } from './service';
+```
+
+Create `app/client/classifications/index.ts`:
+
+```typescript
+export * from './classification';
+export { ClassificationService } from './service';
+export type { ValidateCommand, UpdateCommand } from './service';
+```
+
+Create `app/client/prompts/index.ts`:
+
+```typescript
+export * from './prompt';
+export { PromptService } from './service';
+```
+
+Create `app/client/storage/index.ts`:
+
+```typescript
+export * from './blob';
+export { StorageService } from './service';
+export type { StorageListParams } from './service';
+```
+
+### Step 11: Verify view barrel stays clean
+
+`app/client/views/documents/index.ts` should remain as-is — only exporting the view component:
+
+```typescript
+export * from './documents-view';
+```
+
+No types, services, or state in the view barrel.
+
+### Step 12: Update web-development skill
+
+Update `.claude/skills/web-development/SKILL.md` and relevant references to capture the new conventions:
+
+1. **Domain directory convention**: Types and services in domain directories (`documents/`, `classifications/`), separate from `views/`
+2. **Service/state separation**: Services are stateless API wrappers (plain objects with a `base` path, methods return `Result<T>` or `AbortController`). State orchestration (signals, context, `ClassifyProgress`) lives adjacent to views/components.
+3. **Component organization**: `components/` for stateful components, `elements/` for pure/stateless elements
+4. **View directories**: Only view components in `views/<domain>/`, importing from domain directories
+
+Update `references/services.md` to reflect the stateless service pattern and domain directory import paths (e.g., `@app/documents`).
+
+## Validation Criteria
+
+- [ ] `stream()` accepts `init?: RequestInit` and merges with abort signal
+- [ ] `stream()` parses `event:` lines and pairs with `data:` lines via `onEvent(type, data)` callback
+- [ ] `stream()` completes when reader reports done (no `[DONE]` sentinel dependency)
+- [ ] `ExecutionEvent` in `core/api.ts`, re-exported from `core/index.ts`
+- [ ] `Document` and `DocumentStatus` in `documents/document.ts`
+- [ ] `Classification` in `classifications/classification.ts`
+- [ ] `Prompt`, `PromptStage`, `StageContent`, `CreatePromptCommand`, `UpdatePromptCommand` in `prompts/prompt.ts`
+- [ ] `BlobMeta` and `BlobList` in `storage/blob.ts`
+- [ ] `ValidateCommand` and `UpdateCommand` in `classifications/service.ts`
+- [ ] `DocumentService` — maps all 5 handler methods: `list`, `find`, `search`, `upload`, `delete`
+- [ ] `ClassificationService` — maps all 8 handler methods: `list`, `find`, `findByDocument`, `search`, `classify`, `validate`, `update`, `delete`
+- [ ] `PromptService` — maps all 11 handler methods: `list`, `stages`, `find`, `instructions`, `spec`, `create`, `update`, `delete`, `search`, `activate`, `deactivate`
+- [ ] `StorageService` — maps all 3 handler methods: `list`, `find`, `download`
+- [ ] Services use PascalCase names and `base` path constant
+- [ ] Services return `Result<T>` for request-response, `AbortController` for streaming
+- [ ] No signals, context, or state in services
+- [ ] Domain barrels export types and services
+- [ ] View barrel only exports view component
+- [ ] Web-development skill updated with service/state separation and domain directory conventions
+- [ ] `bun run build` compiles without errors

--- a/.claude/context/sessions/74-document-types-service-sse-stream.md
+++ b/.claude/context/sessions/74-document-types-service-sse-stream.md
@@ -1,0 +1,60 @@
+# 74 - Document types, service, and SSE stream enhancement
+
+## Summary
+
+Established the web client's foundational data layer: enhanced SSE streaming with event type parsing and POST support, TypeScript domain types mirroring all Go API response shapes, and stateless service objects mapping every Go handler endpoint across four domains (documents, classifications, prompts, storage). Also established the domain directory convention and simplified the component/state architecture — components call services directly with no orchestration middleman.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Domain directory convention | Types and services in `app/client/<domain>/`, separate from `views/` | Domain infrastructure is shared across views; co-locating with views creates coupling |
+| Service/state separation | Stateless services + components call services directly | Eliminates unnecessary orchestration layer; components already know when to call services |
+| No state files | Shared data via `Signal.State` + `@provide`/`@consume` inline; local state via `@state()` | Factory functions with methods were pass-through wrappers that added complexity without value |
+| Encapsulated streaming | Document component owns classify SSE lifecycle, emits completion event | Per-document concern; parent view only cares about outcome, not intermediate progress |
+| Full endpoint coverage | All handler methods mapped, not just documents view needs | Services are shared infrastructure; partial coverage would require revisiting later |
+| PascalCase service objects | `DocumentService`, `ClassificationService`, etc. | Matches Go naming convention; clearly distinguishes services from local variables |
+| JSDoc on public TypeScript API | Same responsibility as Godoc on Go exports | Provides IDE intellisense for foundational infrastructure used across all views |
+
+## Files Modified
+
+- `app/client/core/api.ts` — Enhanced `stream()` with `onEvent(type, data)`, `init?: RequestInit`; added `ExecutionEvent`; JSDoc
+- `app/client/core/index.ts` — Re-export `ExecutionEvent`, `StreamOptions`
+- `app/client/documents/document.ts` — `Document`, `DocumentStatus` types
+- `app/client/documents/service.ts` — `DocumentService` (5 methods)
+- `app/client/documents/index.ts` — Barrel
+- `app/client/classifications/classification.ts` — `Classification` type
+- `app/client/classifications/service.ts` — `ClassificationService` (8 methods), `ValidateCommand`, `UpdateCommand`
+- `app/client/classifications/index.ts` — Barrel
+- `app/client/prompts/prompt.ts` — `Prompt`, `PromptStage`, `StageContent`, command types
+- `app/client/prompts/service.ts` — `PromptService` (11 methods)
+- `app/client/prompts/index.ts` — Barrel
+- `app/client/storage/blob.ts` — `BlobMeta`, `BlobList` types
+- `app/client/storage/service.ts` — `StorageService` (3 methods), `StorageListParams`
+- `app/client/storage/index.ts` — Barrel
+- `app/client/router/types.ts` — JSDoc added
+- `app/client/router/router.ts` — JSDoc added
+- `app/client/router/routes.ts` — JSDoc added
+- `app/client/css.d.ts` — JSDoc added
+- `.claude/CLAUDE.md` — Added JSDoc convention alongside Godoc
+- `.claude/skills/web-development/SKILL.md` — Updated architecture (services/state, component hierarchy, anti-patterns)
+- `.claude/skills/web-development/references/services.md` — Rewritten for stateless service pattern
+- `.claude/skills/web-development/references/state.md` — New: shared reactive state, encapsulated streaming
+- `.claude/skills/web-development/references/components.md` — Rewritten: components call services directly
+- `.claude/skills/web-development/references/api.md` — Rewritten: new stream() API, event parsing
+
+## Patterns Established
+
+- **Domain directory convention**: `app/client/<domain>/` holds types + stateless service, separate from views
+- **Stateless service pattern**: PascalCase objects with `base` path, methods return `Result<T>` or `AbortController`
+- **Components call services directly**: No orchestration layer; views update signals, components use `@state()` for local concerns
+- **Encapsulated streaming**: Component owning the SSE concern manages its own lifecycle and emits completion events
+- **JSDoc as AI responsibility**: Added to `.claude/CLAUDE.md` alongside Godoc convention
+
+## Validation Results
+
+- `bun run build` compiles without errors
+- All 14 new files verified with correct exports
+- All 4 services map every Go handler endpoint (27 methods total)
+- `stream()` correctly parses `event:` + `data:` line pairs
+- Web-development skill fully updated with simplified architecture

--- a/.claude/plans/mutable-doodling-phoenix.md
+++ b/.claude/plans/mutable-doodling-phoenix.md
@@ -1,0 +1,261 @@
+# Plan: #74 — Document types, service, and SSE stream enhancement
+
+## Context
+
+First sub-issue of Objective #59 (Document Management View). Establishes the data layer that all subsequent view components depend on: enhanced SSE streaming, TypeScript domain types mirroring Go API shapes, and a reactive service with Signal.State signals. No existing callers of `stream()` beyond its export — the breaking signature change is safe.
+
+This task also establishes the client-side domain directory convention: domain infrastructure (types, services) live in their own directories under `app/client/`, separate from view components in `views/`. The web-development skill and project context documents will be updated to capture these conventions.
+
+## Directory Structure (New Convention)
+
+```
+app/client/
+├── core/
+│   ├── api.ts              # stream() enhancement + ExecutionEvent type
+│   └── index.ts            # barrel (re-export ExecutionEvent)
+├── documents/
+│   ├── document.ts         # Document type + DocumentStatus
+│   ├── service.ts          # DocumentService + context + factory
+│   └── index.ts            # barrel
+├── classifications/
+│   ├── classification.ts   # Classification type
+│   └── index.ts            # barrel
+├── components/             # (future) stateful components
+├── elements/               # (future) stateless/pure elements
+├── views/
+│   ├── documents/          # view components only (no types/services)
+│   │   ├── documents-view.ts
+│   │   ├── documents-view.module.css
+│   │   └── index.ts
+│   ...
+```
+
+**Convention**: Domain directories (`documents/`, `classifications/`) hold types and services. `views/` holds view components that import from domain directories. `components/` holds stateful components, `elements/` holds pure elements. View subdirectories may contain view-specific sub-components if tightly coupled.
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `app/client/core/api.ts` | Modify — enhance `stream()`, add `ExecutionEvent` type |
+| `app/client/core/index.ts` | Modify — re-export `ExecutionEvent` |
+| `app/client/documents/document.ts` | Create — `Document`, `DocumentStatus` |
+| `app/client/documents/service.ts` | Create — `DocumentService`, context, factory |
+| `app/client/documents/index.ts` | Create — barrel |
+| `app/client/classifications/classification.ts` | Create — `Classification` |
+| `app/client/classifications/index.ts` | Create — barrel |
+| `app/client/views/documents/index.ts` | Verify — should only export view component |
+
+## Step 1: Enhance `stream()` and add `ExecutionEvent` in `core/api.ts`
+
+### ExecutionEvent type
+
+Add at the top of `api.ts` alongside other types:
+
+```typescript
+export interface ExecutionEvent {
+  type: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+```
+
+This lives in `core/` because it's SSE streaming infrastructure, not domain-specific.
+
+### StreamOptions changes
+
+Replace `onMessage` callback with `onEvent`:
+
+```typescript
+export interface StreamOptions {
+  onEvent: (type: string, data: string) => void;
+  onError?: (error: string) => void;
+  onComplete?: () => void;
+  signal?: AbortSignal;
+}
+```
+
+### stream() signature
+
+Add `init?: RequestInit` as third parameter:
+
+```typescript
+export function stream(
+  path: string,
+  options: StreamOptions,
+  init?: RequestInit,
+): AbortController
+```
+
+### Parsing logic
+
+Track current event type from `event:` lines, pair with next `data:` line:
+
+```typescript
+let buffer = '';
+let currentEvent = 'message'; // default SSE event type
+
+for (const line of lines) {
+  if (line.startsWith('event: ')) {
+    currentEvent = line.slice(7).trim();
+  } else if (line.startsWith('data: ')) {
+    const data = line.slice(6).trim();
+    options.onEvent(currentEvent, data);
+    currentEvent = 'message'; // reset to default
+  }
+}
+```
+
+### Other changes
+
+- Remove `[DONE]` sentinel check — completion signaled when reader reports `done`
+- Merge init with signal: `fetch(\`${BASE}${path}\`, { ...init, signal })`
+
+### Update `core/index.ts`
+
+Add `ExecutionEvent` to the type re-export line.
+
+## Step 2: Document type in `documents/document.ts`
+
+```typescript
+export type DocumentStatus = 'pending' | 'review' | 'complete';
+
+export interface Document {
+  id: string;
+  external_id: number;
+  external_platform: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  page_count: number | null;
+  storage_key: string;
+  status: DocumentStatus;
+  uploaded_at: string;
+  updated_at: string;
+  classification?: string;
+  confidence?: string;
+  classified_at?: string;
+}
+```
+
+Mirrors Go `documents.Document` struct. `page_count` is `number | null` (Go `*int`, not omitempty). Optional fields match `omitempty` tags.
+
+## Step 3: Classification type in `classifications/classification.ts`
+
+```typescript
+export interface Classification {
+  id: string;
+  document_id: string;
+  classification: string;
+  confidence: string;
+  markings_found: string[];
+  rationale: string;
+  classified_at: string;
+  model_name: string;
+  provider_name: string;
+  validated_by?: string;
+  validated_at?: string;
+}
+```
+
+Mirrors Go `classifications.Classification` struct.
+
+## Step 4: DocumentService in `documents/service.ts`
+
+Follows the established service pattern (Signal.State + @lit/context + factory).
+
+```typescript
+import { createContext } from '@lit/context';
+import { Signal } from '@lit-labs/signals';
+import {
+  request, stream, toQueryString,
+  type PageResult, type PageRequest,
+} from '@app/core';
+import type { Document } from './document';
+
+export interface DocumentService {
+  documents: Signal.State<PageResult<Document>>;
+  loading: Signal.State<boolean>;
+  error: Signal.State<string | null>;
+  classifyingIds: Signal.State<Set<string>>;
+
+  list(params?: PageRequest): void;
+  upload(file: File, externalId: number, platform: string): void;
+  remove(id: string): void;
+  classify(documentId: string): void;
+}
+
+export const documentServiceContext =
+  createContext<DocumentService>('document-service');
+
+export function createDocumentService(): DocumentService { ... }
+```
+
+### Signal initialization
+
+```typescript
+const documents = new Signal.State<PageResult<Document>>({
+  data: [], total: 0, page: 1, page_size: 20, total_pages: 0,
+});
+const loading = new Signal.State(false);
+const error = new Signal.State<string | null>(null);
+const classifyingIds = new Signal.State<Set<string>>(new Set());
+```
+
+`PageResult<Document>` carries pagination metadata — views access `.get().data` for the list.
+
+### Method implementations
+
+- **list(params?)**: GET `/documents` with query string. Sets `loading`, updates `documents` with full `PageResult`, clears on error.
+- **upload(file, externalId, platform)**: POST `/documents` with FormData. On success, refreshes the list to pick up the new document with correct pagination.
+- **remove(id)**: DELETE `/documents/${id}`. On success, refreshes the list.
+- **classify(documentId)**: POST `/classifications/${documentId}` via `stream()`. Adds ID to `classifyingIds`, processes SSE events, removes from `classifyingIds` on complete/error. On `complete` event, refreshes the document list.
+
+### classifyingIds management
+
+Must create new Set for signal reactivity (mutation doesn't trigger):
+
+```typescript
+const ids = new Set(classifyingIds.get());
+ids.add(documentId);
+classifyingIds.set(ids);
+```
+
+## Step 5: Create barrel exports
+
+### `documents/index.ts`
+
+```typescript
+export * from './document';
+export * from './service';
+```
+
+### `classifications/index.ts`
+
+```typescript
+export * from './classification';
+```
+
+## Step 6: Update web-development skill and context docs
+
+Update `.claude/skills/web-development/SKILL.md` and relevant references to capture:
+
+1. **Domain directory convention**: Types and services in domain directories (`documents/`, `classifications/`), separate from views
+2. **Component organization**: `components/` for stateful, `elements/` for pure/stateless
+3. **View directories**: Only view components in `views/<domain>/`, importing from domain directories
+
+Update `_project/objective.md` if any structural decisions need capturing.
+
+## Validation Criteria
+
+- [ ] `stream()` accepts `init?: RequestInit` and merges with abort signal
+- [ ] `stream()` parses `event:` lines and pairs with `data:` lines via `onEvent(type, data)` callback
+- [ ] `stream()` completes when reader reports done (no `[DONE]` sentinel dependency)
+- [ ] TypeScript types match Go API JSON response shapes
+- [ ] `ExecutionEvent` lives in `core/api.ts`, re-exported from `core/index.ts`
+- [ ] `Document` and `DocumentStatus` in `documents/document.ts`
+- [ ] `Classification` in `classifications/classification.ts`
+- [ ] `DocumentService` in `documents/service.ts` with all four signals and four methods
+- [ ] `documentServiceContext` exported for `@provide`/`@consume`
+- [ ] Domain barrels export types and services
+- [ ] Web-development skill updated with domain directory conventions
+- [ ] `bun run build` compiles without errors

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -29,14 +29,24 @@ description: >
 - Client-side router handles view mounting
 - No server-side view awareness for client routes
 
+### Services and State
+
+| Concern | Location | Purpose |
+|---------|----------|---------|
+| Services | `app/client/<domain>/service.ts` | Stateless API wrappers mirroring Go handlers |
+| Shared state | View/component class fields | `Signal.State` signals shared via `@lit/context` |
+| Local state | `@state()` decorator | Per-component reactive state (progress, errors, UI toggles) |
+
+Services are stateless — they return `Result<T>` or `AbortController` and forget. Components call services directly, update their own state (signals or `@state()`), and share reactive data with descendants via `@provide`/`@consume`. There is no orchestration layer between services and components.
+
 ### Three-Tier Component Hierarchy
 
 Each tier has a specific role. Violating the boundaries (e.g., a pure element directly calling an API) creates hidden dependencies that make components harder to test and reuse.
 
 | Tier | Role | Tools | Example |
 |------|------|-------|---------|
-| View | Provide services, route-level | `@provide`, `SignalWatcher` | `hd-documents-view` |
-| Stateful Component | Consume services, coordinate UI | `@consume`, event handlers | `hd-document-list` |
+| View | Call services, provide shared signals, route-level | `@provide`, `SignalWatcher`, services | `hd-documents-view` |
+| Stateful Component | Consume shared state, call services for own concerns | `@consume`, `@state()`, services, events | `hd-document-list` |
 | Pure Element | Props in, events out | `@property`, `CustomEvent` | `hd-document-card` |
 
 ## Reference Guide
@@ -45,11 +55,15 @@ Each topic below has a dedicated reference with full code examples and detailed 
 
 ### Components — [references/components.md](references/components.md)
 
-Three component tiers with complete examples: View components create and `@provide` services via `SignalWatcher(LitElement)`. Stateful components `@consume` services and coordinate UI. Pure elements accept `@property` data and emit `CustomEvent` upward. Every component uses `*.module.css` imports for styles (producing `CSSStyleSheet` directly — no `unsafeCSS()`).
+Three component tiers with complete examples: View components call services, manage `Signal.State` signals, and `@provide` shared data via `SignalWatcher(LitElement)`. Stateful components `@consume` shared state and call services for their own concerns. Pure elements accept `@property` data and emit `CustomEvent` upward. Every component uses `*.module.css` imports for styles (producing `CSSStyleSheet` directly — no `unsafeCSS()`).
 
 ### Services — [references/services.md](references/services.md)
 
-Each domain has a single `service.ts` exporting a context, interface, and factory function. State lives in `Signal.State` signals. Views create services via factory and `@provide` them; descendants `@consume`. The `SignalWatcher` mixin drives re-renders when signals change.
+Stateless API wrappers that mirror Go domain handlers. Each domain has a PascalCase service object (`DocumentService`, `ClassificationService`, etc.) with a `base` path constant. Methods return `Result<T>` for request-response and `AbortController` for streaming. No signals, no context, no state.
+
+### Shared Reactive State — [references/state.md](references/state.md)
+
+`Signal.State` signals shared across component subtrees via `@lit/context`. Views `@provide` signals as class fields; descendants `@consume` them. Components call services directly and update signals themselves — no factory functions or orchestration layer. `@state()` for local concerns (progress, errors, UI toggles). `SignalWatcher` mixin drives re-renders.
 
 ### CSS — [references/css.md](references/css.md)
 
@@ -97,18 +111,33 @@ See [references/components.md](references/components.md) for full code examples 
 
 ### File Structure
 
-Each view lives in its own subdirectory with a barrel export:
+Domain infrastructure (types, services) lives in domain directories. Views, components, and elements each have their own top-level directories.
 
 ```
-views/documents/
-├── index.ts                     # barrel export
-├── documents-view.ts            # @customElement('hd-documents-view')
-├── documents-view.module.css    # component styles
-├── service.ts                   # domain service + context + factory
-└── document-card.ts             # pure element (co-located if small)
+app/client/
+├── core/                            # API layer (request, stream, types)
+├── documents/                       # domain: types + service
+│   ├── document.ts                  # Document, DocumentStatus
+│   ├── service.ts                   # DocumentService (stateless)
+│   └── index.ts                     # barrel
+├── classifications/                 # domain: types + service
+│   ├── classification.ts            # Classification
+│   ├── service.ts                   # ClassificationService (stateless)
+│   └── index.ts                     # barrel
+├── prompts/                         # domain: types + service
+├── storage/                         # domain: types + service
+├── views/
+│   └── documents/                   # view: route-level component
+│       ├── index.ts                 # barrel (view component only)
+│       ├── documents-view.ts        # @customElement('hd-documents-view')
+│       └── documents-view.module.css
+├── components/                      # stateful components (@consume)
+├── elements/                        # pure elements (props/events)
+├── router/
+└── design/
 ```
 
-Shared components go in `app/client/components/` with the same pattern.
+**Domain directories** export types and stateless services. **View directories** export view components. **Components** and **elements** are shared across views.
 
 ### Path Alias
 
@@ -137,8 +166,10 @@ declare global {
 
 - Creating custom elements for native HTML (buttons, inputs, badges) — use CSS classes
 - Using `unsafeCSS()` — Herald's `*.module.css` plugin produces `CSSStyleSheet` directly
-- Storing service references in `@state()` — use `@consume` for context injection
-- Skipping `SignalWatcher` mixin when consuming signal-based services (reactivity won't work)
+- Skipping `SignalWatcher` mixin when consuming signal-based state (reactivity won't work)
+- Putting signals or context in service files — services are stateless API wrappers
+- Creating state orchestration layers between services and components — components call services directly
+- Pure elements calling services — only views and stateful components should import services
 - Using `height: 100%` in flex containers — use `flex: 1` with `min-height: 0`
 - Forgetting `min-height: 0` on flex children that need scroll boundaries
 - Using inline `style` attributes — use CSS classes and custom properties
@@ -149,6 +180,10 @@ declare global {
 
 - Native HTML elements with CSS classes for simple UI
 - `@provide`/`@consume` over prop drilling through intermediate components
+- `@state()` for local component concerns (progress, errors, UI toggles)
+- `Signal.State` via context only for data shared across multiple descendants
+- Components calling services directly — no orchestration middleman
+- Events up (`CustomEvent`), data down (`@property`, context) for parent-child communication
 - `nothing` from Lit for conditional non-rendering
 - FormData extraction over controlled inputs for form handling
 - `disconnectedCallback` cleanup for blob URLs and event listeners

--- a/.claude/skills/web-development/references/api.md
+++ b/.claude/skills/web-development/references/api.md
@@ -55,48 +55,126 @@ const result = await request<Document>('/documents', {
 
 // DELETE
 const result = await request<void>(`/documents/${id}`, { method: 'DELETE' });
+
+// Custom parse (non-JSON response)
+const result = await request<Blob>(
+  `/storage/download/${key}`,
+  undefined,
+  (res) => res.blob(),
+);
 ```
 
 ## stream()
 
-SSE client for classification progress. Returns an `AbortController` for cancellation.
+SSE client for server-sent event streams. Returns an `AbortController` for cancellation. Accepts an optional `RequestInit` for non-GET requests (e.g., POST for classification).
 
 ```typescript
 function stream(
   path: string,
-  callbacks: {
-    onMessage: (data: string) => void;
-    onError?: (err: string) => void;
-    onComplete?: () => void;
-  }
+  options: StreamOptions,
+  init?: RequestInit,
 ): AbortController
 ```
 
-Behavior:
-- Parses SSE `data:` lines
-- Recognizes `[DONE]` as the completion signal
-- Calls `onComplete` when the stream ends normally
-- Calls `onError` on fetch failure or stream errors
+### StreamOptions
+
+```typescript
+interface StreamOptions {
+  onEvent: (type: string, data: string) => void;
+  onError?: (error: string) => void;
+  onComplete?: () => void;
+  signal?: AbortSignal;
+}
+```
+
+### Behavior
+
+- Merges `init` with the abort signal: `fetch(\`${BASE}${path}\`, { ...init, signal })`
+- Parses SSE `event:` lines to track the current event type (defaults to `'message'`)
+- Pairs each `data:` line with the current event type, then dispatches via `onEvent(type, data)`
+- Resets event type to `'message'` after each `data:` dispatch
+- Calls `onComplete()` when the reader reports `done`
+- Calls `onError()` on fetch failure or non-ok response (ignores `AbortError`)
+
+### Event Parsing
+
+The SSE format uses `event:` and `data:` line pairs:
+
+```
+event: node.start
+data: {"type":"node.start","timestamp":"...","data":{"node":"classify"}}
+
+event: node.complete
+data: {"type":"node.complete","timestamp":"...","data":{"node":"classify"}}
+
+event: complete
+data: {"type":"complete","timestamp":"...","data":{}}
+```
+
+The parser tracks the current event type from `event:` lines and pairs it with the next `data:` line:
+
+```typescript
+let currentEvent = 'message';
+
+for (const line of lines) {
+  if (line.startsWith('event: ')) {
+    currentEvent = line.slice(7).trim();
+  } else if (line.startsWith('data: ')) {
+    const data = line.slice(6).trim();
+    options.onEvent(currentEvent, data);
+    currentEvent = 'message';
+  }
+}
+```
 
 ### Usage Example
 
 ```typescript
-const controller = stream(`/classifications/${documentId}/stream`, {
-  onMessage(data) {
+const controller = ClassificationService.classify(documentId, {
+  onEvent(type, data) {
     const event = JSON.parse(data);
-    // Update progress UI
+    switch (type) {
+      case 'node.start':
+        // Update progress UI with event.data.node
+        break;
+      case 'node.complete':
+        if (event.data.error) {
+          // Handle node-level error
+        }
+        break;
+      case 'complete':
+        // Classification finished
+        break;
+      case 'error':
+        // Workflow-level error
+        break;
+    }
   },
   onError(err) {
-    console.error('Stream error:', err);
+    // Fetch/network failure
   },
   onComplete() {
-    // Classification finished, refresh data
+    // Stream ended (reader done)
   },
 });
 
 // Cancel if needed
 controller.abort();
 ```
+
+## ExecutionEvent
+
+Typed structure for SSE events from the classification workflow:
+
+```typescript
+interface ExecutionEvent {
+  type: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+```
+
+Lives in `core/api.ts` as SSE streaming infrastructure. The `data` field in `onEvent` callbacks is the raw JSON string — parse it to get the `ExecutionEvent` shape.
 
 ## Pagination Helpers
 

--- a/.claude/skills/web-development/references/components.md
+++ b/.claude/skills/web-development/references/components.md
@@ -2,32 +2,56 @@
 
 Herald uses a three-tier component hierarchy. Each tier has a distinct responsibility, and crossing boundaries (e.g., a pure element calling an API) creates hidden coupling that makes components harder to test and reuse.
 
-## View Component (provides services)
+## View Component (provides shared state)
 
-Views are route-level components. They create services and make them available to their subtree via `@provide`. `SignalWatcher` ensures the view re-renders when signal state changes.
+Views are route-level components. They call services, manage shared reactive state via `Signal.State`, and `@provide` it to their subtree. `SignalWatcher` ensures the view re-renders when signal state changes.
 
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { provide } from '@lit/context';
-import { SignalWatcher } from '@lit-labs/signals';
-import { documentServiceContext, createDocumentService, DocumentService } from './service';
+import { createContext } from '@lit/context';
+import { SignalWatcher, Signal } from '@lit-labs/signals';
+import { DocumentService } from '@app/documents';
+import type { Document } from '@app/documents';
+import type { PageResult, PageRequest } from '@app/core';
 import styles from './documents-view.module.css';
+
+export const documentsContext =
+  createContext<Signal.State<PageResult<Document> | null>>('documents');
 
 @customElement('hd-documents-view')
 export class DocumentsView extends SignalWatcher(LitElement) {
   static styles = styles;
 
-  @provide({ context: documentServiceContext })
-  private documentService: DocumentService = createDocumentService();
+  @provide({ context: documentsContext })
+  private documents = new Signal.State<PageResult<Document> | null>(null);
 
-  connectedCallback() {
+  async connectedCallback() {
     super.connectedCallback();
-    this.documentService.list();
+    await this.refresh();
+  }
+
+  private async refresh(params?: PageRequest) {
+    const result = await DocumentService.list(params);
+    if (result.ok) this.documents.set(result.data);
+  }
+
+  private handleDocumentDeleted() {
+    this.refresh();
+  }
+
+  private handleClassifyComplete() {
+    this.refresh();
   }
 
   render() {
-    return html`<hd-document-list></hd-document-list>`;
+    return html`
+      <hd-document-list
+        @document-deleted=${this.handleDocumentDeleted}
+        @classify-complete=${this.handleClassifyComplete}
+      ></hd-document-list>
+    `;
   }
 }
 
@@ -38,31 +62,45 @@ declare global {
 }
 ```
 
-## Stateful Component (consumes services)
+## Stateful Component (consumes state, calls services)
 
-Stateful components receive services via `@consume` and coordinate UI interactions. They bridge the service layer with pure elements.
+Stateful components receive shared state via `@consume` and call services directly for their own concerns. They bridge shared state with pure elements and manage local UI state with `@state()`.
 
 ```typescript
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { consume } from '@lit/context';
-import { SignalWatcher } from '@lit-labs/signals';
-import { documentServiceContext, DocumentService } from './service';
+import { SignalWatcher, Signal } from '@lit-labs/signals';
+import { DocumentService } from '@app/documents';
+import { ClassificationService } from '@app/classifications';
+import { documentsContext } from '../views/documents/documents-view';
+import type { Document } from '@app/documents';
+import type { PageResult } from '@app/core';
 import styles from './document-list.module.css';
 
 @customElement('hd-document-list')
 export class DocumentList extends SignalWatcher(LitElement) {
   static styles = styles;
 
-  @consume({ context: documentServiceContext })
-  private documentService!: DocumentService;
+  @consume({ context: documentsContext })
+  private documents!: Signal.State<PageResult<Document> | null>;
 
-  private handleDelete(e: CustomEvent<{ id: string }>) {
-    this.documentService.delete(e.detail.id);
+  private async handleDelete(e: CustomEvent<{ id: string }>) {
+    const result = await DocumentService.delete(e.detail.id);
+    if (result.ok) {
+      this.dispatchEvent(new CustomEvent('document-deleted', {
+        bubbles: true,
+        composed: true,
+      }));
+    }
   }
 
   private renderDocuments() {
-    return this.documentService.documents.get().map(
+    const page = this.documents.get();
+    if (!page) return html`<p>Loading...</p>`;
+    if (page.data.length === 0) return html`<p>No documents</p>`;
+
+    return page.data.map(
       (doc) => html`
         <hd-document-card
           .document=${doc}
@@ -85,7 +123,7 @@ Pure elements receive data via properties and communicate upward through events.
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import type { Document } from '../types';
+import type { Document } from '@app/documents';
 import styles from './document-card.module.css';
 
 @customElement('hd-document-card')
@@ -124,9 +162,8 @@ Extract complex template logic into private `renderXxx()` methods. Use `nothing`
 import { nothing } from 'lit';
 
 private renderError() {
-  const error = this.service.error.get();
-  if (!error) return nothing;
-  return html`<div class="error">${error}</div>`;
+  if (!this.error) return nothing;
+  return html`<div class="error">${this.error}</div>`;
 }
 
 render() {
@@ -142,19 +179,28 @@ render() {
 Extract values via FormData on submit rather than tracking controlled inputs:
 
 ```typescript
-private handleSubmit(e: Event) {
+private async handleSubmit(e: Event) {
   e.preventDefault();
   const form = e.target as HTMLFormElement;
   const data = new FormData(form);
-  this.service.save({
+
+  const result = await PromptService.create({
     name: data.get('name') as string,
+    stage: data.get('stage') as PromptStage,
+    instructions: data.get('instructions') as string,
   });
+
+  if (result.ok) {
+    this.dispatchEvent(new CustomEvent('prompt-created', {
+      bubbles: true, composed: true,
+    }));
+  }
 }
 
 render() {
   return html`
     <form @submit=${this.handleSubmit}>
-      <input name="name" .value=${this.item.name} required />
+      <input name="name" required />
       <button type="submit">Save</button>
     </form>
   `;

--- a/.claude/skills/web-development/references/services.md
+++ b/.claude/skills/web-development/references/services.md
@@ -1,95 +1,88 @@
-# Service Infrastructure
+# Services
 
-Each domain has a single `service.ts` that exports three things: a context key, an interface, and a factory function. This co-location keeps the service contract, creation, and dependency injection in one place.
+Stateless API wrappers that mirror Go domain handlers. Each domain has a PascalCase service object with a `base` path constant. Methods return `Result<T>` for request-response and `AbortController` for streaming. No signals, no context, no state.
 
-## Consolidated Service File
+## Service Pattern
 
 ```typescript
 // documents/service.ts
-import { createContext } from '@lit/context';
-import { Signal } from '@lit-labs/signals';
-import { request, type PageResult, toQueryString, type PageRequest } from '@app/core';
+import {
+  request, toQueryString,
+  type Result, type PageResult, type PageRequest,
+} from '@app/core';
+import type { Document } from './document';
 
-export interface DocumentService {
-  documents: Signal.State<Document[]>;
-  loading: Signal.State<boolean>;
-  error: Signal.State<string | null>;
+const base = '/documents';
 
-  list(params?: PageRequest): void;
-  find(id: string): void;
-  upload(file: File): void;
-  delete(id: string): void;
-}
+export const DocumentService = {
+  async list(params?: PageRequest): Promise<Result<PageResult<Document>>> {
+    return await request<PageResult<Document>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
 
-export const documentServiceContext = createContext<DocumentService>('document-service');
+  async find(id: string): Promise<Result<Document>> {
+    return await request<Document>(`${base}/${id}`);
+  },
 
-export function createDocumentService(): DocumentService {
-  const documents = new Signal.State<Document[]>([]);
-  const loading = new Signal.State<boolean>(false);
-  const error = new Signal.State<string | null>(null);
+  async upload(
+    file: File,
+    externalId: number,
+    platform: string,
+  ): Promise<Result<Document>> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('external_id', String(externalId));
+    form.append('external_platform', platform);
 
-  return {
-    documents,
-    loading,
-    error,
+    return await request<Document>(base, {
+      method: 'POST',
+      body: form,
+    });
+  },
 
-    async list(params) {
-      loading.set(true);
-      const qs = params ? toQueryString(params) : '';
-      const result = await request<PageResult<Document>>(`/documents${qs}`);
-      if (result.ok) {
-        documents.set(result.data.data);
-      } else {
-        error.set(result.error);
-      }
-      loading.set(false);
-    },
-
-    async find(id) { /* ... */ },
-    async upload(file) { /* ... */ },
-    async delete(id) { /* ... */ },
-  };
-}
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};
 ```
 
-## How Services Flow Through the Hierarchy
+## Streaming Endpoints
 
-1. **View creates** the service via factory and `@provide`s it:
+SSE endpoints return `AbortController`. The caller provides `StreamOptions` callbacks, giving the state layer full control over event processing.
 
 ```typescript
-@provide({ context: documentServiceContext })
-private documentService: DocumentService = createDocumentService();
+// classifications/service.ts
+import { stream, type StreamOptions } from '@app/core';
+
+const base = '/classifications';
+
+export const ClassificationService = {
+  classify(documentId: string, options: StreamOptions): AbortController {
+    return stream(`${base}/${documentId}`, options, { method: 'POST' });
+  },
+  // ...other methods
+};
 ```
 
-2. **Stateful components** `@consume` the service from context:
+## Conventions
 
-```typescript
-@consume({ context: documentServiceContext })
-private documentService!: DocumentService;
-```
+- **PascalCase names**: `DocumentService`, `ClassificationService`, `PromptService`, `StorageService`
+- **`base` constant**: Each service captures its API prefix once — methods use `${base}/...`
+- **Mirror Go handlers**: Every handler method has a corresponding service method with matching semantics
+- **`Result<T>` returns**: Request-response methods return `Result<T>` directly from `request()`
+- **`AbortController` returns**: Streaming methods return the controller from `stream()`
+- **No state**: Services never import `Signal`, `createContext`, or `@lit/context`
+- **Domain directories**: Services live in `app/client/<domain>/service.ts`, not in view directories
+- **Barrel exports**: `export { DocumentService } from './service'` — named export, not `export *`
 
-3. **Pure elements** never touch services — they receive data via `@property` and emit events upward.
+## Available Services
 
-## Signal Reactivity
-
-`Signal.State` values are read with `.get()` and written with `.set()`. The `SignalWatcher` mixin on view and stateful components ensures Lit re-renders when any signal read during `render()` changes.
-
-Without `SignalWatcher`, signal changes will not trigger re-renders — this is a common mistake.
-
-```typescript
-// Reading in templates (inside SignalWatcher component)
-${this.service.loading.get() ? html`<p>Loading...</p>` : nothing}
-
-// Writing in service methods
-loading.set(true);
-documents.set(result.data.data);
-```
-
-## Service Conventions
-
-- One `service.ts` per domain (documents, prompts, classifications)
-- Context string keys are kebab-case: `'document-service'`, `'prompt-service'`
-- Factory functions are `createXxxService()` — pure functions, no side effects until called
-- Signals expose `.get()` for reading and `.set()` for writing
-- Error state is `Signal.State<string | null>` — `null` means no error
-- Loading state gates UI to prevent stale data display
+| Service | Domain | Import |
+|---------|--------|--------|
+| `DocumentService` | `documents/` | `import { DocumentService } from '@app/documents'` |
+| `ClassificationService` | `classifications/` | `import { ClassificationService } from '@app/classifications'` |
+| `PromptService` | `prompts/` | `import { PromptService } from '@app/prompts'` |
+| `StorageService` | `storage/` | `import { StorageService } from '@app/storage'` |

--- a/.claude/skills/web-development/references/state.md
+++ b/.claude/skills/web-development/references/state.md
@@ -1,0 +1,185 @@
+# Shared Reactive State
+
+Views and stateful components use `Signal.State` signals with `@lit/context` to share reactive data across their subtree. Components call services directly and update signals themselves — there is no orchestration layer between services and components.
+
+## When to Use Context
+
+Use `@provide`/`@consume` with signals when a parent component has data that multiple descendants need reactively. If only one child needs the data, pass it as a `@property` instead.
+
+```typescript
+// View provides shared data to its subtree
+@provide({ context: documentsContext })
+private documents = new Signal.State<PageResult<Document> | null>(null);
+```
+
+## Providing Shared State
+
+Views create signals as class fields and `@provide` them. The view calls services directly and updates its own signals.
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { provide } from '@lit/context';
+import { SignalWatcher, Signal } from '@lit-labs/signals';
+import { createContext } from '@lit/context';
+import { DocumentService } from '@app/documents';
+import type { Document, PageResult, PageRequest } from '@app/documents';
+
+export const documentsContext =
+  createContext<Signal.State<PageResult<Document> | null>>('documents');
+
+@customElement('hd-documents-view')
+export class DocumentsView extends SignalWatcher(LitElement) {
+  @provide({ context: documentsContext })
+  private documents = new Signal.State<PageResult<Document> | null>(null);
+
+  async connectedCallback() {
+    super.connectedCallback();
+    const result = await DocumentService.list();
+    if (result.ok) this.documents.set(result.data);
+  }
+
+  render() {
+    return html`<hd-document-list></hd-document-list>`;
+  }
+}
+```
+
+## Consuming Shared State
+
+Descendants `@consume` the signal and call `.get()` in templates. `SignalWatcher` drives re-renders when the signal value changes.
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { SignalWatcher, Signal } from '@lit-labs/signals';
+import { documentsContext } from '../views/documents/documents-view';
+import type { Document, PageResult } from '@app/documents';
+
+@customElement('hd-document-list')
+export class DocumentList extends SignalWatcher(LitElement) {
+  @consume({ context: documentsContext })
+  private documents!: Signal.State<PageResult<Document> | null>;
+
+  render() {
+    const page = this.documents.get();
+    if (!page) return html`<p>Loading...</p>`;
+    return html`
+      ${page.data.map((doc) => html`
+        <hd-document-card .document=${doc}></hd-document-card>
+      `)}
+    `;
+  }
+}
+```
+
+## Signal Initialization
+
+- `null` means "not yet loaded" — components show skeleton/spinner
+- Empty `PageResult` (`data: []`) means "loaded but empty" — components show empty state
+- Pagination metadata comes from the server, never hardcoded on the client
+
+```typescript
+const documents = new Signal.State<PageResult<Document> | null>(null);
+```
+
+## Context Key Conventions
+
+- kebab-case strings: `'documents'`, `'prompts'`, `'loading'`
+- Defined adjacent to the providing component, not in a shared file
+- Typed via the generic: `createContext<Signal.State<T>>('key')`
+
+## Components Call Services Directly
+
+There is no orchestration layer between services and components. Components import services, call them, and update their own state (signals or `@state()`) based on results.
+
+```typescript
+// View calls service and updates its signal
+private async refresh(params?: PageRequest) {
+  const result = await DocumentService.list(params);
+  if (result.ok) this.documents.set(result.data);
+}
+
+// Stateful component calls service for its own concern
+private async handleDelete(id: string) {
+  const result = await DocumentService.delete(id);
+  if (result.ok) {
+    this.dispatchEvent(new CustomEvent('document-deleted', {
+      detail: { id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+}
+```
+
+## Encapsulated Streaming
+
+SSE operations are owned by the component closest to the concern. A document component that supports classification manages its own stream lifecycle using `@state()` — no shared signal needed.
+
+```typescript
+@customElement('hd-document-card')
+export class DocumentCard extends SignalWatcher(LitElement) {
+  @property({ type: Object }) document!: Document;
+  @state() private classifyStatus?: string;
+  @state() private classifyNode?: string;
+  @state() private classifyError?: string;
+
+  classify() {
+    this.classifyStatus = 'running';
+    this.classifyNode = 'init';
+
+    ClassificationService.classify(this.document.id, {
+      onEvent: (type, data) => {
+        const event = JSON.parse(data);
+        switch (type) {
+          case 'node.start':
+            this.classifyNode = event.data.node;
+            break;
+          case 'node.complete':
+            if (event.data.error) {
+              this.classifyStatus = 'error';
+              this.classifyError = event.data.error_message;
+            }
+            break;
+          case 'complete':
+            this.classifyStatus = 'complete';
+            this.dispatchEvent(new CustomEvent('classify-complete', {
+              detail: { id: this.document.id },
+              bubbles: true,
+              composed: true,
+            }));
+            break;
+          case 'error':
+            this.classifyStatus = 'error';
+            this.classifyError = event.data.message;
+            break;
+        }
+      },
+      onError: (err) => {
+        this.classifyStatus = 'error';
+        this.classifyError = err;
+      },
+      onComplete: () => {
+        if (this.classifyStatus === 'running') {
+          this.classifyStatus = 'error';
+          this.classifyError = 'stream disconnected unexpectedly';
+        }
+      },
+    });
+  }
+}
+```
+
+The parent view listens for `@classify-complete` and refreshes its document list — it never sees intermediate progress events.
+
+## Conventions
+
+- **Context for shared data only**: Use `@provide`/`@consume` when multiple descendants need the same reactive data
+- **`@state()` for local concerns**: Classification progress, form errors, UI toggles — use Lit's built-in reactive state
+- **Components call services directly**: No orchestration middleman between services and components
+- **Events up, data down**: Children dispatch `CustomEvent` to notify parents of outcomes
+- **Signal reads**: `.get()` in templates inside `SignalWatcher` components
+- **Signal writes**: `.set()` in the component that owns the signal
+- **No state files**: State is defined inline in the component that provides it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.59.74
+- Add web client data layer — enhance SSE `stream()` with event type parsing and POST support, TypeScript domain types mirroring Go API shapes, and stateless service objects mapping all handler endpoints across documents, classifications, prompts, and storage domains (#74)
+
 ## v0.3.0-dev.58.71
 - Add SSE classification streaming — modify `POST /api/classifications/{documentId}` to return an SSE event stream with real-time workflow progress (node.start, node.complete, complete, error events) and persisted classification result on completion (#71)
 

--- a/app/client/classifications/classification.ts
+++ b/app/client/classifications/classification.ts
@@ -1,0 +1,18 @@
+/**
+ * Classification result for a document.
+ * Mirrors Go `classifications.Classification` struct.
+ * Validation fields are omitted when the classification has not been validated.
+ */
+export interface Classification {
+  id: string;
+  document_id: string;
+  classification: string;
+  confidence: string;
+  markings_found: string[];
+  rationale: string;
+  classified_at: string;
+  model_name: string;
+  provider_name: string;
+  validated_by?: string;
+  validated_at?: string;
+}

--- a/app/client/classifications/index.ts
+++ b/app/client/classifications/index.ts
@@ -1,0 +1,3 @@
+export * from './classification';
+export { ClassificationService } from './service';
+export type { ValidateCommand, UpdateCommand } from './service';

--- a/app/client/classifications/service.ts
+++ b/app/client/classifications/service.ts
@@ -1,0 +1,95 @@
+import {
+  request,
+  stream,
+  toQueryString
+} from '@app/core';
+
+import type {
+  PageRequest,
+  PageResult,
+  Result,
+  StreamOptions
+} from '@app/core';
+
+import type { Classification } from './classification';
+
+/** Payload for marking a classification as validated. */
+export interface ValidateCommand {
+  validated_by: string;
+}
+
+/** Payload for manually updating a classification result. */
+export interface UpdateCommand {
+  classification: string;
+  rationale: string;
+  updated_by: string;
+}
+
+const base = '/classifications';
+
+/**
+ * Stateless API wrapper mirroring the Go classifications handler.
+ * Request-response methods return {@link Result}. The `classify` streaming
+ * method returns an {@link AbortController} for cancellation.
+ */
+export const ClassificationService = {
+  /** `GET /api/classifications` — paginated classification list. */
+  async list(params?: PageRequest): Promise<Result<PageResult<Classification>>> {
+    return await request<PageResult<Classification>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  /** `GET /api/classifications/:id` — single classification by ID. */
+  async find(id: string): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}`);
+  },
+
+  /** `GET /api/classifications/document/:documentId` — classification for a specific document. */
+  async findByDocument(documentId: string): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/document/${documentId}`);
+  },
+
+  /** `POST /api/classifications/search` — server-side filtered search. */
+  async search(body: PageRequest): Promise<Result<PageResult<Classification>>> {
+    return await request<PageResult<Classification>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  /**
+   * `POST /api/classifications/:documentId` — run the classification workflow.
+   * Returns an SSE event stream. The caller provides {@link StreamOptions}
+   * callbacks to process `node.start`, `node.complete`, `complete`, and `error` events.
+   */
+  classify(documentId: string, options: StreamOptions): AbortController {
+    return stream(`${base}/${documentId}`, options, { method: 'POST' });
+  },
+
+  /** `POST /api/classifications/:id/validate` — mark a classification as human-validated. */
+  async validate(id: string, command: ValidateCommand): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  /** `PUT /api/classifications/:id` — manually update a classification result. */
+  async update(id: string, command: UpdateCommand): Promise<Result<Classification>> {
+    return await request<Classification>(`${base}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  /** `DELETE /api/classifications/:id` — remove a classification record. */
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};

--- a/app/client/core/api.ts
+++ b/app/client/core/api.ts
@@ -1,9 +1,27 @@
 const BASE = '/api';
 
+/**
+ * Discriminated union for API call results.
+ * Check `result.ok` before accessing `result.data` — TypeScript narrows automatically.
+ */
 export type Result<T> =
   | { ok: true; data: T }
   | { ok: false; error: string };
 
+/** Structured SSE event from the classification workflow. */
+export interface ExecutionEvent {
+  type: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Generic fetch wrapper. Prepends `/api` to the path.
+ *
+ * Non-2xx responses return the body as the error message.
+ * 204 responses return `undefined` as data.
+ * Override `parse` for non-JSON responses (default: `res.json()`).
+ */
 export async function request<T>(
   path: string,
   init?: RequestInit,
@@ -24,21 +42,35 @@ export async function request<T>(
   }
 }
 
+/**
+ * Callbacks for SSE stream consumption.
+ *
+ * `onEvent` receives the event type (from `event:` lines, default `'message'`)
+ * paired with the raw `data:` line content.
+ */
 export interface StreamOptions {
-  onMessage: (data: string) => void;
+  onEvent: (type: string, data: string) => void;
   onError?: (error: string) => void;
   onComplete?: () => void;
   signal?: AbortSignal;
 }
 
+/**
+ * SSE client that returns an {@link AbortController} for cancellation.
+ *
+ * Parses `event:` and `data:` line pairs from the response stream.
+ * Accepts optional `init` for non-GET requests (e.g., POST for classification).
+ * Calls `onComplete` when the reader reports done; ignores `AbortError`.
+ */
 export function stream(
   path: string,
-  options: StreamOptions
+  options: StreamOptions,
+  init?: RequestInit,
 ): AbortController {
   const controller = new AbortController();
   const signal = options.signal ?? controller.signal;
 
-  fetch(`${BASE}${path}`, { signal })
+  fetch(`${BASE}${path}`, { ...init, signal })
     .then(async (res) => {
       if (!res.ok) {
         const text = await res.text();
@@ -54,6 +86,7 @@ export function stream(
 
       const decoder = new TextDecoder();
       let buffer = '';
+      let currentEvent = 'message';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -64,13 +97,12 @@ export function stream(
         buffer = lines.pop() ?? '';
 
         for (const line of lines) {
-          if (line.startsWith('data: ')) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
             const data = line.slice(6).trim();
-            if (data === '[DONE]') {
-              options.onComplete?.();
-              return;
-            }
-            options.onMessage(data);
+            options.onEvent(currentEvent, data);
+            currentEvent = 'message';
           }
         }
       }
@@ -86,6 +118,7 @@ export function stream(
   return controller;
 }
 
+/** Paginated response from the server. */
 export interface PageResult<T> {
   data: T[];
   total: number;
@@ -94,6 +127,7 @@ export interface PageResult<T> {
   total_pages: number;
 }
 
+/** Pagination and filtering parameters for list endpoints. */
 export interface PageRequest {
   page?: number;
   page_size?: number;
@@ -101,6 +135,7 @@ export interface PageRequest {
   sort?: string;
 }
 
+/** Converts pagination params to a query string (e.g., `?page=1&page_size=20`). */
 export function toQueryString(params: PageRequest): string {
   const entries = Object.entries(params)
     .filter(([, v]) => v !== undefined && v !== null && v !== '')

--- a/app/client/core/index.ts
+++ b/app/client/core/index.ts
@@ -1,2 +1,9 @@
 export { request, stream, toQueryString } from './api';
-export type { Result, StreamOptions, PageResult, PageRequest } from './api';
+
+export type {
+  ExecutionEvent,
+  PageRequest,
+  PageResult,
+  Result,
+  StreamOptions
+} from './api';

--- a/app/client/css.d.ts
+++ b/app/client/css.d.ts
@@ -1,3 +1,4 @@
+/** CSS module imports produce a CSSStyleSheet for Lit `static styles`. */
 declare module '*.module.css' {
   const sheet: CSSStyleSheet;
   export default sheet;

--- a/app/client/documents/document.ts
+++ b/app/client/documents/document.ts
@@ -1,0 +1,25 @@
+/** Classification processing state of a document. */
+export type DocumentStatus = 'pending' | 'review' | 'complete';
+
+/**
+ * Uploaded document with optional classification summary.
+ * Mirrors Go `documents.Document` struct. Classification fields
+ * are populated from a LEFT JOIN and omitted when unclassified.
+ */
+export interface Document {
+  id: string;
+  external_id: number;
+  external_platform: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  /** Null when page count has not been determined (e.g., non-PDF). */
+  page_count: number | null;
+  storage_key: string;
+  status: DocumentStatus;
+  uploaded_at: string;
+  updated_at: string;
+  classification?: string;
+  confidence?: string;
+  classified_at?: string;
+}

--- a/app/client/documents/index.ts
+++ b/app/client/documents/index.ts
@@ -1,0 +1,2 @@
+export * from './document';
+export { DocumentService } from './service';

--- a/app/client/documents/service.ts
+++ b/app/client/documents/service.ts
@@ -1,0 +1,56 @@
+import { request, toQueryString } from '@app/core';
+import type { PageRequest, PageResult, Result } from '@app/core';
+import type { Document } from './document';
+
+const base = '/documents';
+
+/**
+ * Stateless API wrapper mirroring the Go documents handler.
+ * All methods return {@link Result} — no signals, no state.
+ */
+export const DocumentService = {
+  /** `GET /api/documents` — paginated document list. */
+  async list(params?: PageRequest): Promise<Result<PageResult<Document>>> {
+    return await request<PageResult<Document>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  /** `GET /api/documents/:id` — single document by ID. */
+  async find(id: string): Promise<Result<Document>> {
+    return await request<Document>(`${base}/${id}`);
+  },
+
+  /** `POST /api/documents/search` — server-side filtered search. */
+  async search(body: PageRequest): Promise<Result<PageResult<Document>>> {
+    return await request<PageResult<Document>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  /** `POST /api/documents` — upload a document via multipart form. */
+  async upload(
+    file: File,
+    externalId: number,
+    platform: string,
+  ): Promise<Result<Document>> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('external_id', String(externalId));
+    form.append('external_platform', platform);
+
+    return await request<Document>(base, {
+      method: 'POST',
+      body: form,
+    });
+  },
+
+  /** `DELETE /api/documents/:id` — remove a document and its storage blob. */
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};

--- a/app/client/prompts/index.ts
+++ b/app/client/prompts/index.ts
@@ -1,0 +1,2 @@
+export * from './prompt';
+export { PromptService } from './service';

--- a/app/client/prompts/prompt.ts
+++ b/app/client/prompts/prompt.ts
@@ -1,0 +1,37 @@
+/** Classification workflow stage that a prompt targets. */
+export type PromptStage = 'classify' | 'enhance' | 'finalize';
+
+/**
+ * Prompt template used by the classification workflow.
+ * Mirrors Go `prompts.Prompt` struct.
+ */
+export interface Prompt {
+  id: string;
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+  active: boolean;
+}
+
+/** Assembled prompt content for a specific workflow stage. */
+export interface StageContent {
+  stage: PromptStage;
+  content: string;
+}
+
+/** Payload for creating a new prompt. */
+export interface CreatePromptCommand {
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+}
+
+/** Payload for updating an existing prompt. */
+export interface UpdatePromptCommand {
+  name: string;
+  stage: PromptStage;
+  instructions: string;
+  description?: string;
+}

--- a/app/client/prompts/service.ts
+++ b/app/client/prompts/service.ts
@@ -1,0 +1,98 @@
+import { request, toQueryString } from '@app/core';
+
+import type {
+  PageRequest,
+  PageResult,
+  Result
+} from '@app/core';
+
+import type {
+  Prompt,
+  PromptStage,
+  StageContent,
+  CreatePromptCommand,
+  UpdatePromptCommand
+} from './prompt';
+
+const base = '/prompts';
+
+/**
+ * Stateless API wrapper mirroring the Go prompts handler.
+ * All methods return {@link Result} — no signals, no state.
+ */
+export const PromptService = {
+  /** `GET /api/prompts` — paginated prompt list. */
+  async list(params?: PageRequest): Promise<Result<PageResult<Prompt>>> {
+    return await request<PageResult<Prompt>>(
+      `${base}${params ? toQueryString(params) : ''}`
+    );
+  },
+
+  /** `GET /api/prompts/stages` — available workflow stages. */
+  async stages(): Promise<Result<PromptStage[]>> {
+    return await request<PromptStage[]>(`${base}/stages`);
+  },
+
+  /** `GET /api/prompts/:id` — single prompt by ID. */
+  async find(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}`);
+  },
+
+  /** `GET /api/prompts/:stage/instructions` — assembled instructions for a stage. */
+  async instructions(stage: PromptStage): Promise<Result<StageContent>> {
+    return await request<StageContent>(`${base}/${stage}/instructions`);
+  },
+
+  /** `GET /api/prompts/:stage/spec` — assembled spec for a stage. */
+  async spec(stage: PromptStage): Promise<Result<StageContent>> {
+    return await request<StageContent>(`${base}/${stage}/spec`);
+  },
+
+  /** `POST /api/prompts/search` — server-side filtered search. */
+  async search(body: PageRequest): Promise<Result<PageResult<Prompt>>> {
+    return await request<PageResult<Prompt>>(`${base}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  /** `POST /api/prompts` — create a new prompt. */
+  async create(command: CreatePromptCommand): Promise<Result<Prompt>> {
+    return await request<Prompt>(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  /** `PUT /api/prompts/:id` — update an existing prompt. */
+  async update(id: string, command: UpdatePromptCommand): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    });
+  },
+
+  /** `DELETE /api/prompts/:id` — remove a prompt. */
+  async delete(id: string): Promise<Result<void>> {
+    return await request<void>(`${base}/${id}`, {
+      method: 'DELETE',
+    });
+  },
+
+  /** `POST /api/prompts/:id/activate` — activate a prompt for its stage. */
+  async activate(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}/activate`, {
+      method: 'POST',
+    });
+  },
+
+  /** `POST /api/prompts/:id/deactivate` — deactivate a prompt. */
+  async deactivate(id: string): Promise<Result<Prompt>> {
+    return await request<Prompt>(`${base}/${id}/deactivate`, {
+      method: 'POST',
+    });
+  },
+};

--- a/app/client/router/router.ts
+++ b/app/client/router/router.ts
@@ -3,10 +3,16 @@ import type { RouteMatch } from './types';
 
 let routerInstance: Router | null = null;
 
+/** Programmatic navigation from anywhere in the app. */
 export function navigate(path: string): void {
   routerInstance?.navigate(path);
 }
 
+/**
+ * History API router. Matches URL paths against the route table,
+ * mounts the corresponding component into a container element,
+ * and sets path/query params as HTML attributes on the mounted component.
+ */
 export class Router {
   private container: HTMLElement;
   private basePath: string;
@@ -25,6 +31,7 @@ export class Router {
     routerInstance = this;
   }
 
+  /** Navigate to a path, optionally pushing to browser history. */
   navigate(path: string, pushState: boolean = true): void {
     const [pathPart, queryPart] = path.split('?');
     const normalized = this.normalizePath(pathPart);
@@ -41,6 +48,7 @@ export class Router {
     this.mount(match);
   }
 
+  /** Initialize the router: mount the current URL and listen for popstate. */
   start(): void {
     this.navigate(this.currentPath(), false);
 

--- a/app/client/router/routes.ts
+++ b/app/client/router/routes.ts
@@ -1,5 +1,6 @@
 import type { RouteConfig } from './types';
 
+/** Route table mapping URL path patterns to view components. */
 export const routes: Record<string, RouteConfig> = {
   '': { component: 'hd-documents-view', title: 'Documents' },
   'prompts': { component: 'hd-prompts-view', title: 'Prompts' },

--- a/app/client/router/types.ts
+++ b/app/client/router/types.ts
@@ -1,8 +1,10 @@
+/** Maps a route pattern to the component that handles it. */
 export interface RouteConfig {
   component: string;
   title: string;
 }
 
+/** Result of matching a URL path against the route table. */
 export interface RouteMatch {
   config: RouteConfig;
   params: Record<string, string>;

--- a/app/client/storage/blob.ts
+++ b/app/client/storage/blob.ts
@@ -1,0 +1,15 @@
+/** Metadata for a blob in object storage. Mirrors Go `storage.BlobMeta`. */
+export interface BlobMeta {
+  name: string;
+  content_type: string;
+  content_length: number;
+  etag: string;
+  created_at: string;
+  last_modified: string;
+}
+
+/** Paginated blob listing with optional continuation marker. */
+export interface BlobList {
+  blobs: BlobMeta[];
+  next_marker?: string;
+}

--- a/app/client/storage/index.ts
+++ b/app/client/storage/index.ts
@@ -1,0 +1,3 @@
+export * from './blob';
+export { StorageService } from './service';
+export type { StorageListParams } from './service';

--- a/app/client/storage/service.ts
+++ b/app/client/storage/service.ts
@@ -1,0 +1,42 @@
+import { request } from '@app/core';
+import type { Result } from '@app/core';
+import type { BlobMeta, BlobList } from './blob';
+
+/** Filtering parameters for blob listing. */
+export interface StorageListParams {
+  prefix?: string;
+  marker?: string;
+  max_results?: number;
+}
+
+const base = '/storage';
+
+/**
+ * Stateless API wrapper mirroring the Go storage handler.
+ * All methods return {@link Result} — no signals, no state.
+ */
+export const StorageService = {
+  /** `GET /api/storage` — list blobs with optional prefix and pagination. */
+  async list(params?: StorageListParams): Promise<Result<BlobList>> {
+    const entries = Object.entries(params ?? {})
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+
+    const qs = entries.length > 0 ? `?${entries.join('&')}` : '';
+    return await request<BlobList>(`${base}${qs}`);
+  },
+
+  /** `GET /api/storage/:key` — blob metadata by storage key. */
+  async find(key: string): Promise<Result<BlobMeta>> {
+    return await request<BlobMeta>(`${base}/${key}`);
+  },
+
+  /** `GET /api/storage/download/:key` — download blob content. */
+  async download(key: string): Promise<Result<Blob>> {
+    return await request<Blob>(
+      `${base}/download/${key}`,
+      undefined,
+      (res) => res.blob(),
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Establish the web client's foundational data layer that all subsequent view components depend on. This enhances SSE streaming to support the classification endpoint's `event:` + `data:` format with POST method, adds TypeScript domain types mirroring Go API response shapes, and creates stateless service objects mapping every Go handler endpoint.

Closes #74

## Changes

- **SSE `stream()` enhancement** — `onEvent(type, data)` callback with event type tracking, `init?: RequestInit` for POST support, removed `[DONE]` sentinel
- **Domain types** — `Document`, `Classification`, `Prompt`, `BlobMeta` and related types mirroring Go structs
- **Stateless services** — `DocumentService` (5 methods), `ClassificationService` (8 methods), `PromptService` (11 methods), `StorageService` (3 methods)
- **Domain directory convention** — types and services in `app/client/<domain>/`, separate from views
- **Web-development skill update** — simplified architecture: components call services directly, no orchestration layer; new `references/state.md` for shared reactive state patterns
- **JSDoc comments** — all public TypeScript API surfaces documented; convention added to `.claude/CLAUDE.md`