### PR TITLE
Add document upload component with multi-file support

### DIFF
--- a/.claude/context/guides/.archive/76-document-upload-component.md
+++ b/.claude/context/guides/.archive/76-document-upload-component.md
@@ -1,0 +1,592 @@
+# 76 - Document Upload Component
+
+## Problem Context
+
+The document management view (#59) needs an upload component that coordinates multi-file PDF uploads. Users must be able to select files (click or drag-and-drop), assign per-file metadata (`external_id` and `external_platform`), and upload all files concurrently with per-file status feedback.
+
+## Architecture Approach
+
+`hd-document-upload` is a **stateful component** in `components/documents/` — it calls `DocumentService.upload()` directly and manages local `@state()` for the file queue and upload lifecycle. It dispatches an `upload-complete` event when all uploads settle so the parent view can refresh its document list.
+
+No `@consume`/`@provide` — this component is self-contained. The three-tier hierarchy is: view (route-level, #77) → component (this, service-calling) → elements (pure, already done in #75).
+
+## Implementation
+
+### Step 1: Create `app/client/documents/upload.ts`
+
+New file — domain types for the upload lifecycle:
+
+```typescript
+type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+interface UploadEntry {
+  file: File;
+  status: UploadStatus;
+  externalId: number;
+  platform: string;
+  error?: string;
+}
+```
+
+Then update `app/client/documents/index.ts` to re-export them. Add after the existing exports:
+
+```typescript
+export type { UploadStatus, UploadEntry } from './upload';
+```
+
+### Step 2: Create `app/client/components/documents/document-upload.ts`
+
+New file — the complete component:
+
+```typescript
+import { LitElement, html, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { DocumentService } from '@app/documents';
+import type { UploadEntry } from '@app/documents';
+import { formatBytes } from '@app/formatting';
+import styles from './document-upload.module.css';
+
+@customElement('hd-document-upload')
+export class DocumentUpload extends LitElement {
+  static styles = styles;
+
+  @state() private queue: UploadEntry[] = [];
+  @state() private uploading = false;
+  @state() private dragover = false;
+
+  private get canUpload(): boolean {
+    return this.queue.length > 0
+      && !this.uploading
+      && this.queue.every(e =>
+        e.status === 'pending'
+        && e.externalId > 0
+        && e.platform.trim() !== ''
+      );
+  }
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has('dragover')) {
+      this.toggleAttribute('dragover', this.dragover);
+    }
+  }
+
+  private addFiles(files: FileList) {
+    const pdfs = Array.from(files).filter(f => f.type === 'application/pdf');
+    if (pdfs.length === 0) return;
+
+    const entries: UploadEntry[] = pdfs.map(file => ({
+      file,
+      status: 'pending' as const,
+      externalId: 0,
+      platform: '',
+    }));
+
+    this.queue = [...this.queue, ...entries];
+  }
+
+  private handleFileInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (input.files) this.addFiles(input.files);
+    input.value = '';
+  }
+
+  private handleClick() {
+    this.renderRoot.querySelector<HTMLInputElement>('#file-input')?.click();
+  }
+
+  private handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    this.dragover = true;
+  }
+
+  private handleDragLeave() {
+    this.dragover = false;
+  }
+
+  private handleDrop(e: DragEvent) {
+    e.preventDefault();
+    this.dragover = false;
+    if (e.dataTransfer?.files) this.addFiles(e.dataTransfer.files);
+  }
+
+  private handleIdChange(index: number, e: Event) {
+    const input = e.target as HTMLInputElement;
+    const value = parseInt(input.value, 10);
+    if (Number.isNaN(value)) return;
+
+    this.queue[index].externalId = value;
+    this.requestUpdate();
+  }
+
+  private handlePlatformChange(index: number, e: Event) {
+    const input = e.target as HTMLInputElement;
+
+    this.queue[index].platform = input.value;
+    this.requestUpdate();
+  }
+
+  private handleRemove(index: number) {
+    this.queue = this.queue.filter((_, i) => i !== index);
+  }
+
+  private handleClear() {
+    this.queue = [];
+  }
+
+  private async handleUpload() {
+    this.uploading = true;
+
+    this.queue = this.queue.map(entry => ({
+      ...entry,
+      status: 'uploading' as const,
+    }));
+
+    const results = await Promise.allSettled(
+      this.queue.map(async (entry, index) => {
+        const result = await DocumentService.upload(
+          entry.file,
+          entry.externalId,
+          entry.platform,
+        );
+
+        this.queue[index].status = result.ok ? 'success' as const : 'error' as const;
+        this.queue[index].error = result.ok ? undefined : result.error;
+        this.requestUpdate();
+
+        if (!result.ok)
+          throw new Error(result.error);
+
+        return result.data;
+      }),
+    );
+
+    this.uploading = false;
+
+    const hasSuccess = results.some(r => r.status === 'fulfilled');
+    if (hasSuccess) {
+      this.dispatchEvent(new CustomEvent('upload-complete', {
+        bubbles: true,
+        composed: true,
+      }));
+    }
+  }
+
+  private renderDropZone() {
+    return html`
+      <div
+        class="drop-zone"
+        @click=${this.handleClick}
+        @dragover=${this.handleDragOver}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
+      >
+        <input
+          id="file-input"
+          type="file"
+          accept=".pdf"
+          multiple
+          hidden
+          @change=${this.handleFileInput}
+        />
+        <span class="drop-icon">📄</span>
+        <span class="drop-text">Drag PDFs here or click to browse</span>
+      </div>
+    `;
+  }
+
+  private renderQueueEntry(entry: UploadEntry, index: number) {
+    const settled = entry.status === 'success' || entry.status === 'error';
+    const editable = entry.status === 'pending';
+
+    return html`
+      <div class="queue-entry">
+        <div class="entry-info">
+          <span class="entry-filename">${entry.file.name}</span>
+          <span class="entry-size">${formatBytes(entry.file.size)}</span>
+          <span class="badge ${entry.status}">${entry.status}</span>
+        </div>
+
+        <div class="entry-fields">
+          <label class="field">
+            <span class="field-label">ID</span>
+            <input
+              type="number"
+              class="field-input id-input"
+              .value=${String(entry.externalId)}
+              ?disabled=${!editable}
+              @change=${(e: Event) => this.handleIdChange(index, e)}
+            />
+          </label>
+
+          <label class="field">
+            <span class="field-label">Platform</span>
+            <input
+              type="text"
+              class="field-input"
+              .value=${entry.platform}
+              placeholder="e.g. HQ"
+              ?disabled=${!editable}
+              @input=${(e: Event) => this.handlePlatformChange(index, e)}
+            />
+          </label>
+
+          ${editable ? html`
+            <button
+              class="btn remove-btn"
+              @click=${() => this.handleRemove(index)}
+            >✕</button>
+          ` : nothing}
+        </div>
+
+        ${entry.error ? html`
+          <div class="entry-error">${entry.error}</div>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private renderQueue() {
+    if (this.queue.length === 0) return nothing;
+
+    return html`
+      <div class="queue">
+        <div class="queue-header">
+          <span class="queue-title">File Queue</span>
+          <span class="queue-count">${this.queue.length} file${this.queue.length !== 1 ? 's' : ''}</span>
+        </div>
+        ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+      </div>
+    `;
+  }
+
+  private renderActions() {
+    if (this.queue.length === 0) return nothing;
+
+    const allSettled = this.queue.every(
+      e => e.status === 'success' || e.status === 'error'
+    );
+
+    return html`
+      <div class="actions">
+        <button
+          class="btn clear-btn"
+          @click=${this.handleClear}
+          ?disabled=${this.uploading}
+        >${allSettled ? 'Done' : 'Clear'}</button>
+        ${!allSettled ? html`
+          <button
+            class="btn upload-btn"
+            @click=${this.handleUpload}
+            ?disabled=${!this.canUpload}
+          >Upload</button>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      ${this.renderDropZone()}
+      ${this.renderQueue()}
+      ${this.renderActions()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-document-upload': DocumentUpload;
+  }
+}
+```
+
+### Step 3: Create `app/client/components/documents/document-upload.module.css`
+
+New file — component styles using the established design token system:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-8);
+  border: 2px dashed var(--divider);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.drop-zone:hover {
+  border-color: var(--color-2);
+  background: var(--bg-1);
+}
+
+:host([dragover]) .drop-zone {
+  border-color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.drop-icon {
+  font-size: var(--text-2xl);
+}
+
+.drop-text {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+}
+
+.queue {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--divider);
+}
+
+.queue-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color);
+}
+
+.queue-count {
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.queue-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.queue-entry:not(:last-child) {
+  border-bottom: 1px solid var(--divider);
+}
+
+.entry-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.entry-filename {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.entry-size {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge.pending {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.badge.uploading {
+  color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.badge.success {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.badge.error {
+  color: var(--red);
+  background: var(--red-bg);
+}
+
+.entry-fields {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field-label {
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.field-input {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+.field-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.id-input {
+  width: 4rem;
+}
+
+.entry-error {
+  font-size: var(--text-xs);
+  color: var(--red);
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--color-2);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.upload-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.upload-btn:hover:not(:disabled) {
+  background: var(--blue-bg);
+}
+
+.remove-btn {
+  padding: var(--space-1) var(--space-2);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.remove-btn:hover:not(:disabled) {
+  background: var(--red-bg);
+}
+
+.clear-btn:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.clear-btn:hover:not(:disabled) {
+  background: var(--yellow-bg);
+}
+```
+
+### Step 4: Create barrel exports
+
+**`app/client/components/documents/index.ts`** — new file:
+
+```typescript
+export { DocumentUpload } from './document-upload';
+```
+
+**`app/client/components/index.ts`** — new file:
+
+```typescript
+export * from './documents';
+```
+
+### Step 5: Register components in `app.ts`
+
+Add the components import to `app/client/app.ts`. After the existing `import './elements';` line, add:
+
+```typescript
+import './components';
+```
+
+The final `app.ts` will be:
+
+```typescript
+import './design/index.css';
+import './elements';
+import './components';
+import './views';
+
+import { Router } from '@app/router';
+
+const router = new Router('app-content');
+router.start();
+```
+
+## Validation Criteria
+
+- [ ] `bun run build` succeeds with no errors
+- [ ] `go vet ./...` passes (no Go changes but verify nothing regressed)
+- [ ] Drop zone renders and responds to click (opens file picker)
+- [ ] Drag-and-drop onto zone adds PDF files to queue
+- [ ] Non-PDF files are filtered out
+- [ ] Per-file `external_id` and `external_platform` inputs are editable
+- [ ] Upload button disabled when `external_id` is 0 or `external_platform` is empty
+- [ ] Remove button (✕) removes individual pending entries
+- [ ] Clear button resets the entire queue
+- [ ] Upload button disabled when platform fields are empty
+- [ ] Upload button disabled during active upload
+- [ ] Each file uploads independently via `DocumentService.upload()`
+- [ ] Per-file status updates from pending → uploading → success/error
+- [ ] Error messages display for failed uploads
+- [ ] `upload-complete` event dispatches when at least one file succeeds
+- [ ] After all uploads settle, Upload button disappears and Clear becomes "Done"

--- a/.claude/context/sessions/76-document-upload-component.md
+++ b/.claude/context/sessions/76-document-upload-component.md
@@ -1,0 +1,36 @@
+# 76 - Document Upload Component
+
+## Summary
+
+Created `hd-document-upload`, a stateful component that coordinates multi-file PDF uploads with per-file metadata inputs and status tracking. This is the third sub-issue of Objective #59 (Document Management View) and establishes the `components/` directory tier.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Component placement | `components/documents/` | Follows three-tier hierarchy — component calls services and manages local state, distinct from views (route-level) and elements (pure) |
+| Upload metadata | Per-file inputs | Each file gets its own `external_id` and `external_platform` fields for maximum flexibility |
+| State mutations | Direct mutation + `requestUpdate()` | For single-entry field changes, avoids unnecessary array mapping; array replacement used for batch status transitions |
+| Domain types | `documents/upload.ts` | `UploadStatus` and `UploadEntry` are domain types, not component-local |
+
+## Files Modified
+
+- `app/client/documents/upload.ts` — new: `UploadStatus` type and `UploadEntry` interface
+- `app/client/documents/index.ts` — updated: re-exports upload types
+- `app/client/components/documents/document-upload.ts` — new: `hd-document-upload` component
+- `app/client/components/documents/document-upload.module.css` — new: component styles
+- `app/client/components/documents/index.ts` — new: barrel export
+- `app/client/components/index.ts` — new: barrel export
+- `app/client/app.ts` — updated: imports `./components`
+
+## Patterns Established
+
+- **`components/` directory**: First stateful component created, establishing the directory structure parallel to `views/` and `elements/`
+- **Direct mutation for field updates**: `this.queue[index].field = value; this.requestUpdate()` preferred over mapping entire arrays for single-entry changes
+- **Upload queue pattern**: `UploadEntry[]` with per-file status tracking and `Promise.allSettled` coordination
+
+## Validation Results
+
+- `bun run build` passes
+- `go vet ./...` passes
+- Interactive validation deferred to #77 (view integration)

--- a/.claude/plans/jazzy-beaming-engelbart.md
+++ b/.claude/plans/jazzy-beaming-engelbart.md
@@ -1,0 +1,95 @@
+# Plan: #76 — Document Upload Component
+
+## Context
+
+Third sub-issue of Objective #59 (Document Management View). Creates `hd-document-upload`, a stateful component that coordinates multi-file PDF uploads with per-file progress tracking. Dependencies #74 (service) and #75 (elements) are both closed.
+
+## Component Placement
+
+**Location**: `app/client/components/documents/` (stateful component tier — calls `DocumentService.upload()`, manages local `@state()`)
+
+## Design
+
+### Upload Metadata
+
+The Go endpoint requires `external_id` (int) and `external_platform` (string) per file. Each file in the queue gets its own editable `external_id` and `external_platform` inputs — maximum flexibility for mixed-source batches.
+
+### File Queue & Status
+
+```typescript
+type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+interface UploadEntry {
+  file: File;
+  status: UploadStatus;
+  externalId: number;
+  platform: string;
+  error?: string;
+}
+```
+
+Tracked via `@state() private queue: UploadEntry[]`. Default `externalId` auto-increments from 1 for each added file. Default `platform` is empty string (required before upload).
+
+### Upload Flow
+
+1. User selects files via hidden `<input type="file" accept=".pdf" multiple>` triggered by styled button, **and/or** drag-and-drop zone
+2. Files appear in a queue list with status badges (all `pending`)
+3. User fills in per-file `external_platform` and `external_id` fields (defaults pre-populated), then clicks "Upload"
+4. All files upload concurrently via `Promise.allSettled`, each calling `DocumentService.upload(entry.file, entry.externalId, entry.platform)`
+5. Per-file status updates reactively as each promise settles
+6. When all settled: dispatch `upload-complete` CustomEvent (bubbles, composed)
+
+### Component API
+
+- **Events out**: `upload-complete` — parent view refreshes document list
+- **No @consume/@provide** — self-contained; just imports `DocumentService` directly
+- **State**: `@state() queue`, `@state() uploading` (boolean to disable form during batch)
+
+## Files
+
+| File | Action |
+|------|--------|
+| `app/client/components/documents/document-upload.ts` | **New** — stateful upload component |
+| `app/client/components/documents/document-upload.module.css` | **New** — component styles |
+| `app/client/components/documents/index.ts` | **New** — barrel export |
+| `app/client/components/index.ts` | **New** — barrel importing `./documents` |
+| `app/client/app.ts` | **Edit** — add `import './components'` side-effect import |
+
+## UI Layout
+
+```
+┌─────────────────────────────────────────┐
+│  Drop Zone / Click to Select            │
+│  ┌───────────────────────────────────┐  │
+│  │  📄  Drag PDFs here or click to   │  │
+│  │     browse                        │  │
+│  └───────────────────────────────────┘  │
+│                                         │
+│  ┌─ File Queue ───────────────────────────────────────────┐ │
+│  │ report.pdf    48.2 KB  ID:[1___] Platform:[____] pending │ │
+│  │ analysis.pdf  102 KB   ID:[2___] Platform:[____] success │ │
+│  │ summary.pdf   23.1 KB  ID:[3___] Platform:[____] error   │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                                         │
+│  [Clear]                     [Upload]   │
+└─────────────────────────────────────────┘
+```
+
+## Styling Approach
+
+- Design tokens from `tokens.css` (spacing, typography, colors, radii)
+- Status badge pattern from `document-card.module.css` (`.badge.pending`, `.badge.review`, etc.)
+- Drag-over visual feedback via host attribute reflection (`dragover` attr toggled in JS, CSS drives style)
+- Dashed border drop zone, subtle background shift on hover/dragover
+- Consistent `.btn` styling matching document-card buttons
+
+## Validation
+
+- `go vet ./...` passes (no Go changes, but verify)
+- `bun run build` succeeds
+- Component renders in browser at `/app/`
+- File selection populates queue
+- Drag-and-drop populates queue
+- Upload dispatches to `/api/documents` per file
+- Per-file status updates correctly
+- `upload-complete` event fires when all settle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.59.76
+- Add document upload stateful component with drag-and-drop file selection, per-file metadata inputs, concurrent `Promise.allSettled` upload coordination, and per-file status tracking (#76)
+
 ## v0.3.0-dev.59.75
 - Add document card and classify progress pure elements with `WorkflowStage` domain type, shared formatting utilities, and corrected streaming orchestration in web-development skill references (#75)
 

--- a/app/client/app.ts
+++ b/app/client/app.ts
@@ -1,4 +1,5 @@
 import './design/index.css';
+import './components';
 import './elements';
 import './views';
 

--- a/app/client/components/documents/document-upload.module.css
+++ b/app/client/components/documents/document-upload.module.css
@@ -1,0 +1,229 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-8);
+  border: 2px dashed var(--divider);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.drop-zone:hover {
+  border-color: var(--color-2);
+  background: var(--bg-1);
+}
+
+:host([dragover]) .drop-zone {
+  border-color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.drop-icon {
+  font-size: var(--text-2xl);
+}
+
+.drop-text {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+}
+
+.queue {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--divider);
+}
+
+.queue-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color);
+}
+
+.queue-count {
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.queue-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.queue-entry:not(:last-child) {
+  border-bottom: 1px solid var(--divider);
+}
+
+.entry-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.entry-filename {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.entry-size {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge.pending {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.badge.uploading {
+  color: var(--blue);
+  background: var(--blue-bg);
+}
+
+.badge.success {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.badge.error {
+  color: var(--red);
+  background: var(--red-bg);
+}
+
+.entry-fields {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field-label {
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.field-input {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+.field-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.id-input {
+  width: 4rem;
+}
+
+.entry-error {
+  font-size: var(--text-xs);
+  color: var(--red);
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.btn {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  color: var(--color);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--color-2);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.upload-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.upload-btn:hover:not(:disabled) {
+  background: var(--blue-bg);
+}
+
+.remove-btn {
+  padding: var(--space-1) var(--space-2);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.remove-btn:hover:not(:disabled) {
+  background: var(--red-bg);
+}
+
+.clear-btn:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.clear-btn:hover:not(:disabled) {
+  background: var(--yellow-bg);
+}

--- a/app/client/components/documents/document-upload.ts
+++ b/app/client/components/documents/document-upload.ts
@@ -1,0 +1,278 @@
+import { LitElement, html, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { DocumentService } from '@app/documents';
+import type { UploadEntry } from '@app/documents';
+import { formatBytes } from '@app/formatting';
+import styles from './document-upload.module.css';
+
+/**
+ * Stateful component that coordinates multi-file PDF uploads.
+ * Provides drag-and-drop and file picker selection, per-file metadata
+ * inputs, and concurrent upload via {@link DocumentService.upload}.
+ * Dispatches `upload-complete` when at least one file uploads successfully.
+ */
+@customElement('hd-document-upload')
+export class DocumentUpload extends LitElement {
+  static styles = styles;
+
+  @state() private queue: UploadEntry[] = [];
+  @state() private uploading = false;
+  @state() private dragover = false;
+
+  private get canUpload(): boolean {
+    return this.queue.length > 0
+      && !this.uploading
+      && this.queue.every(e =>
+        e.status === 'pending'
+        && e.externalId > 0
+        && e.platform.trim() !== ''
+      );
+  }
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has('dragover')) {
+      this.toggleAttribute('dragover', this.dragover);
+    }
+  }
+
+  private addFiles(files: FileList) {
+    const pdfs = Array
+      .from(files)
+      .filter(f => f.type === 'application/pdf');
+
+    if (pdfs.length < 1)
+      return;
+
+    const entries: UploadEntry[] = pdfs.map(file => ({
+      file,
+      status: 'pending' as const,
+      externalId: 0,
+      platform: '',
+    }));
+
+    this.queue = [...this.queue, ...entries];
+  }
+
+  private handleFileInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (input.files) this.addFiles(input.files);
+    input.value = '';
+  }
+
+  private handleClick() {
+    this.renderRoot
+      .querySelector<HTMLInputElement>('#file-input')
+      ?.click();
+  }
+
+  private handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    this.dragover = true;
+  }
+
+  private handleDragLeave() {
+    this.dragover = false;
+  }
+
+  private handleDrop(e: DragEvent) {
+    e.preventDefault();
+    this.dragover = false;
+    if (e.dataTransfer?.files)
+      this.addFiles(e.dataTransfer.files);
+  }
+
+  private handleIdChange(index: number, e: Event) {
+    const input = e.target as HTMLInputElement;
+    const value = parseInt(input.value, 10);
+    if (Number.isNaN(value))
+      return;
+
+    this.queue[index].externalId = value;
+    this.requestUpdate();
+  }
+
+  private handlePlatformChange(index: number, e: Event) {
+    const input = e.target as HTMLInputElement;
+
+    this.queue[index].platform = input.value;
+    this.requestUpdate();
+  }
+
+  private handleRemove(index: number) {
+    this.queue = this.queue
+      .filter((_, i) => i !== index);
+  }
+
+  private handleClear() {
+    this.queue = [];
+  }
+
+  private async handleUpload() {
+    this.uploading = true;
+
+    this.queue = this.queue.map(entry => ({
+      ...entry,
+      status: 'uploading' as const,
+    }));
+
+    const results = await Promise.allSettled(
+      this.queue.map(async (entry, index) => {
+        const result = await DocumentService.upload(
+          entry.file,
+          entry.externalId,
+          entry.platform,
+        );
+
+        this.queue[index].status = result.ok ? 'success' as const : 'error' as const;
+        this.queue[index].error = result.ok ? undefined : result.error;
+        this.requestUpdate();
+
+        if (!result.ok)
+          throw new Error(result.error);
+
+        return result.data;
+      }),
+    );
+
+    this.uploading = false;
+
+    const hasSuccess = results.some(r => r.status === 'fulfilled');
+    if (hasSuccess) {
+      this.dispatchEvent(new CustomEvent('upload-complete', {
+        bubbles: true,
+        composed: true,
+      }));
+    }
+  }
+
+  private renderDropZone() {
+    return html`
+      <div
+        class="drop-zone"
+        @click=${this.handleClick}
+        @dragover=${this.handleDragOver}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
+      >
+        <input
+          id="file-input"
+          type="file"
+          accept=".pdf"
+          multiple
+          hidden
+          @change=${this.handleFileInput}
+        />
+        <span class="drop-icon">📄</span>
+        <span class="drop-text">Drag PDFs here or click to browse</span>
+      </div>
+    `;
+  }
+
+  private renderQueueEntry(entry: UploadEntry, index: number) {
+    const settled = entry.status === 'success' || entry.status === 'error';
+    const editable = entry.status === 'pending';
+
+    return html`
+      <div class="queue-entry">
+        <div class="entry-info">
+          <span class="entry-filename">${entry.file.name}</span>
+          <span class="entry-size">${formatBytes(entry.file.size)}</span>
+          <span class="badge ${entry.status}">${entry.status}</span>
+        </div>
+
+        <div class="entry-fields">
+          <label class="field">
+            <span class="field-label">ID</span>
+            <input
+              type="number"
+              class="field-input id-input"
+              .value=${String(entry.externalId)}
+              ?disabled=${!editable}
+              @change=${(e: Event) => this.handleIdChange(index, e)}
+            />
+          </label>
+
+          <label class="field">
+            <span class="field-label">Platform</span>
+            <input
+              type="text"
+              class="field-input"
+              .value=${entry.platform}
+              placeholder="e.g. HQ"
+              ?disabled=${!editable}
+              @input=${(e: Event) => this.handlePlatformChange(index, e)}
+            />
+          </label>
+
+          ${editable ? html`
+            <button
+              class="btn remove-btn"
+              @click=${() => this.handleRemove(index)}
+            >✕</button>
+          ` : nothing}
+        </div>
+
+        ${entry.error ? html`
+          <div class="entry-error">${entry.error}</div>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private renderQueue() {
+    if (this.queue.length < 1)
+      return nothing;
+
+    return html`
+      <div class="queue">
+        <div class="queue-header">
+          <span class="queue-title">File Queue</span>
+          <span class="queue-count">
+            ${this.queue.length} file${this.queue.length > 1 ? 's' : ''}
+          </span>
+        </div>
+        ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+      </div>
+    `;
+  }
+
+  private renderActions() {
+    if (this.queue.length < 1)
+      return nothing;
+
+    const allSettled = this.queue.every(
+      e => e.status === 'success' || e.status === 'error'
+    );
+
+    return html`
+      <div class="actions">
+        <button
+          class="btn clear-btn"
+          @click=${this.handleClear}
+          ?disabled=${this.uploading}
+        >${allSettled ? 'Done' : 'Clear'}</button>
+        ${!allSettled ? html`
+          <button
+            class="btn upload-btn"
+            @click=${this.handleUpload}
+            ?disabled=${!this.canUpload}
+          >Upload</button>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      ${this.renderDropZone()}
+      ${this.renderQueue()}
+      ${this.renderActions()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hd-document-upload': DocumentUpload;
+  }
+}

--- a/app/client/components/documents/index.ts
+++ b/app/client/components/documents/index.ts
@@ -1,0 +1,1 @@
+export { DocumentUpload } from './document-upload';

--- a/app/client/components/index.ts
+++ b/app/client/components/index.ts
@@ -1,0 +1,1 @@
+export * from './documents';

--- a/app/client/documents/index.ts
+++ b/app/client/documents/index.ts
@@ -1,2 +1,3 @@
 export * from './document';
 export { DocumentService } from './service';
+export type { UploadEntry, UploadStatus } from './upload';

--- a/app/client/documents/upload.ts
+++ b/app/client/documents/upload.ts
@@ -1,0 +1,11 @@
+/** Lifecycle state of a file in the upload queue. */
+export type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+/** A file queued for upload with its metadata and current status. */
+export interface UploadEntry {
+  file: File;
+  status: UploadStatus;
+  externalId: number;
+  platform: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

Stateful `hd-document-upload` component that coordinates multi-file PDF uploads with per-file metadata inputs and status tracking. Establishes the `components/` directory tier in the three-tier component hierarchy.

Closes #76

## Changes

- Add `UploadStatus` type and `UploadEntry` interface in `documents/upload.ts`
- Add `hd-document-upload` stateful component in `components/documents/` with:
  - Drag-and-drop zone and file picker for PDF selection
  - Per-file `external_id` and `external_platform` inputs
  - Concurrent upload via `Promise.allSettled` with per-file status (pending/uploading/success/error)
  - `upload-complete` event dispatch when at least one file succeeds
- Add `components/` barrel exports and register in `app.ts`
- Add CHANGELOG entry for `v0.3.0-dev.59.76`