### PR TITLE
Add prompt form module and compose prompts view

### DIFF
--- a/.claude/context/guides/.archive/84-prompt-form-view-integration.md
+++ b/.claude/context/guides/.archive/84-prompt-form-view-integration.md
@@ -1,0 +1,667 @@
+# 84 - Prompt Form Module and View Integration
+
+## Problem Context
+
+Third and final sub-issue of Objective #60 (Prompt Management View). The prompt card (#82) and prompt list (#83) modules are merged. This task creates the `hd-prompt-form` module for create/edit operations and replaces the stub `hd-prompts-view` with a full split-panel layout composing the list and form.
+
+## Architecture Approach
+
+Follows the established view composition pattern from `hd-documents-view`:
+- View manages UI state (`showForm`, `selectedPrompt`) with `@state()`
+- Coordinates between list and form modules via custom events and `querySelector`
+- Form uses `FormData` API for value extraction on submit (not controlled inputs)
+- Stage dropdown disabled in edit mode to prevent accidental stage changes
+
+## Implementation
+
+### Step 1: Create `app/client/ui/modules/prompt-form.module.css`
+
+New file — complete implementation:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.form-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.form-header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.form-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.field input,
+.field select,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.field textarea.instructions {
+  min-height: 12rem;
+  flex: 1;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.save-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+
+.error {
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--red);
+}
+```
+
+### Step 2: Create `app/client/ui/modules/prompt-form.ts`
+
+New file — complete implementation:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { PromptService } from "@domains/prompts";
+import type { Prompt } from "@domains/prompts";
+
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./prompt-form.module.css";
+
+@customElement("hd-prompt-form")
+export class PromptForm extends LitElement {
+  static styles = [buttonStyles, styles];
+
+  @property({ type: Object }) prompt: Prompt | null = null;
+
+  @state() private submitting = false;
+  @state() private error = "";
+
+  private get isEdit() {
+    return this.prompt !== null;
+  }
+
+  private async handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    this.error = "";
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+
+    const name = (data.get("name") as string).trim();
+    const stage = data.get("stage") as string;
+    const instructions = (data.get("instructions") as string).trim();
+    const description = (data.get("description") as string).trim();
+
+    const command = {
+      name,
+      stage: stage as Prompt["stage"],
+      instructions,
+      ...(description && { description }),
+    };
+
+    const result = this.isEdit
+      ? await PromptService.update(this.prompt!.id, command)
+      : await PromptService.create(command);
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error ?? "An unexpected error occurred.";
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("save", {
+        detail: { prompt: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleCancel() {
+    this.error = "";
+    this.dispatchEvent(
+      new CustomEvent("cancel", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private renderError() {
+    if (!this.error) return nothing;
+    return html`<div class="error">${this.error}</div>`;
+  }
+
+  render() {
+    const p = this.prompt;
+
+    return html`
+      <div class="form-header">
+        <h2>${this.isEdit ? "Edit Prompt" : "New Prompt"}</h2>
+      </div>
+      <form class="form-body" @submit=${this.handleSubmit}>
+        <div class="field">
+          <label for="name">Name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            required
+            .value=${p?.name ?? ""}
+          />
+        </div>
+        <div class="field">
+          <label for="stage">Stage</label>
+          <select
+            id="stage"
+            name="stage"
+            required
+            ?disabled=${this.isEdit}
+          >
+            <option value="" ?selected=${!p}>---</option>
+            <option value="classify" ?selected=${p?.stage === "classify"}>
+              Classify
+            </option>
+            <option value="enhance" ?selected=${p?.stage === "enhance"}>
+              Enhance
+            </option>
+            <option value="finalize" ?selected=${p?.stage === "finalize"}>
+              Finalize
+            </option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="instructions">Instructions</label>
+          <textarea
+            id="instructions"
+            name="instructions"
+            class="instructions"
+            required
+            .value=${p?.instructions ?? ""}
+          ></textarea>
+        </div>
+        <div class="field">
+          <label for="description">Description</label>
+          <textarea
+            id="description"
+            name="description"
+            .value=${p?.description ?? ""}
+          ></textarea>
+        </div>
+        ${this.renderError()}
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn save-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-prompt-form": PromptForm;
+  }
+}
+```
+
+### Step 3: Update `app/client/ui/modules/index.ts`
+
+Add the prompt form export:
+
+```typescript
+export { PromptForm } from "./prompt-form";
+```
+
+### Step 4: Replace `app/client/ui/views/prompts-view.module.css`
+
+Replace entire file:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-4) var(--space-6);
+  overflow: hidden;
+}
+
+.view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.view-header {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+h1 {
+  font-size: var(--text-xl);
+  font-weight: 600;
+}
+
+.view-content {
+  display: flex;
+  gap: var(--space-6);
+  flex: 1;
+  min-height: 0;
+}
+
+.list-panel {
+  display: flex;
+  flex-direction: column;
+  width: 22rem;
+  min-width: 18rem;
+  flex-shrink: 0;
+  border-right: 1px solid var(--divider);
+  padding-right: var(--space-6);
+  overflow: hidden;
+}
+
+.form-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+```
+
+### Step 5: Replace `app/client/ui/views/prompts-view.ts`
+
+Replace entire file:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import type { Prompt } from "@domains/prompts";
+
+import styles from "./prompts-view.module.css";
+
+@customElement("hd-prompts-view")
+export class PromptsView extends LitElement {
+  static styles = styles;
+
+  @state() private selectedPrompt: Prompt | null = null;
+  @state() private showForm = false;
+
+  private handleCreate() {
+    this.selectedPrompt = null;
+    this.showForm = true;
+  }
+
+  private handlePromptSelect(e: CustomEvent<{ prompt: Prompt }>) {
+    this.selectedPrompt = e.detail.prompt;
+    this.showForm = true;
+  }
+
+  private handlePromptSaved() {
+    this.showForm = false;
+    this.selectedPrompt = null;
+    this.renderRoot.querySelector<any>("hd-prompt-list")?.refresh();
+  }
+
+  private handleCancel() {
+    this.showForm = false;
+    this.selectedPrompt = null;
+  }
+
+  private handlePromptDeleted(e: CustomEvent<{ id: string }>) {
+    if (this.selectedPrompt?.id === e.detail.id) {
+      this.showForm = false;
+      this.selectedPrompt = null;
+    }
+  }
+
+  render() {
+    return html`
+      <div class="view">
+        <div class="view-header">
+          <h1>Prompts</h1>
+        </div>
+        <div class="view-content">
+          <div class="list-panel">
+            <hd-prompt-list
+              .selected=${this.selectedPrompt}
+              @create=${this.handleCreate}
+              @select=${this.handlePromptSelect}
+              @delete=${this.handlePromptDeleted}
+            ></hd-prompt-list>
+          </div>
+          ${this.showForm
+            ? html`
+                <div class="form-panel">
+                  <hd-prompt-form
+                    .prompt=${this.selectedPrompt}
+                    @save=${this.handlePromptSaved}
+                    @cancel=${this.handleCancel}
+                  ></hd-prompt-form>
+                </div>
+              `
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-prompts-view": PromptsView;
+  }
+}
+```
+
+## Remediation
+
+### R1: Default prompt reference panel
+
+Prompts have two layers: an immutable **specification** (return format, behavioral constraints) and transient **instructions** (optimizable per-prompt). Users need full context into the default behavior of the stage they're modifying.
+
+This remediation adds three things:
+1. A form description beneath the header explaining the relationship between specification and instructions
+2. A `?default=true` query param on the Go instructions endpoint to bypass DB overrides
+3. A collapsible `<details>` panel showing both the spec and default instructions for the selected stage
+
+#### R1a: Go — add `default` query param to instructions endpoint
+
+**`internal/prompts/handler.go`** — pass a `defaultOnly` flag to the system call:
+
+In the `Instructions` handler method, read a `default` query param from the request. When `"true"`, call the hardcoded `Instructions(stage)` function directly instead of going through the repository (which checks for active DB overrides).
+
+```go
+func (h *Handler) Instructions(w http.ResponseWriter, r *http.Request) {
+	stage, err := ParseStage(r.PathValue("stage"))
+	if err != nil {
+		handlers.RespondError(w, h.logger, http.StatusBadRequest, err)
+		return
+	}
+
+	var text string
+	if r.URL.Query().Get("default") == "true" {
+		text, err = Instructions(stage)
+	} else {
+		text, err = h.sys.Instructions(r.Context(), stage)
+	}
+
+	if err != nil {
+		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
+		return
+	}
+
+	handlers.RespondJSON(w, http.StatusOK, StageContent{Stage: stage, Content: text})
+}
+```
+
+This is backwards-compatible — existing calls without the param behave identically.
+
+#### R1b: Client — add `default` param to service
+
+**`app/client/domains/prompts/service.ts`** — add optional `defaultOnly` param to the `instructions` method:
+
+```typescript
+async instructions(
+  stage: PromptStage,
+  defaultOnly?: boolean,
+): Promise<Result<StageContent>> {
+  const params = defaultOnly ? "?default=true" : "";
+  return await request<StageContent>(`${base}/${stage}/instructions${params}`);
+},
+```
+
+#### R1c: Form — default prompt reference panel
+
+**`app/client/ui/modules/prompt-form.ts`** — add state, fetch logic, description, and reference panel:
+
+Rename the existing `@state() private instructions` to `@state() private defaultInstructions` (the existing `instructions` state conflicts with the form field name — the default instructions state tracks the hardcoded default fetched from the API, not the form textarea value).
+
+Add `fetchDefaults` method — fetches both spec and default instructions in parallel:
+
+```typescript
+private async fetchDefaults(stage: string) {
+  this.spec = "";
+  this.defaultInstructions = "";
+
+  const typedStage = stage as Prompt["stage"];
+
+  const [specResult, instrResult] = await Promise.all([
+    PromptService.spec(typedStage),
+    PromptService.instructions(typedStage, true),
+  ]);
+
+  if (specResult.ok) this.spec = specResult.data.content;
+  if (instrResult.ok) this.defaultInstructions = instrResult.data.content;
+}
+```
+
+Add `updated()` lifecycle for edit mode — fetches defaults when the prompt property changes:
+
+```typescript
+updated(changed: Map<string, unknown>) {
+  if (changed.has("prompt") && this.prompt) {
+    this.fetchDefaults(this.prompt.stage);
+  }
+}
+```
+
+Add `handleStageChange` for create mode — wire to `@change` on the stage `<select>`:
+
+```typescript
+private handleStageChange(e: Event) {
+  const stage = (e.target as HTMLSelectElement).value;
+
+  if (stage) this.fetchDefaults(stage);
+}
+```
+
+In the template, add `@change=${this.handleStageChange}` to the stage `<select>` element.
+
+Add `renderDefaults()` method:
+
+```typescript
+private renderDefaults() {
+  if (!this.spec && !this.defaultInstructions) return nothing;
+
+  const stage = this.prompt?.stage
+    ?? (this.renderRoot.querySelector<HTMLSelectElement>("#stage")?.value || "");
+
+  const label = stage.charAt(0).toUpperCase() + stage.slice(1);
+
+  return html`
+    <details class="defaults">
+      <summary>${label} — Default Prompt</summary>
+      <div class="defaults-content">
+        ${this.spec
+          ? html`
+              <h4>Specification</h4>
+              <pre>${this.spec}</pre>
+            `
+          : nothing}
+        ${this.defaultInstructions
+          ? html`
+              <h4>Default Instructions</h4>
+              <pre>${this.defaultInstructions}</pre>
+            `
+          : nothing}
+      </div>
+    </details>
+  `;
+}
+```
+
+- Insert `${this.renderDefaults()}` in `render()` between the stage field and the instructions field
+- Add a form description beneath the header:
+
+```typescript
+<div class="form-header">
+  <h2>${this.isEdit ? "Edit Prompt" : "New Prompt"}</h2>
+</div>
+<p class="form-description">
+  Instructions are combined with the stage specification to form the complete
+  prompt. Override the default instructions below to customize behavior.
+</p>
+```
+
+**`app/client/ui/modules/prompt-form.module.css`** — add styles:
+
+```css
+.form-description {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  margin: 0;
+}
+
+.defaults {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  background: var(--bg-1);
+}
+
+.defaults summary {
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  cursor: pointer;
+}
+
+.defaults-content {
+  padding: var(--space-3);
+  border-top: 1px solid var(--divider);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-height: 20rem;
+  overflow-y: auto;
+}
+
+.defaults-content h4 {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.defaults-content pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+  white-space: pre-wrap;
+}
+```
+
+## Validation Criteria
+
+- [ ] `bun run build` completes with no errors
+- [ ] Form creates new prompts (name, stage, instructions, description)
+- [ ] Form edits existing prompts (pre-populated fields, stage disabled)
+- [ ] Form dispatches `prompt-saved` on success, `cancel` on cancel
+- [ ] Form shows error messages on API failure
+- [ ] View composes list and form in split layout
+- [ ] Selecting a prompt populates the form in edit mode
+- [ ] "New" button opens form in create mode
+- [ ] Saving refreshes the list
+- [ ] Deleting a selected prompt clears the form
+- [ ] Instructions textarea uses monospace font
+- [ ] `GET /api/prompts/{stage}/instructions?default=true` returns hardcoded default (bypasses DB)
+- [ ] `GET /api/prompts/{stage}/instructions` (no param) behaves unchanged
+- [ ] Default prompt details panel appears between stage and instructions when stage is known
+- [ ] Panel is collapsed by default, shows both specification and default instructions
+- [ ] Panel loads on stage dropdown change (create mode)
+- [ ] Panel loads when prompt is set (edit mode)
+- [ ] Form description text appears beneath the form header

--- a/.claude/context/sessions/84-prompt-form-view-integration.md
+++ b/.claude/context/sessions/84-prompt-form-view-integration.md
@@ -1,0 +1,51 @@
+# 84 - Prompt Form Module and View Integration
+
+## Summary
+
+Created the `hd-prompt-form` module and replaced the stub `hd-prompts-view` with a full split-panel layout composing the prompt list and form. Added a default prompt reference panel (specification + default instructions) with a Go-side `?default=true` query param on the instructions endpoint. Established custom event naming convention. Removed unused `@lit-labs/signals` and `@lit/context` dependencies.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Event naming convention | Simple action verbs (`select`, `delete`, `save`, `create`, `cancel`) | Component tag provides domain context; avoids redundant prefixing. Avoid overwriting semantically associated native events. |
+| Card select event payload | Full `Prompt` object instead of ID | Eliminates unnecessary `PromptService.find()` call in the view |
+| List `selectedId` → `selected` | `Prompt \| null` property | Richer type, view passes prompt directly |
+| Disabled select + FormData | Fallback to `this.prompt.stage` | Disabled form elements excluded from FormData per HTML spec |
+| Default prompt panel | Single `<details>` with spec + default instructions | Gives users full context of what they're overriding |
+| Instructions endpoint `?default=true` | Bypass DB in handler, call hardcoded `Instructions()` directly | Backwards-compatible, avoids new system interface method |
+| Remove signals/context deps | Deleted `@lit-labs/signals` and `@lit/context` | Unused — architecture uses `@state()` and direct service calls |
+| Focus ring fix | `padding-inline` / `padding` on scroll containers | Gives outline-offset room to render without removing overflow containment |
+| Toolbar layout | 4-column CSS grid | Search spans 3, new button 1; stage filter and sort each span 2 |
+
+## Files Modified
+
+- `app/client/ui/modules/prompt-form.ts` — new: create/edit form module with default prompt reference
+- `app/client/ui/modules/prompt-form.module.css` — new: form styling
+- `app/client/ui/modules/prompt-list.ts` — event renames, `selected` property change
+- `app/client/ui/modules/prompt-list.module.css` — grid toolbar layout, padding fix
+- `app/client/ui/modules/index.ts` — added `PromptForm` export
+- `app/client/ui/elements/prompt-card.ts` — select event emits full prompt
+- `app/client/ui/views/prompts-view.ts` — full split-panel view composition
+- `app/client/ui/views/prompts-view.module.css` — split-panel layout
+- `app/client/domains/prompts/service.ts` — `defaultOnly` param on instructions method
+- `app/package.json` — removed unused dependencies
+- `app/bun.lock` — updated lockfile
+- `internal/prompts/handler.go` — `?default=true` query param support
+- `tests/prompts/handler_test.go` — new test for default=true bypass
+- `_project/api/prompts/README.md` — documented default query param
+- `_project/api/prompts/prompts.http` — added default-only request
+- `.claude/skills/web-development/SKILL.md` — custom event convention, directory listing
+
+## Patterns Established
+
+- **Custom event naming**: Simple action verbs, no domain prefix. Avoid overwriting native events semantically associated with the component. Documented in web-development skill.
+- **Focus ring breathing room**: Use `padding-inline` or `padding` on scroll containers rather than removing `overflow: hidden` to give `outline-offset` room to render.
+- **Default prompt reference panel**: Collapsible `<details>` showing immutable spec + hardcoded instructions for user context when editing prompts.
+
+## Validation Results
+
+- `bun run build` — clean
+- `go vet ./...` — clean
+- `go test ./tests/...` — all 20 packages pass (including new `default=true` handler test)
+- Manual browser testing confirmed all acceptance criteria

--- a/.claude/plans/replicated-doodling-tome.md
+++ b/.claude/plans/replicated-doodling-tome.md
@@ -1,0 +1,93 @@
+# 84 - Prompt Form Module and View Integration
+
+## Context
+
+Third and final sub-issue of Objective #60 (Prompt Management View). The prompt card (#82) and prompt list (#83) are merged. This task creates the `hd-prompt-form` module and replaces the stub `hd-prompts-view` with a full split-panel layout composing the list and form.
+
+## Files to Create
+
+### 1. `app/client/ui/modules/prompt-form.ts`
+
+New stateful module:
+- `@property()`: `prompt: Prompt | null` — null = create mode, populated = edit mode
+- `@state()`: `submitting: boolean`, `error: string`
+- Form fields: name input, stage dropdown (disabled when `prompt` is set), instructions textarea (monospace), description textarea
+- Submit handler: extracts values via `FormData`, calls `PromptService.create()` or `.update()` based on mode
+- Dispatches `prompt-saved` (detail: `{ prompt }`) on success, `cancel` on cancel button click
+- Shows error message on API failure
+- Reuses `buttonStyles` from `@styles/buttons.module.css`
+- Imports `PromptService` and `Prompt`/`CreatePromptCommand`/`UpdatePromptCommand` types
+
+### 2. `app/client/ui/modules/prompt-form.module.css`
+
+Form styling:
+- Vertical flex layout with gap
+- Form inputs matching existing toolbar input styling (border, radius, bg, mono font)
+- Instructions textarea gets `font-family: var(--font-mono)`
+- Error message styled with `--red` color
+- Form actions row (save/cancel buttons) at bottom
+- Consistent with existing design tokens
+
+## Files to Modify
+
+### 3. `app/client/ui/modules/index.ts`
+
+Add `export { PromptForm } from "./prompt-form";`
+
+### 4. `app/client/ui/views/prompts-view.ts`
+
+Replace stub with full view composition:
+- `@state()`: `selectedPrompt: Prompt | null`, `showForm: boolean`
+- Split layout: left panel (`hd-prompt-list`), right panel (conditional `hd-prompt-form`)
+- Event coordination:
+  - `prompt-select` from list → `PromptService.find(id)` → set `selectedPrompt`, `showForm = true`
+  - `create` from list → `selectedPrompt = null`, `showForm = true`
+  - `prompt-saved` from form → `showForm = false`, refresh list, clear selection
+  - `cancel` from form → `showForm = false`, clear selection
+  - `prompt-deleted` from list → if deleted id matches `selectedPrompt.id`, clear form
+- Pass `selectedId` to `hd-prompt-list` for highlight sync
+- Import `PromptService` and `Prompt` type
+
+### 5. `app/client/ui/views/prompts-view.module.css`
+
+Replace stub CSS with split-panel layout:
+- `:host` — flex column with padding (matches documents-view)
+- `.view` — flex column container
+- `.view-content` — flex row, split layout
+- `.list-panel` — fixed/min width (~320-360px), overflow-y auto, border-right
+- `.form-panel` — flex: 1, fills remaining space
+- View header with title
+
+## Event Flow
+
+```
+List "create" → View sets showForm=true, selectedPrompt=null
+List "prompt-select" → View fetches prompt, sets showForm=true, selectedPrompt=prompt
+List "prompt-deleted" → View clears form if deleted prompt was selected
+Form "prompt-saved" → View hides form, refreshes list
+Form "cancel" → View hides form, clears selection
+```
+
+## Patterns to Follow
+
+- **View composition**: Same pattern as `documents-view.ts` — view manages UI state, coordinates modules via events + querySelector
+- **FormData extraction**: Per web-dev skill convention, not controlled inputs
+- **Stateless service calls**: Direct `PromptService.*` calls from modules
+- **Flat UI convention**: Files at `app/client/ui/modules/prompt-form.ts` (not nested in subdirectory)
+- **Import convention**: third-party → cross-package aliased → relative → styles
+
+## Phase 5: Comprehensive Prompts-View Evaluation
+
+Since this is the first time all prompts-view infrastructure is assembled together, Phase 5 is a comprehensive evaluation of the entire prompts view — not just the new form/view code, but also the list (#83) and card (#82) modules. Any issues discovered (visual, functional, UX) are fixed in-place before moving forward. The view must be in a finished state before closeout.
+
+Evaluation scope:
+- **Form**: create/edit modes, validation, error display, FormData extraction, submit/cancel flow
+- **List**: search, filtering, sorting, pagination, activate/deactivate, delete confirmation
+- **Card**: display, selection highlight, stage badge, active indicator, actions
+- **View composition**: split-panel layout, event coordination, state sync between panels
+- **CSS**: responsive behavior, token consistency, spacing, typography
+
+## Build Verification
+
+1. `bun run build` — clean build with no errors
+2. Manual testing in browser at `/app/prompts`

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -143,6 +143,8 @@ app/client/
     ├── modules/                       # stateful capability units
     │   ├── document-grid.ts
     │   ├── document-upload.ts
+    │   ├── prompt-form.ts
+    │   ├── prompt-list.ts
     │   └── index.ts                   # barrel
     └── views/                         # route-level composition
         ├── documents-view.ts
@@ -195,6 +197,15 @@ import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
 import styles from "./document-card.module.css";
 ```
+
+### Custom Events
+
+Event names are simple action verbs describing what happened from the component's perspective. Avoid prefixing with the domain name — the component tag already provides context.
+
+- **Simple verbs**: `select`, `delete`, `save`, `create`, `cancel`
+- **Compound verbs** when needed for clarity: `toggle-active`, `upload-complete`, `page-change`
+- **No domain prefix**: `select` not `prompt-select`, `delete` not `prompt-deleted`
+- **Avoid overwriting native events** that are semantically associated with the component itself (e.g., don't use `input` on a component that wraps an input). A list emitting `select` is fine — the list itself doesn't have a native `select` semantic.
 
 ### HTMLElementTagNameMap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.60.84
+- Add prompt form module with create/edit modes, FormData extraction, and error display; compose prompts view with split-panel layout coordinating list and form via custom events; add collapsible default prompt reference panel showing stage specification and hardcoded default instructions; add `?default=true` query param to instructions endpoint to bypass active DB overrides; establish custom event naming convention (simple action verbs, no domain prefix); remove unused `@lit-labs/signals` and `@lit/context` dependencies (#84)
+
 ## v0.3.0-dev.60.83
 - Add prompt list module with search (300ms debounce), stage filtering, sorting, pagination, activate/deactivate lifecycle, and delete with confirmation dialog; clean up document-grid filter/sort/search handlers to delegate to `refresh()` (#83)
 

--- a/_project/api/prompts/README.md
+++ b/_project/api/prompts/README.md
@@ -316,13 +316,19 @@ curl -s -X POST "$HERALD_API_BASE/api/prompts/550e8400-e29b-41d4-a716-4466554400
 
 `GET /api/prompts/{stage}/instructions`
 
-Returns the effective instructions for a workflow stage. If an active prompt override exists for the stage, returns its instructions. Otherwise, returns the hardcoded default instructions.
+Returns the effective instructions for a workflow stage. If an active prompt override exists for the stage, returns its instructions. Otherwise, returns the hardcoded default instructions. Pass `?default=true` to always return the hardcoded default, bypassing any active override.
 
 ### Path Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | stage | string | Workflow stage (classify, enhance) |
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| default | string | no | When `"true"`, returns hardcoded default instructions regardless of active overrides |
 
 ### Responses
 
@@ -342,6 +348,12 @@ Returns the effective instructions for a workflow stage. If an active prompt ove
 
 ```bash
 curl -s "$HERALD_API_BASE/api/prompts/classify/instructions" | jq .
+```
+
+### Default-Only Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/prompts/classify/instructions?default=true" | jq .
 ```
 
 ---

--- a/_project/api/prompts/prompts.http
+++ b/_project/api/prompts/prompts.http
@@ -40,6 +40,11 @@ GET {{HOST}}/api/prompts/{{promptId}} HTTP/1.1
 GET {{HOST}}/api/prompts/classify/instructions HTTP/1.1
 
 
+### Get Stage Default Instructions
+
+GET {{HOST}}/api/prompts/classify/instructions?default=true HTTP/1.1
+
+
 ### Get Stage Spec
 
 GET {{HOST}}/api/prompts/classify/spec HTTP/1.1

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -5,8 +5,6 @@
     "": {
       "name": "herald-app",
       "dependencies": {
-        "@lit-labs/signals": "^0.2.0",
-        "@lit/context": "^1.1.6",
         "lit": "^3.3.2",
       },
       "devDependencies": {
@@ -15,11 +13,7 @@
     },
   },
   "packages": {
-    "@lit-labs/signals": ["@lit-labs/signals@0.2.0", "", { "dependencies": { "lit": "^2.0.0 || ^3.0.0", "signal-polyfill": "^0.2.2" } }, "sha512-68plyIbciumbwKaiilhLNyhz4Vg6/+nJwDufG2xxWA9r/fUw58jxLHCAlKs+q1CE5Lmh3cZ3ShyYKnOCebEpVA=="],
-
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
-
-    "@lit/context": ["@lit/context@1.1.6", "", { "dependencies": { "@lit/reactive-element": "^1.6.2 || ^2.1.0" } }, "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A=="],
 
     "@lit/reactive-element": ["@lit/reactive-element@2.1.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0" } }, "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A=="],
 
@@ -36,8 +30,6 @@
     "lit-element": ["lit-element@4.2.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0", "@lit/reactive-element": "^2.1.0", "lit-html": "^3.3.0" } }, "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w=="],
 
     "lit-html": ["lit-html@3.3.2", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw=="],
-
-    "signal-polyfill": ["signal-polyfill@0.2.2", "", {}, "sha512-p63Y4Er5/eMQ9RHg0M0Y64NlsQKpiu6MDdhBXpyywRuWiPywhJTpKJ1iB5K2hJEbFZ0BnDS7ZkJ+0AfTuL37Rg=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }

--- a/app/client/design/styles/badge.module.css
+++ b/app/client/design/styles/badge.module.css
@@ -18,15 +18,15 @@
   }
 
   &.classify,
-  &.finalize,
   &.review,
   &.uploading {
     color: var(--blue);
     background: var(--blue-bg);
   }
 
-  &.success,
-  &.complete {
+  &.complete,
+  &.finalize,
+  &.success {
     color: var(--green);
     background: var(--green-bg);
   }

--- a/app/client/domains/prompts/service.ts
+++ b/app/client/domains/prompts/service.ts
@@ -35,8 +35,15 @@ export const PromptService = {
   },
 
   /** `GET /api/prompts/:stage/instructions` — assembled instructions for a stage. */
-  async instructions(stage: PromptStage): Promise<Result<StageContent>> {
-    return await request<StageContent>(`${base}/${stage}/instructions`);
+  async instructions(
+    stage: PromptStage,
+    defaultOnly?: boolean,
+  ): Promise<Result<StageContent>> {
+    const params = defaultOnly ? "?default=true" : "";
+
+    return await request<StageContent>(
+      `${base}/${stage}/instructions${params}`,
+    );
   },
 
   /** `GET /api/prompts/:stage/spec` — assembled spec for a stage. */

--- a/app/client/ui/elements/prompt-card.ts
+++ b/app/client/ui/elements/prompt-card.ts
@@ -21,7 +21,7 @@ export class PromptCard extends LitElement {
   private handleSelect() {
     this.dispatchEvent(
       new CustomEvent("select", {
-        detail: { id: this.prompt.id },
+        detail: { prompt: this.prompt },
         bubbles: true,
         composed: true,
       }),

--- a/app/client/ui/modules/index.ts
+++ b/app/client/ui/modules/index.ts
@@ -1,3 +1,4 @@
 export { DocumentGrid } from "./document-grid";
 export { DocumentUpload } from "./document-upload";
+export { PromptForm } from "./prompt-form";
 export { PromptList } from "./prompt-list";

--- a/app/client/ui/modules/prompt-form.module.css
+++ b/app/client/ui/modules/prompt-form.module.css
@@ -1,0 +1,153 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.form-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.form-header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.form-description {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  margin: 0;
+}
+
+.form-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-inline: var(--space-2);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.field input,
+.field select,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.field textarea.instructions {
+  min-height: 12rem;
+  flex: 1;
+}
+
+.defaults {
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  background: var(--bg-1);
+}
+
+.defaults summary {
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  cursor: pointer;
+}
+
+.defaults-content {
+  padding: var(--space-3);
+  border-top: 1px solid var(--divider);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-height: 20rem;
+  overflow-y: auto;
+}
+
+.defaults-content h4 {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.defaults-content pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+  white-space: pre-wrap;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.save-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+
+.error {
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--red);
+}

--- a/app/client/ui/modules/prompt-form.ts
+++ b/app/client/ui/modules/prompt-form.ts
@@ -1,0 +1,226 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { PromptService } from "@domains/prompts";
+import type { Prompt } from "@domains/prompts";
+
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./prompt-form.module.css";
+
+/**
+ * Stateful module for creating and editing prompts.
+ * Null prompt = create mode, populated prompt = edit mode.
+ * Fetches and displays the stage specification and default instructions
+ * in a collapsible reference panel. Dispatches `save` and `cancel` events.
+ */
+@customElement("hd-prompt-form")
+export class PromptForm extends LitElement {
+  static styles = [buttonStyles, styles];
+
+  @property({ type: Object }) prompt: Prompt | null = null;
+
+  @state() private submitting = false;
+  @state() private error = "";
+  @state() private defaultInstructions = "";
+  @state() private spec = "";
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has("prompt") && this.prompt) {
+      this.fetchDefaults(this.prompt.stage);
+    }
+  }
+
+  private get isEdit() {
+    return this.prompt !== null;
+  }
+
+  private async fetchDefaults(stage: string) {
+    this.spec = "";
+    this.defaultInstructions = "";
+
+    const typedStage = stage as Prompt["stage"];
+
+    const [specResult, instrResult] = await Promise.all([
+      PromptService.spec(typedStage),
+      PromptService.instructions(typedStage, true),
+    ]);
+
+    if (specResult.ok) this.spec = specResult.data.content;
+    if (instrResult.ok) this.defaultInstructions = instrResult.data.content;
+  }
+
+  private handleStageChange(e: Event) {
+    const stage = (e.target as HTMLSelectElement).value;
+    if (stage) this.fetchDefaults(stage);
+  }
+
+  private async handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    this.error = "";
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+
+    const name = (data.get("name") as string).trim();
+    const stage = (data.get("stage") as string) ?? this.prompt!.stage;
+    const instructions = (data.get("instructions") as string).trim();
+    const description = (data.get("description") as string).trim();
+
+    const command = {
+      name,
+      stage: stage as Prompt["stage"],
+      instructions,
+      ...(description && { description }),
+    };
+
+    const result = this.isEdit
+      ? await PromptService.update(this.prompt!.id, command)
+      : await PromptService.create(command);
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error ?? "An unexpected error occurred.";
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("save", {
+        detail: { prompt: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleCancel() {
+    this.error = "";
+    this.dispatchEvent(
+      new CustomEvent("cancel", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private renderDefaults() {
+    if (!this.spec && !this.defaultInstructions) return nothing;
+
+    return html`
+      <details class="defaults">
+        <summary>Default Prompt</summary>
+        <div class="defaults-content">
+          ${this.spec
+            ? html`
+                <h4>Specification</h4>
+                <pre>${this.spec}</pre>
+              `
+            : nothing}
+          ${this.defaultInstructions
+            ? html`
+                <h4>Default Instructions</h4>
+                <pre>${this.defaultInstructions}</pre>
+              `
+            : nothing}
+        </div>
+      </details>
+    `;
+  }
+
+  private renderError() {
+    if (!this.error) return nothing;
+    return html`<div class="error">${this.error}</div>`;
+  }
+
+  render() {
+    const p = this.prompt;
+
+    return html`
+      <div class="form-header">
+        <h2>${this.isEdit ? "Edit Prompt" : "New Prompt"}</h2>
+      </div>
+      <div class="form-description">
+        Instructions are combined with the stage specification to form the
+        complete prompt. Override the default instructions below to customize
+        behavior.
+      </div>
+      <form class="form-body" @submit=${this.handleSubmit}>
+        <div class="field">
+          <label for="name">Name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            required
+            .value=${p?.name ?? ""}
+          />
+        </div>
+        <div class="field">
+          <label for="stage">Stage</label>
+          <select
+            id="stage"
+            name="stage"
+            required
+            ?disabled=${this.isEdit}
+            @change=${this.handleStageChange}
+          >
+            <option value="" ?selected=${!p}>---</option>
+            <option value="classify" ?selected=${p?.stage === "classify"}>
+              Classify
+            </option>
+            <option value="enhance" ?selected=${p?.stage === "enhance"}>
+              Enhance
+            </option>
+            <option value="finalize" ?selected=${p?.stage === "finalize"}>
+              Finalize
+            </option>
+          </select>
+        </div>
+        ${this.renderDefaults()}
+        <div class="field">
+          <label for="instructions">Instructions</label>
+          <textarea
+            id="instructions"
+            name="instructions"
+            class="instructions"
+            required
+            .value=${p?.instructions ?? ""}
+          ></textarea>
+        </div>
+        <div class="field">
+          <label for="description">Description</label>
+          <textarea
+            id="descripion"
+            name="description"
+            .value=${p?.description ?? ""}
+          ></textarea>
+        </div>
+        ${this.renderError()}
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn save-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-prompt-form": PromptForm;
+  }
+}

--- a/app/client/ui/modules/prompt-list.module.css
+++ b/app/client/ui/modules/prompt-list.module.css
@@ -7,11 +7,11 @@
 }
 
 .toolbar {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: var(--space-3);
   flex-shrink: 0;
-  flex-wrap: wrap;
+  padding: var(--space-2);
 }
 
 .search-input,
@@ -32,8 +32,12 @@
 }
 
 .search-input {
-  flex: 1;
-  min-width: 12rem;
+  grid-column: span 3;
+}
+
+.filter-select,
+.sort-select {
+  grid-column: span 2;
 }
 
 .list {

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -17,7 +17,7 @@ import styles from "./prompt-list.module.css";
 export class PromptList extends LitElement {
   static styles = [buttonStyles, styles];
 
-  @property({ type: String }) selectedId = "";
+  @property({ type: Object }) selected: Prompt | null = null;
 
   @state() private prompts: PageResult<Prompt> | null = null;
   @state() private page = 1;
@@ -83,10 +83,10 @@ export class PromptList extends LitElement {
     this.fetchPrompts();
   }
 
-  private handleSelect(e: CustomEvent<{ id: string }>) {
+  private handleSelect(e: CustomEvent<{ prompt: Prompt }>) {
     this.dispatchEvent(
-      new CustomEvent("prompt-select", {
-        detail: { id: e.detail.id },
+      new CustomEvent("select", {
+        detail: { prompt: e.detail.prompt },
         bubbles: true,
         composed: true,
       }),
@@ -118,7 +118,7 @@ export class PromptList extends LitElement {
 
     if (result.ok) {
       this.dispatchEvent(
-        new CustomEvent("prompt-deleted", {
+        new CustomEvent("delete", {
           detail: { id },
           bubbles: true,
           composed: true,
@@ -151,6 +151,7 @@ export class PromptList extends LitElement {
           .value=${this.search}
           @input=${this.handleSearchInput}
         />
+        <button class="btn new-btn" @click=${this.handleNew}>New</button>
         <select class="filter-select" @change=${this.handleStageFilter}>
           <option value="">---</option>
           <option value="classify" ?selected=${this.stage === "classify"}>
@@ -177,7 +178,6 @@ export class PromptList extends LitElement {
             Stage (Z-A)
           </option>
         </select>
-        <button class="btn new-btn" @click=${this.handleNew}>New</button>
       </div>
     `;
   }
@@ -197,7 +197,7 @@ export class PromptList extends LitElement {
           (prompt) => html`
             <hd-prompt-card
               .prompt=${prompt}
-              ?selected=${this.selectedId === prompt.id}
+              ?selected=${this.selected?.id === prompt.id}
               @select=${this.handleSelect}
               @toggle-active=${this.handleToggleActive}
               @delete=${this.handleDelete}

--- a/app/client/ui/views/prompts-view.module.css
+++ b/app/client/ui/views/prompts-view.module.css
@@ -1,17 +1,51 @@
 :host {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  padding: var(--space-4) var(--space-6);
+  overflow: hidden;
 }
 
-.container {
-  text-align: center;
+.view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.view-header {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 h1 {
-  margin-bottom: var(--space-4);
+  font-size: var(--text-xl);
+  font-weight: 600;
 }
 
-p {
-  color: var(--color-1);
+.view-content {
+  display: flex;
+  gap: var(--space-6);
+  flex: 1;
+  min-height: 0;
+}
+
+.list-panel {
+  display: flex;
+  flex-direction: column;
+  width: 22rem;
+  min-width: 18rem;
+  flex-shrink: 0;
+  border-right: 1px solid var(--divider);
+  padding-right: var(--space-6);
+  overflow: hidden;
+}
+
+.form-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }

--- a/app/client/ui/views/prompts-view.ts
+++ b/app/client/ui/views/prompts-view.ts
@@ -1,5 +1,8 @@
-import { LitElement, html } from "lit";
-import { customElement } from "lit/decorators.js";
+import { LitElement, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import type { Prompt } from "@domains/prompts";
+
 import styles from "./prompts-view.module.css";
 
 /** Route-level view for prompt management. */
@@ -7,11 +10,66 @@ import styles from "./prompts-view.module.css";
 export class PromptsView extends LitElement {
   static styles = styles;
 
+  @state() private selectedPrompt: Prompt | null = null;
+  @state() private showForm = false;
+
+  private reset() {
+    this.showForm = false;
+    this.selectedPrompt = null;
+  }
+
+  private handleCreate() {
+    this.selectedPrompt = null;
+    this.showForm = true;
+  }
+
+  private async handlePromptSelect(e: CustomEvent<{ prompt: Prompt }>) {
+    this.selectedPrompt = e.detail.prompt;
+    this.showForm = true;
+  }
+
+  private handlePromptSaved() {
+    this.reset();
+    this.renderRoot.querySelector<any>("hd-prompt-list").refresh();
+  }
+
+  private handleCancel() {
+    this.reset();
+  }
+
+  private handlePromptDeleted(e: CustomEvent<{ id: string }>) {
+    if (this.selectedPrompt?.id === e.detail.id) {
+      this.reset();
+    }
+  }
+
   render() {
     return html`
-      <div class="container">
-        <h1>Prompts</h1>
-        <p>Prompt management interface.</p>
+      <div class="view">
+        <div class="view-header">
+          <h1>Prompts</h1>
+        </div>
+        <div class="view-content">
+          <div class="list-panel">
+            <hd-prompt-list
+              .selected=${this.selectedPrompt}
+              @create=${this.handleCreate}
+              @select=${this.handlePromptSelect}
+              @delete=${this.handlePromptDeleted}
+            ></hd-prompt-list>
+          </div>
+          ${this.showForm
+            ? html`
+                <div class="form-panel">
+                  <hd-prompt-form
+                    .prompt=${this.selectedPrompt}
+                    @save=${this.handlePromptSaved}
+                    @cancel=${this.handleCancel}
+                  ></hd-prompt-form>
+                </div>
+              `
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/app/package.json
+++ b/app/package.json
@@ -7,8 +7,6 @@
     "watch": "bun scripts/watch.ts"
   },
   "dependencies": {
-    "@lit-labs/signals": "^0.2.0",
-    "@lit/context": "^1.1.6",
     "lit": "^3.3.2"
   },
   "devDependencies": {

--- a/internal/prompts/handler.go
+++ b/internal/prompts/handler.go
@@ -102,6 +102,7 @@ func (h *Handler) Find(w http.ResponseWriter, r *http.Request) {
 
 // Instructions returns the effective instructions for a workflow stage.
 // Returns the active DB override if one exists, otherwise the hardcoded default.
+// When ?default=true is set, always returns the hardcoded default.
 func (h *Handler) Instructions(w http.ResponseWriter, r *http.Request) {
 	stage, err := ParseStage(r.PathValue("stage"))
 	if err != nil {
@@ -109,7 +110,13 @@ func (h *Handler) Instructions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	text, err := h.sys.Instructions(r.Context(), stage)
+	var text string
+	if r.URL.Query().Get("default") == "true" {
+		text, err = Instructions(stage)
+	} else {
+		text, err = h.sys.Instructions(r.Context(), stage)
+	}
+
 	if err != nil {
 		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
 		return

--- a/tests/prompts/handler_test.go
+++ b/tests/prompts/handler_test.go
@@ -306,6 +306,37 @@ func TestHandlerInstructions(t *testing.T) {
 			t.Errorf("status = %d, want 400", rec.Code)
 		}
 	})
+
+	t.Run("default=true bypasses system and returns hardcoded", func(t *testing.T) {
+		sys := &mockSystem{
+			instructionsFn: func(_ context.Context, _ prompts.Stage) (string, error) {
+				t.Fatal("system.Instructions should not be called with default=true")
+				return "", nil
+			},
+		}
+		mux := setupMux(newTestHandler(sys))
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/prompts/classify/instructions?default=true", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+
+		var got prompts.StageContent
+		if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		want, _ := prompts.Instructions(prompts.StageClassify)
+		if got.Content != want {
+			t.Errorf("content mismatch: got %d bytes, want %d bytes", len(got.Content), len(want))
+		}
+		if got.Stage != prompts.StageClassify {
+			t.Errorf("stage = %q, want classify", got.Stage)
+		}
+	})
 }
 
 func TestHandlerSpec(t *testing.T) {


### PR DESCRIPTION
## Summary

- Create `hd-prompt-form` module with create/edit modes, FormData extraction, and error display
- Compose `hd-prompts-view` with split-panel layout coordinating list and form via custom events
- Add collapsible default prompt reference panel showing stage specification and hardcoded default instructions
- Add `?default=true` query param to `GET /api/prompts/{stage}/instructions` to bypass active DB overrides
- Establish custom event naming convention (simple action verbs, no domain prefix)
- Remove unused `@lit-labs/signals` and `@lit/context` dependencies

Closes #84

## Changes

- **New**: `app/client/ui/modules/prompt-form.ts` + `.module.css` — stateful form module
- **Modified**: `prompts-view.ts` + `.module.css` — split-panel view composition replacing stub
- **Modified**: `prompt-list.ts` + `.module.css` — event renames, `selected` property, grid toolbar
- **Modified**: `prompt-card.ts` — select event emits full prompt object
- **Modified**: `internal/prompts/handler.go` — `?default=true` instructions bypass
- **Modified**: `app/client/domains/prompts/service.ts` — `defaultOnly` param on instructions
- **Modified**: `app/package.json` — removed unused deps
- **Updated**: API cartographer docs, web-development skill, handler tests