### PR TITLE
Add prompt list module with stage filtering and activation

### DIFF
--- a/.claude/context/guides/.archive/83-prompt-list-module.md
+++ b/.claude/context/guides/.archive/83-prompt-list-module.md
@@ -1,0 +1,341 @@
+# 83 - Prompt List Module with Stage Filtering and Activation
+
+## Problem Context
+
+Second sub-issue of Objective #60 (Prompt Management View). Creates the stateful list module that manages browsing, filtering, pagination, and prompt lifecycle actions (activate/deactivate/delete). The prompt card element (#82) and prompts domain layer (types + service) are already complete.
+
+## Architecture Approach
+
+Follow the `hd-document-grid` module pattern. The prompt list is simpler — no SSE streaming, no bulk selection. Uses `PromptService.search()` (POST with `SearchRequest` body) for server-side filtering. Vertical list layout instead of grid (prompts are text-heavy per objective decision).
+
+## Implementation
+
+### Step 1: Create prompt-list.module.css
+
+**New file:** `app/client/ui/modules/prompt-list.module.css`
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.search-input,
+.filter-select,
+.sort-select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+
+.search-input {
+  flex: 1;
+  min-width: 12rem;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: var(--space-2);
+}
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-2);
+}
+
+.new-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+```
+
+### Step 2: Create prompt-list.ts
+
+**New file:** `app/client/ui/modules/prompt-list.ts`
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { PageResult } from "@core";
+import { PromptService } from "@domains/prompts";
+import type { Prompt, SearchRequest } from "@domains/prompts";
+
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./prompt-list.module.css";
+
+@customElement("hd-prompt-list")
+export class PromptList extends LitElement {
+  static styles = [buttonStyles, styles];
+
+  @property({ type: String }) selectedId = "";
+
+  @state() private prompts: PageResult<Prompt> | null = null;
+  @state() private page = 1;
+  @state() private search = "";
+  @state() private stage = "";
+  @state() private sort = "Name";
+  @state() private deletePrompt: Prompt | null = null;
+
+  private searchTimer = 0;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.fetchPrompts();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this.searchTimer);
+  }
+
+  async refresh() {
+    this.page = 1;
+    await this.fetchPrompts();
+  }
+
+  private async fetchPrompts() {
+    const req: SearchRequest = {
+      page: this.page,
+      page_size: 12,
+      sort: this.sort,
+    };
+
+    if (this.search) req.search = this.search;
+    if (this.stage) req.stage = this.stage as SearchRequest["stage"];
+
+    const result = await PromptService.search(req);
+
+    if (result.ok) this.prompts = result.data;
+  }
+
+  private handleSearchInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.search = input.value;
+
+    clearTimeout(this.searchTimer);
+    this.searchTimer = window.setTimeout(() => this.refresh(), 300);
+  }
+
+  private handleStageFilter(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.stage = select.value;
+    this.refresh();
+  }
+
+  private handleSort(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.sort = select.value;
+    this.refresh();
+  }
+
+  private handlePageChange(e: CustomEvent<{ page: number }>) {
+    this.page = e.detail.page;
+    this.fetchPrompts();
+  }
+
+  private handleSelect(e: CustomEvent<{ id: string }>) {
+    this.dispatchEvent(
+      new CustomEvent("prompt-select", {
+        detail: { id: e.detail.id },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private async handleToggleActive(
+    e: CustomEvent<{ id: string; active: boolean }>,
+  ) {
+    const { id, active } = e.detail;
+    const result = active
+      ? await PromptService.activate(id)
+      : await PromptService.deactivate(id);
+
+    if (result.ok) this.fetchPrompts();
+  }
+
+  private handleDelete(e: CustomEvent<{ prompt: Prompt }>) {
+    this.deletePrompt = e.detail.prompt;
+  }
+
+  private async confirmDelete() {
+    if (!this.deletePrompt) return;
+
+    const id = this.deletePrompt.id;
+    this.deletePrompt = null;
+
+    const result = await PromptService.delete(id);
+
+    if (result.ok) {
+      this.dispatchEvent(
+        new CustomEvent("prompt-deleted", {
+          detail: { id },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      this.fetchPrompts();
+    }
+  }
+
+  private cancelDelete() {
+    this.deletePrompt = null;
+  }
+
+  private handleNew() {
+    this.dispatchEvent(
+      new CustomEvent("create", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private renderToolbar() {
+    return html`
+      <div class="toolbar">
+        <input
+          type="search"
+          class="search-input"
+          placeholder="Search prompts..."
+          .value=${this.search}
+          @input=${this.handleSearchInput}
+        />
+        <select class="filter-select" @change=${this.handleStageFilter}>
+          <option value="">---</option>
+          <option value="classify" ?selected=${this.stage === "classify"}>
+            Classify
+          </option>
+          <option value="enhance" ?selected=${this.stage === "enhance"}>
+            Enhance
+          </option>
+          <option value="finalize" ?selected=${this.stage === "finalize"}>
+            Finalize
+          </option>
+        </select>
+        <select class="sort-select" @change=${this.handleSort}>
+          <option value="Name" ?selected=${this.sort === "Name"}>
+            Name (A-Z)
+          </option>
+          <option value="-Name" ?selected=${this.sort === "-Name"}>
+            Name (Z-A)
+          </option>
+          <option value="Stage" ?selected=${this.sort === "Stage"}>
+            Stage
+          </option>
+        </select>
+        <button class="btn new-btn" @click=${this.handleNew}>New</button>
+      </div>
+    `;
+  }
+
+  private renderList() {
+    if (!this.prompts) {
+      return html`<div class="empty-state">Loading...</div>`;
+    }
+
+    if (this.prompts.data.length < 1) {
+      return html`<div class="empty-state">No prompts found.</div>`;
+    }
+
+    return html`
+      <div class="list">
+        ${this.prompts.data.map(
+          (prompt) => html`
+            <hd-prompt-card
+              .prompt=${prompt}
+              ?selected=${this.selectedId === prompt.id}
+              @select=${this.handleSelect}
+              @toggle-active=${this.handleToggleActive}
+              @delete=${this.handleDelete}
+            ></hd-prompt-card>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      ${this.renderToolbar()} ${this.renderList()}
+      <hd-pagination
+        .page=${this.prompts?.page ?? 1}
+        .totalPages=${this.prompts?.total_pages ?? 1}
+        @page-change=${this.handlePageChange}
+      ></hd-pagination>
+      ${this.deletePrompt
+        ? html`
+            <hd-confirm-dialog
+              message="Are you sure you want to delete ${this.deletePrompt.name}?"
+              @confirm=${this.confirmDelete}
+              @cancel=${this.cancelDelete}
+            ></hd-confirm-dialog>
+          `
+        : nothing}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-prompt-list": PromptList;
+  }
+}
+```
+
+### Step 3: Update barrel export
+
+**Modify:** `app/client/ui/modules/index.ts`
+
+Add after existing exports:
+
+```typescript
+export { PromptList } from "./prompt-list";
+```
+
+## Validation Criteria
+
+- [ ] Module fetches and displays paginated prompts on mount
+- [ ] Search input filters with 300ms debounce
+- [ ] Stage dropdown filters by workflow stage
+- [ ] Toggle active calls activate/deactivate API and refreshes list
+- [ ] Delete shows confirmation dialog and removes prompt on confirm
+- [ ] `prompt-select`, `create`, and `prompt-deleted` events dispatched correctly
+- [ ] Pagination controls navigate pages
+- [ ] Public `refresh()` method works
+- [ ] Barrel exports updated
+- [ ] Bun build succeeds

--- a/.claude/context/sessions/83-prompt-list-module.md
+++ b/.claude/context/sessions/83-prompt-list-module.md
@@ -1,0 +1,31 @@
+# 83 - Prompt List Module with Stage Filtering and Activation
+
+## Summary
+
+Created the `hd-prompt-list` stateful module for browsing, filtering, pagination, and prompt lifecycle management (activate/deactivate/delete). Also cleaned up `hd-document-grid` to delegate filter/sort/search handlers to `refresh()` instead of duplicating page reset + fetch logic.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Search method | `PromptService.search()` (POST) | Server-side filtering with `SearchRequest` body, consistent with document-grid pattern |
+| Layout | Vertical flex list | Prompts are text-heavy; vertical list is more scannable than grid (per objective decision) |
+| Debounced search delegation | `refresh()` | Eliminates duplicated `page = 1` + fetch logic; applied to both prompt-list and document-grid |
+| Confirm dialog message | Extracted to local variable | Linter reformatted inline template expression; cleaner as variable |
+
+## Files Modified
+
+- `app/client/ui/modules/prompt-list.ts` (new)
+- `app/client/ui/modules/prompt-list.module.css` (new)
+- `app/client/ui/modules/index.ts` (added PromptList export)
+- `app/client/ui/modules/document-grid.ts` (cleanup: delegate to refresh())
+
+## Patterns Established
+
+- Module filter/sort/search handlers should delegate to `refresh()` rather than duplicating `page = 1` + fetch
+
+## Validation Results
+
+- Bun build: pass
+- go vet: pass
+- Fixed typo: `?selectetd` → `?selected` in sort select

--- a/.claude/plans/proud-doodling-quiche.md
+++ b/.claude/plans/proud-doodling-quiche.md
@@ -1,0 +1,84 @@
+# 83 - Prompt List Module
+
+## Context
+
+Issue #83 is the second sub-issue of Objective #60 (Prompt Management View). It creates the `hd-prompt-list` stateful module that manages browsing, filtering, pagination, and prompt lifecycle actions. Depends on #82 (prompt card element), which is merged.
+
+## Architecture Approach
+
+Follow the `hd-document-grid` module pattern exactly. The prompt list is simpler — no SSE streaming, no bulk selection. It uses `PromptService.search()` (POST) for server-side filtering with `SearchRequest` body.
+
+## Files to Create
+
+### 1. `app/client/ui/modules/prompt-list.module.css`
+
+Reuse the document-grid layout structure but use a vertical list instead of a grid (prompts are text-heavy per objective decision). Key differences:
+- `.list` replaces `.grid` — single-column flex layout instead of CSS grid
+- Toolbar identical to document-grid (search input, filter select, sort select, "New" button)
+- Same empty state styling
+
+### 2. `app/client/ui/modules/prompt-list.ts`
+
+`@customElement("hd-prompt-list")` extending `LitElement`:
+
+**State:**
+- `@state() prompts: PageResult<Prompt> | null = null`
+- `@state() page = 1`
+- `@state() search = ""`
+- `@state() stage = ""` (empty string = all stages)
+- `@state() sort = "Name"` (alphabetical default)
+- `@state() deletePrompt: Prompt | null = null`
+- `@property({ type: String }) selectedId = ""`
+
+**Private fields:**
+- `searchTimer = 0`
+
+**Lifecycle:**
+- `connectedCallback()` → `fetchPrompts()`
+- `disconnectedCallback()` → `clearTimeout(searchTimer)`
+
+**Public method:**
+- `refresh()` → reset page to 1, re-fetch
+
+**Private methods:**
+- `fetchPrompts()` → build `SearchRequest`, call `PromptService.search()`, set `this.prompts`
+- `handleSearchInput()` → 300ms debounce, reset page
+- `handleStageFilter()` → set stage, reset page, fetch
+- `handleSort()` → set sort, reset page, fetch
+- `handlePageChange()` → set page, fetch
+- `handleSelect()` → dispatch `prompt-select` event with `{ id }`
+- `handleToggleActive()` → call `PromptService.activate()` or `.deactivate()`, re-fetch
+- `handleDelete()` → set `deletePrompt` state (shows confirm dialog)
+- `confirmDelete()` → call `PromptService.delete()`, dispatch `prompt-deleted`, re-fetch
+- `cancelDelete()` → clear `deletePrompt`
+- `handleNew()` → dispatch `create` event
+
+**Rendering:**
+- `renderToolbar()` — search input, stage dropdown (All/classify/enhance/finalize), sort select, "New" button
+- `renderList()` — map prompts to `<hd-prompt-card>` elements in a vertical list
+- `render()` — toolbar + list + pagination + conditional confirm dialog
+
+**Events dispatched:**
+- `prompt-select` (`{ id }`) — card selected
+- `create` — "New" button clicked
+- `prompt-deleted` (`{ id }`) — after successful delete
+
+## Files to Modify
+
+### 3. `app/client/ui/modules/index.ts`
+
+Add: `export { PromptList } from "./prompt-list";`
+
+## Validation Criteria
+
+- Module fetches and displays paginated prompts on mount
+- Search input filters with 300ms debounce
+- Stage dropdown filters by workflow stage
+- Toggle active calls activate/deactivate API and refreshes list
+- Delete shows confirmation dialog and removes prompt on confirm
+- `prompt-select`, `create`, and `prompt-deleted` events dispatched correctly
+- Pagination controls navigate pages
+- Public `refresh()` method works
+- Barrel exports updated
+- `go vet ./...` passes
+- Bun build succeeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.60.83
+- Add prompt list module with search (300ms debounce), stage filtering, sorting, pagination, activate/deactivate lifecycle, and delete with confirmation dialog; clean up document-grid filter/sort/search handlers to delegate to `refresh()` (#83)
+
 ## v0.3.0-dev.60.82
 - Add prompt card pure element with stage badge, active indicator, and toggle/delete events; add prompts `SearchRequest` type with domain-owned pagination fields; flatten `ui/` tier directories removing domain subdirectories; invert router route dependency via constructor injection with routes at `app/client/routes.ts`; consolidate badge CSS variants by color; fix app test base href assertion for format-agnostic self-closing tags (#82)
 

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -76,24 +76,19 @@ export class DocumentGrid extends LitElement {
     this.search = input.value;
 
     clearTimeout(this.searchTimer);
-    this.searchTimer = window.setTimeout(() => {
-      this.page = 1;
-      this.fetchDocuments();
-    }, 300);
+    this.searchTimer = window.setTimeout(() => this.refresh(), 300);
   }
 
   private handleStatusFilter(e: Event) {
     const select = e.target as HTMLSelectElement;
     this.status = select.value;
-    this.page = 1;
-    this.fetchDocuments();
+    this.refresh();
   }
 
   private handleSort(e: Event) {
     const select = e.target as HTMLSelectElement;
     this.sort = select.value;
-    this.page = 1;
-    this.fetchDocuments();
+    this.refresh();
   }
 
   private handlePageChange(e: CustomEvent<{ page: number }>) {

--- a/app/client/ui/modules/index.ts
+++ b/app/client/ui/modules/index.ts
@@ -1,2 +1,3 @@
 export { DocumentGrid } from "./document-grid";
 export { DocumentUpload } from "./document-upload";
+export { PromptList } from "./prompt-list";

--- a/app/client/ui/modules/prompt-list.module.css
+++ b/app/client/ui/modules/prompt-list.module.css
@@ -1,0 +1,65 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.search-input,
+.filter-select,
+.sort-select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+
+.search-input {
+  flex: 1;
+  min-width: 12rem;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: var(--space-2);
+}
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-2);
+}
+
+.new-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -1,0 +1,238 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { PageResult } from "@core";
+import { PromptService } from "@domains/prompts";
+import type { Prompt, SearchRequest } from "@domains/prompts";
+
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./prompt-list.module.css";
+
+/**
+ * Stateful module that manages the prompt browsing experience.
+ * Owns search, filtering, sorting, pagination, activate/deactivate
+ * lifecycle, and delete confirmation.
+ */
+@customElement("hd-prompt-list")
+export class PromptList extends LitElement {
+  static styles = [buttonStyles, styles];
+
+  @property({ type: String }) selectedId = "";
+
+  @state() private prompts: PageResult<Prompt> | null = null;
+  @state() private page = 1;
+  @state() private search = "";
+  @state() private stage = "";
+  @state() private sort = "Name";
+  @state() private deletePrompt: Prompt | null = null;
+
+  private searchTimer = 0;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.fetchPrompts();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this.searchTimer);
+  }
+
+  async refresh() {
+    this.page = 1;
+    await this.fetchPrompts();
+  }
+
+  private async fetchPrompts() {
+    const req: SearchRequest = {
+      page: this.page,
+      page_size: 12,
+      sort: this.sort,
+    };
+
+    if (this.search) req.search = this.search;
+    if (this.stage) req.stage = this.stage as SearchRequest["stage"];
+
+    const result = await PromptService.search(req);
+
+    if (result.ok) this.prompts = result.data;
+  }
+
+  private handleSearchInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.search = input.value;
+
+    clearTimeout(this.searchTimer);
+    this.searchTimer = window.setTimeout(() => this.refresh(), 300);
+  }
+
+  private handleStageFilter(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.stage = select.value;
+    this.refresh();
+  }
+
+  private handleSort(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.sort = select.value;
+    this.refresh();
+  }
+
+  private handlePageChange(e: CustomEvent<{ page: number }>) {
+    this.page = e.detail.page;
+    this.fetchPrompts();
+  }
+
+  private handleSelect(e: CustomEvent<{ id: string }>) {
+    this.dispatchEvent(
+      new CustomEvent("prompt-select", {
+        detail: { id: e.detail.id },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private async handleToggleActive(
+    e: CustomEvent<{ id: string; active: boolean }>,
+  ) {
+    const { id, active } = e.detail;
+    const result = active
+      ? await PromptService.activate(id)
+      : await PromptService.deactivate(id);
+
+    if (result.ok) this.fetchPrompts();
+  }
+
+  private handleDelete(e: CustomEvent<{ prompt: Prompt }>) {
+    this.deletePrompt = e.detail.prompt;
+  }
+
+  private async confirmDelete() {
+    if (!this.deletePrompt) return;
+
+    const id = this.deletePrompt.id;
+    this.deletePrompt = null;
+
+    const result = await PromptService.delete(id);
+
+    if (result.ok) {
+      this.dispatchEvent(
+        new CustomEvent("prompt-deleted", {
+          detail: { id },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      this.fetchPrompts();
+    }
+  }
+
+  private cancelDelete() {
+    this.deletePrompt = null;
+  }
+
+  private handleNew() {
+    this.dispatchEvent(
+      new CustomEvent("create", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private renderToolbar() {
+    return html`
+      <div class="toolbar">
+        <input
+          type="search"
+          class="search-input"
+          placeholder="Search prompts..."
+          .value=${this.search}
+          @input=${this.handleSearchInput}
+        />
+        <select class="filter-select" @change=${this.handleStageFilter}>
+          <option value="">---</option>
+          <option value="classify" ?selected=${this.stage === "classify"}>
+            Classify
+          </option>
+          <option value="enhance" ?selected=${this.stage === "enhance"}>
+            Enhance
+          </option>
+          <option value="finalize" ?selected=${this.stage === "finalize"}>
+            Finalize
+          </option>
+        </select>
+        <select class="sort-select" @change=${this.handleSort}>
+          <option value="Name" ?selected=${this.sort === "Name"}>
+            Name (A-Z)
+          </option>
+          <option value="-Name" ?selected=${this.sort === "-Name"}>
+            Name (Z-A)
+          </option>
+          <option value="Stage" ?selected=${this.sort === "Stage"}>
+            Stage (A-Z)
+          </option>
+          <option value="-Stage" ?selected=${this.sort === "-Stage"}>
+            Stage (Z-A)
+          </option>
+        </select>
+        <button class="btn new-btn" @click=${this.handleNew}>New</button>
+      </div>
+    `;
+  }
+
+  private renderList() {
+    if (!this.prompts) {
+      return html`<div class="empty-state">Loading...</div>`;
+    }
+
+    if (this.prompts.data.length < 1) {
+      return html`<div class="empty-state">No prompts found.</div>`;
+    }
+
+    return html`
+      <div class="list">
+        ${this.prompts.data.map(
+          (prompt) => html`
+            <hd-prompt-card
+              .prompt=${prompt}
+              ?selected=${this.selectedId === prompt.id}
+              @select=${this.handleSelect}
+              @toggle-active=${this.handleToggleActive}
+              @delete=${this.handleDelete}
+            ></hd-prompt-card>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  render() {
+    const message = `Are you sure you want to delete ${this.deletePrompt?.name}?`;
+
+    return html`
+      ${this.renderToolbar()} ${this.renderList()}
+      <hd-pagination
+        .page=${this.prompts?.page ?? 1}
+        .totalPages=${this.prompts?.total_pages ?? 1}
+        @page-change=${this.handlePageChange}
+      ></hd-pagination>
+      ${this.deletePrompt
+        ? html`
+            <hd-confirm-dialog
+              message=${message}
+              @confirm=${this.confirmDelete}
+              @cancel=${this.cancelDelete}
+            ></hd-confirm-dialog>
+          `
+        : nothing}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-prompt-list": PromptList;
+  }
+}


### PR DESCRIPTION
## Summary

Create `hd-prompt-list` stateful module — the second sub-issue of Objective #60 (Prompt Management View). Manages browsing, filtering, pagination, and prompt lifecycle actions (activate/deactivate/delete). Also cleans up `hd-document-grid` to delegate filter/sort/search handlers to `refresh()`.

Closes #83

## Changes

- New `hd-prompt-list` module with search (300ms debounce), stage filter dropdown, sort select, pagination, activate/deactivate toggle, and delete with confirmation dialog
- Dispatches `prompt-select`, `create`, and `prompt-deleted` events for parent view coordination
- Public `refresh()` method for parent view to call
- Clean up `hd-document-grid` filter/sort/search handlers to use `refresh()` instead of duplicating page reset + fetch
- Barrel export update in `ui/modules/index.ts`