### PR TITLE
Add document card and classify progress pure elements

### DIFF
--- a/.claude/context/guides/.archive/75-document-card-classify-progress.md
+++ b/.claude/context/guides/.archive/75-document-card-classify-progress.md
@@ -1,0 +1,808 @@
+# 75 - Document Card and Classify Progress Elements
+
+## Problem Context
+
+Issue #75 creates two pure elements for the documents view: a document card displaying document info with action buttons, and a classify progress pipeline showing SSE workflow stages. Before building them, the web-development skill's `state.md` "Encapsulated Streaming" section contradicts the three-tier hierarchy by showing a pure element calling `ClassificationService.classify()` directly. This session fixes that architectural contradiction and implements the elements with the corrected conventions.
+
+## Architecture Approach
+
+**Streaming orchestration belongs in the stateful component tier.** The card stays pure — props in, events out — and the list/grid component (#77) will own SSE lifecycle. The card emits `classify` and `review` events; the parent handles service calls and navigation.
+
+**Pure element import boundary**: pure elements can import `lit`, their own CSS module, and **immutable domain infrastructure** (types, constants, formatters) from domain modules. What's prohibited is anything that holds or mutates state — services, signals, context (`@provide`/`@consume`), `SignalWatcher`. The principle: pure elements can depend on domain knowledge (what the data looks like) but not domain behavior (what the application does with it).
+
+**Directory convention**: `elements/` directory with domain subdirectories, parallel to `views/` and `components/`.
+
+## Implementation
+
+### Step 1: Add `WorkflowStage` type and constant to classifications domain
+
+**`app/client/classifications/classification.ts`** — add after the `Classification` interface:
+
+```typescript
+export type WorkflowStage = 'init' | 'classify' | 'enhance' | 'finalize';
+
+export const WORKFLOW_STAGES: readonly WorkflowStage[] = [
+  'init', 'classify', 'enhance', 'finalize',
+];
+```
+
+**`app/client/classifications/index.ts`** — add the new exports:
+
+```typescript
+export type { WorkflowStage } from './classification';
+export { WORKFLOW_STAGES } from './classification';
+```
+
+### Step 2: Create `hd-classify-progress` element
+
+**`app/client/elements/documents/classify-progress.ts`** (new file)
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { WORKFLOW_STAGES } from '@app/classifications';
+import type { WorkflowStage } from '@app/classifications';
+import styles from './classify-progress.module.css';
+
+@customElement('hd-classify-progress')
+export class ClassifyProgress extends LitElement {
+  static styles = styles;
+
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private stageState(stage: WorkflowStage): string {
+    if (this.completedNodes.includes(stage)) return 'completed';
+    if (stage === this.currentNode) return 'active';
+    return 'pending';
+  }
+
+  render() {
+    return html`
+      <div class="pipeline">
+        ${WORKFLOW_STAGES.map(
+          (stage) => html`
+            <div class="stage ${this.stageState(stage)}">
+              <div class="indicator"></div>
+              <span class="label">${stage}</span>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-classify-progress': ClassifyProgress;
+  }
+}
+```
+
+**`app/client/elements/documents/classify-progress.module.css`** (new file)
+
+```css
+:host {
+  display: block;
+}
+
+.pipeline {
+  display: flex;
+  position: relative;
+  padding: 0 var(--space-2);
+}
+
+.pipeline::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: calc(var(--space-2) + 5px);
+  right: calc(var(--space-2) + 5px);
+  height: 2px;
+  background: var(--divider);
+}
+
+.stage {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 2px solid var(--divider);
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.stage.completed .indicator {
+  background: var(--green);
+  border-color: var(--green);
+}
+
+.stage.active .indicator {
+  background: var(--blue);
+  border-color: var(--blue);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.label {
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+  text-transform: capitalize;
+}
+
+.stage.completed .label {
+  color: var(--green);
+}
+
+.stage.active .label {
+  color: var(--blue);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+```
+
+### Step 3: Create formatting utilities
+
+**`app/client/formatting/bytes.ts`** (new file)
+
+Mirrors Go `pkg/formatting/bytes.go` `FormatBytes` — base-1024 units.
+
+```typescript
+const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+export function formatBytes(n: number, precision = 1): string {
+  if (n === 0) return '0 B';
+
+  const k = 1024;
+  const i = Math.min(
+    Math.floor(Math.log(n) / Math.log(k)),
+    units.length - 1,
+  );
+
+  const size = n / Math.pow(k, i);
+  return `${size.toFixed(Math.max(precision, 0))} ${units[i]}`;
+}
+```
+
+**`app/client/formatting/date.ts`** (new file)
+
+Locale-aware date formatting for ISO strings.
+
+```typescript
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+```
+
+**`app/client/formatting/index.ts`** (new file)
+
+```typescript
+export { formatBytes } from './bytes';
+export { formatDate } from './date';
+```
+
+### Step 4: Create `hd-document-card` element
+
+**`app/client/elements/documents/document-card.ts`** (new file)
+
+```typescript
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { formatBytes, formatDate } from '@app/formatting';
+import type { Document } from '@app/documents';
+import type { WorkflowStage } from '@app/classifications';
+import styles from './document-card.module.css';
+
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  static styles = styles;
+
+  @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private get classifyDisabled(): boolean {
+    return this.document.status === 'complete' || this.classifying;
+  }
+
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private handleReview() {
+    this.dispatchEvent(new CustomEvent('review', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private renderClassification() {
+    if (!this.document.classification) return nothing;
+
+    return html`
+      <div class="classification">
+        <span class="classification-label">${this.document.classification}</span>
+        ${this.document.confidence
+          ? html`<span class="confidence">${this.document.confidence}</span>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderProgress() {
+    if (!this.classifying) return nothing;
+
+    return html`
+      <hd-classify-progress
+        .currentNode=${this.currentNode}
+        .completedNodes=${this.completedNodes}
+      ></hd-classify-progress>
+    `;
+  }
+
+  render() {
+    const doc = this.document;
+
+    return html`
+      <div class="card">
+        <div class="header">
+          <span class="filename">${doc.filename}</span>
+          <span class="badge ${doc.status}">${doc.status}</span>
+        </div>
+
+        <div class="meta">
+          ${doc.page_count !== null
+            ? html`<span>${doc.page_count} pages</span>`
+            : nothing}
+          <span>${formatBytes(doc.size_bytes)}</span>
+          <span>${formatDate(doc.uploaded_at)}</span>
+        </div>
+
+        ${this.renderClassification()}
+        ${this.renderProgress()}
+
+        <div class="actions">
+          <button
+            class="btn classify-btn"
+            ?disabled=${this.classifyDisabled}
+            @click=${this.handleClassify}
+          >Classify</button>
+          <button
+            class="btn review-btn"
+            @click=${this.handleReview}
+          >Review</button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-document-card': DocumentCard;
+  }
+}
+```
+
+**`app/client/elements/documents/document-card.module.css`** (new file)
+
+```css
+:host {
+  display: block;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.filename {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge.pending {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.badge.review {
+  color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.badge.complete {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.meta span:not(:last-child)::after {
+  content: '·';
+  margin-left: var(--space-2);
+  color: var(--divider);
+}
+
+.classification {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.classification-label {
+  font-weight: 600;
+  color: var(--color);
+}
+
+.confidence {
+  font-size: var(--text-xs);
+  color: var(--color-1);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--color-2);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.classify-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.classify-btn:hover:not(:disabled) {
+  background: var(--blue-bg);
+}
+
+.review-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.review-btn:hover:not(:disabled) {
+  background: var(--green-bg);
+}
+```
+
+### Step 5: Barrel exports and registration
+
+**`app/client/elements/documents/index.ts`** (new file)
+
+```typescript
+export { ClassifyProgress } from './classify-progress';
+export { DocumentCard } from './document-card';
+```
+
+**`app/client/elements/index.ts`** (new file)
+
+```typescript
+export * from './documents';
+```
+
+**`app/client/app.ts`** — add elements import after the views import:
+
+```typescript
+import './elements';
+```
+
+### Step 6: Update web-development skill — `SKILL.md`
+
+In the **Architecture Overview > Services and State** table, change the Services row description from:
+
+> Stateless API wrappers mirroring Go handlers
+
+to:
+
+> Stateless API wrappers mirroring Go handlers. Called by views and stateful components only — never by pure elements.
+
+In the **Three-Tier Component Hierarchy** table, update the Pure Element tools from:
+
+> `@property`, `CustomEvent`
+
+to:
+
+> `@property`, `CustomEvent`. Imports `lit`, own CSS module, and immutable domain infrastructure (types, constants).
+
+In the **File Structure** section, update the directory tree to include `components/` and `elements/`:
+
+```
+app/client/
+├── core/                            # API layer (request, stream, types)
+├── documents/                       # domain: types + service
+├── classifications/                 # domain: types + service
+├── prompts/                         # domain: types + service
+├── storage/                         # domain: types + service
+├── views/
+│   └── documents/                   # view: route-level component
+├── components/                      # stateful components (@consume, service calls)
+│   └── documents/                   # domain-scoped components
+├── elements/                        # pure elements (@property, CustomEvent)
+│   └── documents/                   # domain-scoped elements
+│       ├── document-card.ts
+│       ├── document-card.module.css
+│       ├── classify-progress.ts
+│       ├── classify-progress.module.css
+│       └── index.ts
+├── router/
+└── design/
+```
+
+After the directory tree explanation, add:
+
+> **Component type directories** (`views/`, `components/`, `elements/`) each use domain subdirectories mirroring the domain infrastructure layout. Elements are registered via `import './elements'` in `app.ts`.
+
+In the **Anti-Patterns > Avoid** list, update:
+
+> - Pure elements calling services — only views and stateful components should import services
+
+to:
+
+> - Pure elements importing stateful infrastructure — services, signals, context (`@provide`/`@consume`), `SignalWatcher`, or router utilities. Elements can import immutable domain infrastructure (types, constants, formatters) but never anything that holds or mutates state.
+
+In the **Anti-Patterns > Prefer** list, add:
+
+> - Domain types and constants in pure elements — immutable domain knowledge is fine, stateful behavior is not
+
+### Step 7: Update `references/components.md`
+
+Replace the **Stateful Component** example with one that shows streaming orchestration:
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { SignalWatcher, Signal } from '@lit-labs/signals';
+import { ClassificationService } from '@app/classifications';
+import { documentsContext } from '../views/documents/documents-view';
+import type { Document } from '@app/documents';
+import type { PageResult } from '@app/core';
+import styles from './document-list.module.css';
+
+interface ClassifyProgress {
+  currentNode: string;
+  completedNodes: string[];
+}
+
+@customElement('hd-document-list')
+export class DocumentList extends SignalWatcher(LitElement) {
+  static styles = styles;
+
+  @consume({ context: documentsContext })
+  private documents!: Signal.State<PageResult<Document> | null>;
+
+  @state() private classifying = new Map<string, ClassifyProgress>();
+
+  private handleClassify(e: CustomEvent<{ id: string }>) {
+    const docId = e.detail.id;
+    this.classifying.set(docId, { currentNode: 'init', completedNodes: [] });
+    this.requestUpdate();
+
+    ClassificationService.classify(docId, {
+      onEvent: (type, data) => {
+        const event = JSON.parse(data);
+        const progress = this.classifying.get(docId);
+        if (!progress) return;
+
+        switch (type) {
+          case 'node.start':
+            progress.currentNode = event.data.node;
+            break;
+          case 'node.complete':
+            progress.completedNodes = [...progress.completedNodes, event.data.node];
+            break;
+          case 'complete':
+            this.classifying.delete(docId);
+            this.dispatchEvent(new CustomEvent('classify-complete', {
+              bubbles: true, composed: true,
+            }));
+            break;
+          case 'error':
+            this.classifying.delete(docId);
+            break;
+        }
+        this.requestUpdate();
+      },
+      onError: () => {
+        this.classifying.delete(docId);
+        this.requestUpdate();
+      },
+    });
+  }
+
+  private renderDocuments() {
+    const page = this.documents.get();
+    if (!page) return html`<p>Loading...</p>`;
+    if (page.data.length === 0) return html`<p>No documents</p>`;
+
+    return page.data.map((doc) => {
+      const progress = this.classifying.get(doc.id);
+      return html`
+        <hd-document-card
+          .document=${doc}
+          ?classifying=${progress !== undefined}
+          .currentNode=${progress?.currentNode ?? ''}
+          .completedNodes=${progress?.completedNodes ?? []}
+          @classify=${this.handleClassify}
+        ></hd-document-card>
+      `;
+    });
+  }
+
+  render() {
+    return html`<div class="grid">${this.renderDocuments()}</div>`;
+  }
+}
+```
+
+Replace the **Pure Element** example with the document card pattern:
+
+```typescript
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { Document } from '@app/documents';
+import type { WorkflowStage } from '@app/classifications';
+import styles from './document-card.module.css';
+
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  static styles = styles;
+
+  @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private handleReview() {
+    this.dispatchEvent(new CustomEvent('review', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  render() {
+    return html`
+      <div class="card">
+        <span class="filename">${this.document.filename}</span>
+        <span class="badge ${this.document.status}">${this.document.status}</span>
+        ${this.classifying
+          ? html`<hd-classify-progress
+              .currentNode=${this.currentNode}
+              .completedNodes=${this.completedNodes}
+            ></hd-classify-progress>`
+          : nothing}
+        <button
+          ?disabled=${this.document.status === 'complete' || this.classifying}
+          @click=${this.handleClassify}
+        >Classify</button>
+        <button @click=${this.handleReview}>Review</button>
+      </div>
+    `;
+  }
+}
+```
+
+### Step 8: Update `references/state.md`
+
+Replace the **Encapsulated Streaming** section with:
+
+```markdown
+## Streaming Orchestration
+
+SSE operations are owned by the **stateful component** closest to the collection concern — not the pure element that triggered the action. The stateful component calls the streaming service, tracks per-item progress via `@state()`, and passes progress data to pure elements as properties.
+
+This keeps pure elements context-free and reusable. The parent never exposes intermediate SSE events to the view — it dispatches a single completion event when the operation finishes.
+
+\`\`\`typescript
+// Stateful component — owns SSE lifecycle for the collection
+@customElement('hd-document-list')
+export class DocumentList extends SignalWatcher(LitElement) {
+  @consume({ context: documentsContext })
+  private documents!: Signal.State<PageResult<Document> | null>;
+
+  @state() private classifying = new Map<string, ClassifyProgress>();
+
+  private handleClassify(e: CustomEvent<{ id: string }>) {
+    const docId = e.detail.id;
+    this.classifying.set(docId, { currentNode: 'init', completedNodes: [] });
+    this.requestUpdate();
+
+    ClassificationService.classify(docId, {
+      onEvent: (type, data) => {
+        const event = JSON.parse(data);
+        const progress = this.classifying.get(docId);
+        if (!progress) return;
+
+        switch (type) {
+          case 'node.start':
+            progress.currentNode = event.data.node;
+            break;
+          case 'node.complete':
+            progress.completedNodes = [...progress.completedNodes, event.data.node];
+            break;
+          case 'complete':
+            this.classifying.delete(docId);
+            this.dispatchEvent(new CustomEvent('classify-complete', {
+              bubbles: true, composed: true,
+            }));
+            break;
+          case 'error':
+            this.classifying.delete(docId);
+            break;
+        }
+        this.requestUpdate();
+      },
+      onError: () => {
+        this.classifying.delete(docId);
+        this.requestUpdate();
+      },
+    });
+  }
+
+  render() {
+    const page = this.documents.get();
+    if (!page) return html\`<p>Loading...</p>\`;
+
+    return html\`
+      \${page.data.map((doc) => {
+        const progress = this.classifying.get(doc.id);
+        return html\`
+          <hd-document-card
+            .document=\${doc}
+            ?classifying=\${progress !== undefined}
+            .currentNode=\${progress?.currentNode ?? ''}
+            .completedNodes=\${progress?.completedNodes ?? []}
+            @classify=\${this.handleClassify}
+          ></hd-document-card>
+        \`;
+      })}
+    \`;
+  }
+}
+\`\`\`
+
+The pure element receives all streaming state as properties and dispatches intent events upward. It has no knowledge of services, SSE, or `AbortController`.
+
+\`\`\`typescript
+// Pure element — props in, events out
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode = '';
+  @property({ type: Array }) completedNodes: string[] = [];
+
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true, composed: true,
+    }));
+  }
+
+  render() {
+    return html\`
+      <button ?disabled=\${this.classifying} @click=\${this.handleClassify}>
+        Classify
+      </button>
+      \${this.classifying
+        ? html\`<hd-classify-progress .currentNode=\${this.currentNode}>\`
+        : nothing}
+    \`;
+  }
+}
+\`\`\`
+```
+
+Update the **Conventions** list. Replace:
+
+> - **Context for shared data only**: Use `@provide`/`@consume` when multiple descendants need the same reactive data
+
+with:
+
+> - **Context for shared data only**: Use `@provide`/`@consume` when multiple descendants need the same reactive data. Pure elements never use context — only views and stateful components.
+> - **Streaming in stateful components**: The component managing the collection (list/grid) owns SSE lifecycle. Pure elements receive progress as properties and dispatch intent events.
+
+Remove the standalone "Encapsulated Streaming" heading and its obsolete example showing the card calling `ClassificationService.classify()`.
+
+## Validation Criteria
+
+- [ ] `hd-classify-progress` renders 4-stage pipeline with pending/active/completed visual states
+- [ ] `hd-document-card` renders filename, page count, date, size, status badge
+- [ ] Status badge visually differentiates pending/review/complete via color tokens
+- [ ] Classification summary shown conditionally when document has classification data
+- [ ] Classify button dispatches `classify` CustomEvent with document ID
+- [ ] Classify button disabled when status === 'complete' or classifying is true
+- [ ] Review button dispatches `review` CustomEvent with document ID
+- [ ] Progress element shown inline when classifying is true
+- [ ] Neither element imports stateful infrastructure (services, signals, context, router)
+- [ ] `WorkflowStage` type and `WORKFLOW_STAGES` constant exported from classifications domain
+- [ ] Both elements use `*.module.css` with design tokens
+- [ ] `app.ts` imports `./elements` for registration
+- [ ] Skill references updated — no more contradiction between tiers and streaming
+- [ ] `bun run build` compiles without errors

--- a/.claude/context/sessions/75-document-card-classify-progress.md
+++ b/.claude/context/sessions/75-document-card-classify-progress.md
@@ -1,0 +1,48 @@
+# 75 - Document Card and Classify Progress Elements
+
+## Summary
+
+Created two pure elements (`hd-document-card`, `hd-classify-progress`) for the documents view, along with supporting infrastructure (`WorkflowStage` domain type, `formatting/` module). Resolved a fundamental architectural contradiction in the web-development skill where the "Encapsulated Streaming" section showed a pure element calling `ClassificationService.classify()` directly, violating the three-tier hierarchy.
+
+## Key Decisions
+
+### Pure Element Import Boundary
+
+Established a clear boundary: pure elements can import `lit`, their own CSS module, and **immutable domain infrastructure** (types, constants, formatters). Prohibited: services, signals, context (`@provide`/`@consume`), `SignalWatcher`, router utilities — anything that holds or mutates state.
+
+### Streaming Orchestration Correction
+
+Moved SSE lifecycle ownership from the pure element tier to the stateful component tier. The list/grid component owns `ClassificationService.classify()` calls, tracks per-item progress via `@state()` (Map), and passes progress data to pure cards as `@property()` values. Cards dispatch intent events only.
+
+### WorkflowStage as Domain Infrastructure
+
+Formalized workflow stages as a domain type (`WorkflowStage`) and constant (`WORKFLOW_STAGES`) in the classifications domain, rather than a local constant in the element. This follows the principle that domain knowledge (what stages exist) is immutable infrastructure importable by elements.
+
+### Formatting Module
+
+Created `app/client/formatting/` module parallel to Go `pkg/formatting/` with `formatBytes()` and `formatDate()` utilities. Shared across elements rather than implemented as private methods.
+
+## Changes
+
+### New Files
+- `app/client/elements/documents/document-card.ts` — Pure element displaying document metadata with classify/review action buttons
+- `app/client/elements/documents/document-card.module.css` — Card styles with status badge colors, action button accents
+- `app/client/elements/documents/classify-progress.ts` — Pure element rendering horizontal 4-stage pipeline indicator
+- `app/client/elements/documents/classify-progress.module.css` — Pipeline styles with pending/active/completed states
+- `app/client/elements/documents/index.ts` — Domain barrel
+- `app/client/elements/index.ts` — Top-level elements barrel
+- `app/client/formatting/bytes.ts` — `formatBytes()` (base-1024 units)
+- `app/client/formatting/date.ts` — `formatDate()` (locale-aware short date)
+- `app/client/formatting/index.ts` — Formatting barrel
+
+### Modified Files
+- `app/client/classifications/classification.ts` — Added `WorkflowStage` type and `WORKFLOW_STAGES` constant
+- `app/client/classifications/index.ts` — Export new type and constant
+- `app/client/app.ts` — Added `import './elements'` for element registration
+- `.claude/skills/web-development/SKILL.md` — Updated pure element tools, file structure, anti-patterns
+- `.claude/skills/web-development/references/components.md` — Replaced examples with streaming orchestration and card patterns
+- `.claude/skills/web-development/references/state.md` — Replaced "Encapsulated Streaming" with corrected "Streaming Orchestration" section
+
+## Bugs Fixed
+- Missing `.` prefix in CSS selector `stage.active .label` → `.stage.active .label`
+- Unclosed `<hd-classify-progress>` tag in `renderProgress()` method

--- a/.claude/plans/cozy-drifting-ocean.md
+++ b/.claude/plans/cozy-drifting-ocean.md
@@ -1,0 +1,172 @@
+# 75 - Document Card and Classify Progress Elements
+
+## Context
+
+Issue #75 creates two pure elements for the documents view. Before building them, the web-development skill has a contradiction that must be resolved: `state.md`'s "Encapsulated Streaming" example shows `hd-document-card` calling `ClassificationService.classify()` directly — making it a stateful component, not a pure element. This violates the three-tier hierarchy and the anti-pattern "Pure elements calling services."
+
+The fix: **streaming orchestration belongs in the stateful component tier**, not in pure elements. The card stays pure (props in, events out), and the list/grid component (#77) will own SSE lifecycle. The card emits a `classify` event; the parent handles it.
+
+This session delivers the two elements AND updates the skill references to resolve the contradiction.
+
+## Architecture Decisions
+
+### Streaming Orchestration (skill correction)
+
+The `state.md` "Encapsulated Streaming" example was placed in the wrong tier. The principle "component closest to the concern" is correct, but the card is closest to the **presentation** concern, not the streaming concern. The stateful list/grid component that renders cards is closest to the collection/streaming concern — it knows about all documents, can coordinate bulk operations, and is the natural bridge between services and elements.
+
+**Updated pattern**: Stateful component calls `ClassificationService.classify()`, tracks per-document progress in `@state()` (e.g., `Map<string, progress>`), and passes progress data to pure cards as `@property()` values.
+
+### Pure element import boundary
+
+Pure elements import **only framework primitives** (`lit`, their own `*.module.css`). Nothing from the application — no domain services, no router utilities, no `@lit/context`. This is a hard boundary with no exceptions.
+
+The cost is one extra event handler in the parent for navigation, but the payoff is significant:
+- Elements are self-documenting: `@property()` shows inputs, `CustomEvent` shows outputs
+- Elements are context-free: reusable in any parent (navigation, modal, embed)
+- No judgment calls about what qualifies as a "utility" vs. a "service"
+- Convention is universally applicable across any project
+
+The card dispatches a `review` CustomEvent. The parent calls `navigate()`.
+
+**Type imports are fine.** `import type { Document } from '@app/documents'` is erased at compile time — it creates zero runtime coupling. The boundary is **runtime imports**: only `lit` and the element's own CSS module. Type-only imports from domain modules are permitted because they describe the shape of data the element receives, without creating dependencies on application behavior.
+
+### Directory structure
+
+Three component-type directories under `app/client/`, each with domain subdirectories:
+
+```
+app/client/
+├── views/           # route-level view components
+│   └── documents/
+├── components/      # stateful components (@consume, service calls)
+│   └── (created in #77)
+├── elements/        # pure elements (@property, CustomEvent)
+│   └── documents/
+│       ├── document-card.ts
+│       ├── document-card.module.css
+│       ├── classify-progress.ts
+│       ├── classify-progress.module.css
+│       └── index.ts
+```
+
+Elements are registered via side-effect import in `app.ts`: `import './elements'`.
+
+## Implementation
+
+### Step 1: `hd-classify-progress` element
+
+**`app/client/elements/documents/classify-progress.ts`**
+
+Pure element rendering a horizontal 4-stage pipeline: init → classify → enhance → finalize.
+
+Properties:
+- `currentNode: string` — the active stage
+- `completedNodes: string[]` — stages that have finished
+
+Stage state logic (hardcoded stage list `['init', 'classify', 'enhance', 'finalize']`):
+- In `completedNodes` → `completed` class
+- Equals `currentNode` → `active` class
+- Otherwise → `pending` (default)
+
+Renders as a flex row of stage indicators with connecting lines between them. Each stage: a small circle/dot + label below. Active stage gets a subtle pulse animation. Completed stages get the green accent. Pending stages are dimmed.
+
+**`app/client/elements/documents/classify-progress.module.css`**
+
+CSS using design tokens: `--green` for completed, `--blue` for active, `--color-2` for pending. Pulse keyframe for the active indicator. Flex layout with `gap` for spacing, connecting line segments via `::before`/`::after` pseudo-elements or border-based connectors.
+
+### Step 2: `hd-document-card` element
+
+**`app/client/elements/documents/document-card.ts`**
+
+Pure element displaying document information with action buttons.
+
+Properties:
+- `document: Document` — document data (includes optional `classification`, `confidence`, `classified_at` from LEFT JOIN)
+- `classifying: boolean` — whether classification SSE is in progress (default `false`)
+- `currentNode: string` — current SSE stage (passed through to `hd-classify-progress`)
+- `completedNodes: string[]` — completed SSE stages (passed through to `hd-classify-progress`)
+
+Renders:
+- **Header**: filename
+- **Metadata**: page count, formatted upload date, file size
+- **Status badge**: CSS class driven by `document.status` — `pending` (yellow tokens), `review` (blue tokens), `complete` (green tokens)
+- **Classification summary** (conditional — when `document.classification` exists): classification label + confidence
+- **Classify progress** (conditional — when `classifying` is true): `<hd-classify-progress>` with currentNode/completedNodes
+- **Actions**: Classify button (dispatches `classify` CustomEvent), Review button (dispatches `review` CustomEvent)
+
+Classify button disabled when `document.status === 'complete'` OR `classifying` is true.
+
+Events dispatched:
+- `classify` — `CustomEvent<{ id: string }>` with `bubbles: true, composed: true`
+- `review` — `CustomEvent<{ id: string }>` with `bubbles: true, composed: true`
+
+**`app/client/elements/documents/document-card.module.css`**
+
+Card layout with `--bg-1` background, `--radius-md` border radius, `--shadow-sm` elevation. Status badge as inline pill using semantic color tokens. Action buttons in a footer row. Responsive-friendly with min-width constraints.
+
+### Step 3: Barrel exports and registration
+
+**`app/client/elements/documents/index.ts`**
+```typescript
+export { ClassifyProgress } from './classify-progress';
+export { DocumentCard } from './document-card';
+```
+
+**`app/client/elements/index.ts`**
+```typescript
+export * from './documents';
+```
+
+**`app/client/app.ts`** — add `import './elements';` alongside existing `import './views';`
+
+### Step 4: Update web-development skill references
+
+**`references/state.md`** — Rewrite "Encapsulated Streaming" section:
+- Show a stateful **list/grid component** (not the card) calling `ClassificationService.classify()`
+- List component tracks `Map<string, { status, currentNode, completedNodes }>` via `@state()`
+- List passes progress data to pure cards as properties
+- List dispatches `classify-complete` to view for data refresh
+
+**`references/components.md`** — Update:
+- Stateful component example shows streaming orchestration
+- Pure element example shows the card receiving classify progress as properties and dispatching classify event
+- Pure element example dispatches `review` event instead of calling `navigate()` directly
+
+**`SKILL.md`** — Update:
+- Architecture Overview: clarify "components call services directly" means views and stateful components
+- File Structure: add `elements/` and `components/` directories with domain subdirectories
+- Naming Conventions: add element file naming pattern
+- Anti-Patterns: strengthen "Pure elements calling services" — no application imports at all, including router
+- Add convention: "Pure elements import only `lit` and their own CSS module — nothing from the application"
+
+## Affected Files
+
+New:
+- `app/client/elements/documents/classify-progress.ts`
+- `app/client/elements/documents/classify-progress.module.css`
+- `app/client/elements/documents/document-card.ts`
+- `app/client/elements/documents/document-card.module.css`
+- `app/client/elements/documents/index.ts`
+- `app/client/elements/index.ts`
+
+Modified:
+- `app/client/app.ts` — add elements import
+- `.claude/skills/web-development/SKILL.md` — architecture updates
+- `.claude/skills/web-development/references/state.md` — fix encapsulated streaming
+- `.claude/skills/web-development/references/components.md` — update examples
+
+## Validation Criteria
+
+- [ ] `hd-classify-progress` renders 4-stage pipeline with pending/active/completed visual states
+- [ ] `hd-document-card` renders filename, page count, date, size, status badge
+- [ ] Status badge visually differentiates pending/review/complete via color tokens
+- [ ] Classification summary shown conditionally when document has classification data
+- [ ] Classify button dispatches `classify` CustomEvent with document ID
+- [ ] Classify button disabled when status === 'complete' or classifying is true
+- [ ] Review button dispatches `review` CustomEvent with document ID
+- [ ] Progress element shown inline when classifying is true
+- [ ] Neither element has runtime imports beyond `lit` and its own CSS module (`import type` from domain modules is OK)
+- [ ] Both elements use `*.module.css` with design tokens
+- [ ] `app.ts` imports `./elements` for registration
+- [ ] Skill references updated — no more contradiction between tiers and streaming
+- [ ] `bun run build` compiles without errors

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -33,7 +33,7 @@ description: >
 
 | Concern | Location | Purpose |
 |---------|----------|---------|
-| Services | `app/client/<domain>/service.ts` | Stateless API wrappers mirroring Go handlers |
+| Services | `app/client/<domain>/service.ts` | Stateless API wrappers mirroring Go handlers. Called by views and stateful components only. |
 | Shared state | View/component class fields | `Signal.State` signals shared via `@lit/context` |
 | Local state | `@state()` decorator | Per-component reactive state (progress, errors, UI toggles) |
 
@@ -47,7 +47,7 @@ Each tier has a specific role. Violating the boundaries (e.g., a pure element di
 |------|------|-------|---------|
 | View | Call services, provide shared signals, route-level | `@provide`, `SignalWatcher`, services | `hd-documents-view` |
 | Stateful Component | Consume shared state, call services for own concerns | `@consume`, `@state()`, services, events | `hd-document-list` |
-| Pure Element | Props in, events out | `@property`, `CustomEvent` | `hd-document-card` |
+| Pure Element | Props in, events out | `@property`, `CustomEvent`. Imports `lit`, own CSS module, and immutable domain infrastructure (types, constants). | `hd-document-card` |
 
 ## Reference Guide
 
@@ -116,12 +116,13 @@ Domain infrastructure (types, services) lives in domain directories. Views, comp
 ```
 app/client/
 ├── core/                            # API layer (request, stream, types)
+├── formatting/                      # shared formatting utilities (formatBytes, formatDate)
 ├── documents/                       # domain: types + service
 │   ├── document.ts                  # Document, DocumentStatus
 │   ├── service.ts                   # DocumentService (stateless)
 │   └── index.ts                     # barrel
-├── classifications/                 # domain: types + service
-│   ├── classification.ts            # Classification
+├── classifications/                 # domain: types + service + constants
+│   ├── classification.ts            # Classification, WorkflowStage, WORKFLOW_STAGES
 │   ├── service.ts                   # ClassificationService (stateless)
 │   └── index.ts                     # barrel
 ├── prompts/                         # domain: types + service
@@ -131,13 +132,20 @@ app/client/
 │       ├── index.ts                 # barrel (view component only)
 │       ├── documents-view.ts        # @customElement('hd-documents-view')
 │       └── documents-view.module.css
-├── components/                      # stateful components (@consume)
+├── components/                      # stateful components (@consume, service calls)
+│   └── documents/                   # domain-scoped components
 ├── elements/                        # pure elements (props/events)
+│   └── documents/                   # domain-scoped elements
+│       ├── document-card.ts         # @customElement('hd-document-card')
+│       ├── document-card.module.css
+│       ├── classify-progress.ts     # @customElement('hd-classify-progress')
+│       ├── classify-progress.module.css
+│       └── index.ts                 # barrel
 ├── router/
 └── design/
 ```
 
-**Domain directories** export types and stateless services. **View directories** export view components. **Components** and **elements** are shared across views.
+**Domain directories** export types, constants, and stateless services. **Component type directories** (`views/`, `components/`, `elements/`) each use domain subdirectories mirroring the domain infrastructure layout. Elements and components are registered via side-effect imports in `app.ts`.
 
 ### Path Alias
 
@@ -169,7 +177,7 @@ declare global {
 - Skipping `SignalWatcher` mixin when consuming signal-based state (reactivity won't work)
 - Putting signals or context in service files — services are stateless API wrappers
 - Creating state orchestration layers between services and components — components call services directly
-- Pure elements calling services — only views and stateful components should import services
+- Pure elements importing stateful infrastructure — services, signals, context (`@provide`/`@consume`), `SignalWatcher`, or router utilities. Elements can import immutable domain infrastructure (types, constants, formatters) but never anything that holds or mutates state.
 - Using `height: 100%` in flex containers — use `flex: 1` with `min-height: 0`
 - Forgetting `min-height: 0` on flex children that need scroll boundaries
 - Using inline `style` attributes — use CSS classes and custom properties
@@ -188,3 +196,4 @@ declare global {
 - FormData extraction over controlled inputs for form handling
 - `disconnectedCallback` cleanup for blob URLs and event listeners
 - Event delegation at the list level over individual handlers on each item
+- Domain types and constants in pure elements — immutable domain knowledge is fine, stateful behavior is not

--- a/.claude/skills/web-development/references/components.md
+++ b/.claude/skills/web-development/references/components.md
@@ -64,7 +64,7 @@ declare global {
 
 ## Stateful Component (consumes state, calls services)
 
-Stateful components receive shared state via `@consume` and call services directly for their own concerns. They bridge shared state with pure elements and manage local UI state with `@state()`.
+Stateful components receive shared state via `@consume` and call services directly for their own concerns. They bridge shared state with pure elements, manage local UI state with `@state()`, and own streaming orchestration for their subtree.
 
 ```typescript
 import { LitElement, html } from 'lit';
@@ -75,8 +75,14 @@ import { DocumentService } from '@app/documents';
 import { ClassificationService } from '@app/classifications';
 import { documentsContext } from '../views/documents/documents-view';
 import type { Document } from '@app/documents';
+import type { WorkflowStage } from '@app/classifications';
 import type { PageResult } from '@app/core';
 import styles from './document-list.module.css';
+
+interface ClassifyProgress {
+  currentNode: WorkflowStage | null;
+  completedNodes: WorkflowStage[];
+}
 
 @customElement('hd-document-list')
 export class DocumentList extends SignalWatcher(LitElement) {
@@ -85,12 +91,50 @@ export class DocumentList extends SignalWatcher(LitElement) {
   @consume({ context: documentsContext })
   private documents!: Signal.State<PageResult<Document> | null>;
 
+  @state() private classifying = new Map<string, ClassifyProgress>();
+
+  private handleClassify(e: CustomEvent<{ id: string }>) {
+    const docId = e.detail.id;
+    this.classifying.set(docId, { currentNode: 'init', completedNodes: [] });
+    this.requestUpdate();
+
+    ClassificationService.classify(docId, {
+      onEvent: (type, data) => {
+        const event = JSON.parse(data);
+        const progress = this.classifying.get(docId);
+        if (!progress) return;
+
+        switch (type) {
+          case 'node.start':
+            progress.currentNode = event.data.node;
+            break;
+          case 'node.complete':
+            progress.completedNodes = [...progress.completedNodes, event.data.node];
+            break;
+          case 'complete':
+            this.classifying.delete(docId);
+            this.dispatchEvent(new CustomEvent('classify-complete', {
+              bubbles: true, composed: true,
+            }));
+            break;
+          case 'error':
+            this.classifying.delete(docId);
+            break;
+        }
+        this.requestUpdate();
+      },
+      onError: () => {
+        this.classifying.delete(docId);
+        this.requestUpdate();
+      },
+    });
+  }
+
   private async handleDelete(e: CustomEvent<{ id: string }>) {
     const result = await DocumentService.delete(e.detail.id);
     if (result.ok) {
       this.dispatchEvent(new CustomEvent('document-deleted', {
-        bubbles: true,
-        composed: true,
+        bubbles: true, composed: true,
       }));
     }
   }
@@ -100,14 +144,19 @@ export class DocumentList extends SignalWatcher(LitElement) {
     if (!page) return html`<p>Loading...</p>`;
     if (page.data.length === 0) return html`<p>No documents</p>`;
 
-    return page.data.map(
-      (doc) => html`
+    return page.data.map((doc) => {
+      const progress = this.classifying.get(doc.id);
+      return html`
         <hd-document-card
           .document=${doc}
+          ?classifying=${progress !== undefined}
+          .currentNode=${progress?.currentNode ?? null}
+          .completedNodes=${progress?.completedNodes ?? []}
+          @classify=${this.handleClassify}
           @delete=${this.handleDelete}
         ></hd-document-card>
-      `
-    );
+      `;
+    });
   }
 
   render() {
@@ -118,12 +167,14 @@ export class DocumentList extends SignalWatcher(LitElement) {
 
 ## Pure Element (stateless)
 
-Pure elements receive data via properties and communicate upward through events. They have no knowledge of services or application state.
+Pure elements receive data via properties and communicate upward through events. They can import immutable domain infrastructure (types, constants, formatters) but never anything that holds or mutates state (services, signals, context, router).
 
 ```typescript
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { formatBytes, formatDate } from '@app/formatting';
 import type { Document } from '@app/documents';
+import type { WorkflowStage } from '@app/classifications';
 import styles from './document-card.module.css';
 
 @customElement('hd-document-card')
@@ -131,9 +182,20 @@ export class DocumentCard extends LitElement {
   static styles = styles;
 
   @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
 
-  private handleDelete() {
-    this.dispatchEvent(new CustomEvent('delete', {
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private handleReview() {
+    this.dispatchEvent(new CustomEvent('review', {
       detail: { id: this.document.id },
       bubbles: true,
       composed: true,
@@ -141,11 +203,24 @@ export class DocumentCard extends LitElement {
   }
 
   render() {
+    const doc = this.document;
     return html`
       <div class="card">
-        <h3>${this.document.filename}</h3>
-        <p>${this.document.status}</p>
-        <button @click=${this.handleDelete}>Delete</button>
+        <span class="filename">${doc.filename}</span>
+        <span class="badge ${doc.status}">${doc.status}</span>
+        <span>${formatBytes(doc.size_bytes)}</span>
+        <span>${formatDate(doc.uploaded_at)}</span>
+        ${this.classifying
+          ? html`<hd-classify-progress
+              .currentNode=${this.currentNode}
+              .completedNodes=${this.completedNodes}
+            ></hd-classify-progress>`
+          : nothing}
+        <button
+          ?disabled=${doc.status === 'complete' || this.classifying}
+          @click=${this.handleClassify}
+        >Classify</button>
+        <button @click=${this.handleReview}>Review</button>
       </div>
     `;
   }

--- a/.claude/skills/web-development/references/state.md
+++ b/.claude/skills/web-development/references/state.md
@@ -114,71 +114,121 @@ private async handleDelete(id: string) {
 }
 ```
 
-## Encapsulated Streaming
+## Streaming Orchestration
 
-SSE operations are owned by the component closest to the concern. A document component that supports classification manages its own stream lifecycle using `@state()` — no shared signal needed.
+SSE operations are owned by the **stateful component** closest to the collection concern — not the pure element that triggered the action. The stateful component calls the streaming service, tracks per-item progress via `@state()`, and passes progress data to pure elements as properties.
+
+This keeps pure elements context-free and reusable. The parent dispatches a single completion event when the operation finishes — the view never sees intermediate progress events.
 
 ```typescript
-@customElement('hd-document-card')
-export class DocumentCard extends SignalWatcher(LitElement) {
-  @property({ type: Object }) document!: Document;
-  @state() private classifyStatus?: string;
-  @state() private classifyNode?: string;
-  @state() private classifyError?: string;
+// Stateful component — owns SSE lifecycle for the collection
+@customElement('hd-document-list')
+export class DocumentList extends SignalWatcher(LitElement) {
+  @consume({ context: documentsContext })
+  private documents!: Signal.State<PageResult<Document> | null>;
 
-  classify() {
-    this.classifyStatus = 'running';
-    this.classifyNode = 'init';
+  @state() private classifying = new Map<string, ClassifyProgress>();
 
-    ClassificationService.classify(this.document.id, {
+  private handleClassify(e: CustomEvent<{ id: string }>) {
+    const docId = e.detail.id;
+    this.classifying.set(docId, { currentNode: 'init', completedNodes: [] });
+    this.requestUpdate();
+
+    ClassificationService.classify(docId, {
       onEvent: (type, data) => {
         const event = JSON.parse(data);
+        const progress = this.classifying.get(docId);
+        if (!progress) return;
+
         switch (type) {
           case 'node.start':
-            this.classifyNode = event.data.node;
+            progress.currentNode = event.data.node;
             break;
           case 'node.complete':
-            if (event.data.error) {
-              this.classifyStatus = 'error';
-              this.classifyError = event.data.error_message;
-            }
+            progress.completedNodes = [...progress.completedNodes, event.data.node];
             break;
           case 'complete':
-            this.classifyStatus = 'complete';
+            this.classifying.delete(docId);
             this.dispatchEvent(new CustomEvent('classify-complete', {
-              detail: { id: this.document.id },
-              bubbles: true,
-              composed: true,
+              bubbles: true, composed: true,
             }));
             break;
           case 'error':
-            this.classifyStatus = 'error';
-            this.classifyError = event.data.message;
+            this.classifying.delete(docId);
             break;
         }
+        this.requestUpdate();
       },
-      onError: (err) => {
-        this.classifyStatus = 'error';
-        this.classifyError = err;
-      },
-      onComplete: () => {
-        if (this.classifyStatus === 'running') {
-          this.classifyStatus = 'error';
-          this.classifyError = 'stream disconnected unexpectedly';
-        }
+      onError: () => {
+        this.classifying.delete(docId);
+        this.requestUpdate();
       },
     });
+  }
+
+  render() {
+    const page = this.documents.get();
+    if (!page) return html`<p>Loading...</p>`;
+
+    return html`
+      ${page.data.map((doc) => {
+        const progress = this.classifying.get(doc.id);
+        return html`
+          <hd-document-card
+            .document=${doc}
+            ?classifying=${progress !== undefined}
+            .currentNode=${progress?.currentNode ?? null}
+            .completedNodes=${progress?.completedNodes ?? []}
+            @classify=${this.handleClassify}
+          ></hd-document-card>
+        `;
+      })}
+    `;
   }
 }
 ```
 
-The parent view listens for `@classify-complete` and refreshes its document list — it never sees intermediate progress events.
+The pure element receives all streaming state as properties and dispatches intent events upward. It has no knowledge of services, SSE, or `AbortController`.
+
+```typescript
+// Pure element — props in, events out
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true, composed: true,
+    }));
+  }
+
+  render() {
+    return html`
+      <button
+        ?disabled=${this.document.status === 'complete' || this.classifying}
+        @click=${this.handleClassify}
+      >Classify</button>
+      ${this.classifying
+        ? html`<hd-classify-progress
+            .currentNode=${this.currentNode}
+            .completedNodes=${this.completedNodes}
+          ></hd-classify-progress>`
+        : nothing}
+    `;
+  }
+}
+```
 
 ## Conventions
 
-- **Context for shared data only**: Use `@provide`/`@consume` when multiple descendants need the same reactive data
+- **Context for shared data only**: Use `@provide`/`@consume` when multiple descendants need the same reactive data. Pure elements never use context — only views and stateful components.
+- **Streaming in stateful components**: The component managing the collection (list/grid) owns SSE lifecycle. Pure elements receive progress as properties and dispatch intent events.
 - **`@state()` for local concerns**: Classification progress, form errors, UI toggles — use Lit's built-in reactive state
-- **Components call services directly**: No orchestration middleman between services and components
+- **Views and stateful components call services directly**: No orchestration middleman between services and components. Pure elements dispatch events instead.
 - **Events up, data down**: Children dispatch `CustomEvent` to notify parents of outcomes
 - **Signal reads**: `.get()` in templates inside `SignalWatcher` components
 - **Signal writes**: `.set()` in the component that owns the signal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.59.75
+- Add document card and classify progress pure elements with `WorkflowStage` domain type, shared formatting utilities, and corrected streaming orchestration in web-development skill references (#75)
+
 ## v0.3.0-dev.59.74
 - Add web client data layer — enhance SSE `stream()` with event type parsing and POST support, TypeScript domain types mirroring Go API shapes, and stateless service objects mapping all handler endpoints across documents, classifications, prompts, and storage domains (#74)
 

--- a/app/client/app.ts
+++ b/app/client/app.ts
@@ -1,4 +1,5 @@
 import './design/index.css';
+import './elements';
 import './views';
 
 import { Router } from '@app/router';

--- a/app/client/classifications/classification.ts
+++ b/app/client/classifications/classification.ts
@@ -1,3 +1,11 @@
+/** A stage in the classification workflow pipeline. */
+export type WorkflowStage = 'init' | 'classify' | 'enhance' | 'finalize';
+
+/** Ordered list of all classification workflow stages. */
+export const WORKFLOW_STAGES: readonly WorkflowStage[] = [
+  'init', 'classify', 'enhance', 'finalize'
+];
+
 /**
  * Classification result for a document.
  * Mirrors Go `classifications.Classification` struct.

--- a/app/client/classifications/index.ts
+++ b/app/client/classifications/index.ts
@@ -1,3 +1,4 @@
-export * from './classification';
+export { WORKFLOW_STAGES } from './classification';
+export type { Classification, WorkflowStage } from './classification';
 export { ClassificationService } from './service';
 export type { ValidateCommand, UpdateCommand } from './service';

--- a/app/client/elements/documents/classify-progress.module.css
+++ b/app/client/elements/documents/classify-progress.module.css
@@ -1,0 +1,75 @@
+:host {
+  display: block;
+}
+
+.pipeline {
+  display: flex;
+  position: relative;
+  padding: 0 var(--space-2);
+}
+
+.pipeline::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: calc(var(--space-2) + 5px);
+  right: calc(var(--space-2) + 5px);
+  height: 2px;
+  background: var(--divider);
+}
+
+.stage {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 2px solid var(--divider);
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.stage.completed .indicator {
+  background: var(--green);
+  border-color: var(--green);
+}
+
+.stage.active .indicator {
+  background: var(--blue);
+  border-color: var(--blue);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.label {
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+  text-transform: capitalize;
+}
+
+.stage.completed .label {
+  color: var(--green);
+}
+
+.stage.active .label {
+  color: var(--blue);
+}
+
+@keyframes pulse {
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/app/client/elements/documents/classify-progress.ts
+++ b/app/client/elements/documents/classify-progress.ts
@@ -1,0 +1,42 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { WORKFLOW_STAGES } from '@app/classifications';
+import type { WorkflowStage } from '@app/classifications';
+import styles from './classify-progress.module.css'
+
+/**
+ * Pure element that renders a horizontal 4-stage pipeline indicator
+ * for the classification workflow. Receives progress state as properties.
+ */
+@customElement('hd-classify-progress')
+export class ClassifyProgress extends LitElement {
+  static styles = styles;
+
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private stageState(stage: WorkflowStage): string {
+    if (this.completedNodes.includes(stage)) return 'completed';
+    if (stage === this.currentNode) return 'active';
+    return 'pending';
+  }
+
+  render() {
+    return html`
+      <div class="pipeline">
+        ${WORKFLOW_STAGES.map((stage) => html`
+            <div class="stage ${this.stageState(stage)}">
+              <div class="indicator"></div>
+              <span class="label">${stage}</span>
+            </div>
+        `)}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-classify-progress': ClassifyProgress;
+  }
+}

--- a/app/client/elements/documents/document-card.module.css
+++ b/app/client/elements/documents/document-card.module.css
@@ -1,0 +1,131 @@
+:host {
+  display: block;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.filename {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge.pending {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.badge.review {
+  color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.badge.complete {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.meta span:not(:last-child)::after {
+  content: '·';
+  margin-left: var(--space-2);
+  color: var(--divider);
+}
+
+.classification {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.classification-label {
+  font-weight: 600;
+  color: var(--color);
+}
+
+.confidence {
+  font-size: var(--text-xs);
+  color: var(--color-1);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--color-2);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.classify-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.classify-btn:hover:not(:disabled) {
+  background: var(--blue-bg);
+}
+
+.review-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.review-btn:hover:not(:disabled) {
+  background: var(--green-bg);
+}

--- a/app/client/elements/documents/document-card.ts
+++ b/app/client/elements/documents/document-card.ts
@@ -1,0 +1,106 @@
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { WorkflowStage } from '@app/classifications';
+import type { Document } from '@app/documents';
+import { formatBytes, formatDate } from '@app/formatting';
+import styles from './document-card.module.css';
+
+/**
+ * Pure element that displays a document's metadata, classification summary,
+ * and action buttons. Dispatches `classify` and `review` custom events.
+ */
+@customElement('hd-document-card')
+export class DocumentCard extends LitElement {
+  static styles = styles;
+
+  @property({ type: Object }) document!: Document;
+  @property({ type: Boolean }) classifying = false;
+  @property() currentNode: WorkflowStage | null = null;
+  @property({ type: Array }) completedNodes: WorkflowStage[] = [];
+
+  private get classifyDisabled(): boolean {
+    return this.document.status === 'complete' || this.classifying;
+  }
+
+  private handleClassify() {
+    this.dispatchEvent(new CustomEvent('classify', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private handleReview() {
+    this.dispatchEvent(new CustomEvent('review', {
+      detail: { id: this.document.id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private renderClassification() {
+    if (!this.document.classification) return nothing;
+
+    return html`
+      <div class="classification">
+        <span class="classification-label">${this.document.classification}</span>
+        ${this.document.confidence
+        ? html`<span class="confidence">${this.document.confidence}</span>`
+        : nothing}
+      </div>
+    `;
+  }
+
+  private renderProgress() {
+    if (!this.classifying) return nothing;
+
+    return html`
+      <hd-classify-progress
+        .currentNode=${this.currentNode}
+        .completedNodes=${this.completedNodes}
+      ></hd-classify-progress>
+    `;
+  }
+
+  render() {
+    const doc = this.document;
+
+    return html`
+      <div class="card">
+        <div class="header">
+          <span class="filename">${doc.filename}</span>
+          <span class="badge ${doc.status}">${doc.status}</span>
+        </div>
+
+        <div class="meta">
+          ${doc.page_count !== null
+        ? html`<span>${doc.page_count} pages</span>`
+        : nothing}
+          <span>${formatBytes(doc.size_bytes)}</span>
+          <span>${formatDate(doc.uploaded_at)}</span>
+        </div>
+
+        ${this.renderClassification()}
+        ${this.renderProgress()}
+
+        <div class="actions">
+          <button
+            class="btn classify-btn"
+            ?disabled=${this.classifyDisabled}
+            @click=${this.handleClassify}
+          >Classify</button>
+          <button
+            class="btn review-btn"
+            @click=${this.handleReview}
+          >Review</button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-document-card': DocumentCard;
+  }
+}

--- a/app/client/elements/documents/index.ts
+++ b/app/client/elements/documents/index.ts
@@ -1,0 +1,2 @@
+export { ClassifyProgress } from './classify-progress';
+export { DocumentCard } from './document-card';

--- a/app/client/elements/index.ts
+++ b/app/client/elements/index.ts
@@ -1,0 +1,1 @@
+export * from './documents';

--- a/app/client/formatting/bytes.ts
+++ b/app/client/formatting/bytes.ts
@@ -1,0 +1,18 @@
+const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+/**
+ * Formats a byte count into a human-readable string using base-1024 units.
+ * Mirrors Go `pkg/formatting.FormatBytes`.
+ */
+export function formatBytes(n: number, precision = 1): string {
+  if (n === 0) return '0 B';
+
+  const k = 1024;
+  const i = Math.min(
+    Math.floor(Math.log(n) / Math.log(k)),
+    units.length - 1,
+  );
+
+  const size = n / Math.pow(k, i);
+  return `${size.toFixed(Math.max(precision, 0))} ${units[i]}`;
+}

--- a/app/client/formatting/date.ts
+++ b/app/client/formatting/date.ts
@@ -1,0 +1,8 @@
+/** Formats an ISO date string into a locale-aware short date (e.g., "Mar 3, 2026"). */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/app/client/formatting/index.ts
+++ b/app/client/formatting/index.ts
@@ -1,0 +1,2 @@
+export { formatBytes } from './bytes';
+export { formatDate } from './date';


### PR DESCRIPTION
## Summary

- Create `hd-document-card` and `hd-classify-progress` pure elements for the documents view
- Add `WorkflowStage` domain type and `WORKFLOW_STAGES` constant to classifications domain
- Add shared formatting utilities (`formatBytes`, `formatDate`) in `app/client/formatting/`
- Establish element barrel exports and registration in `app.ts`
- Correct web-development skill references to place streaming orchestration in the stateful component tier, resolving the architectural contradiction where pure elements were shown calling services directly

## Key Architecture Decisions

- **Pure element import boundary**: Elements can import `lit`, own CSS module, and immutable domain infrastructure (types, constants, formatters). Stateful infrastructure (services, signals, context, router) is prohibited.
- **Streaming orchestration**: SSE lifecycle belongs in the stateful component tier (list/grid), not in pure elements. Cards receive progress as properties and dispatch intent events.
- **WorkflowStage formalized**: Domain type and constant in classifications rather than local element constants.

## Test plan

- [ ] `bun run build` compiles without errors
- [ ] Verify `hd-document-card` renders document metadata, status badge, and action buttons
- [ ] Verify `hd-classify-progress` renders 4-stage pipeline with visual state differentiation
- [ ] Verify neither element imports stateful infrastructure
- [ ] Verify skill references no longer show pure elements calling services

Closes #75