### PR TITLE
Add blob viewer element and storage inline endpoint

### DIFF
--- a/.claude/context/guides/.archive/88-pdf-viewer-storage-inline.md
+++ b/.claude/context/guides/.archive/88-pdf-viewer-storage-inline.md
@@ -1,0 +1,281 @@
+# 88 — PDF Viewer Element and Storage Inline Endpoint
+
+## Problem Context
+
+The document review view (#61) needs to display PDFs inline so reviewers can see the document alongside its classification. This requires a backend endpoint that streams blobs with `Content-Disposition: inline` (browsers render PDFs natively in iframes) and a pure Lit element that wraps the iframe.
+
+## Architecture Approach
+
+The `view` handler mirrors the existing `download` handler exactly, differing only in the `Content-Disposition` value (`inline` vs `attachment`). The `hd-blob-viewer` element is a generic pure element — accepts a `src` URL and renders an iframe. It has no knowledge of storage routes, blob types, or documents. The caller constructs the URL and passes it in. The review view composes `hd-blob-viewer` by loading the document via `DocumentService.find()` and building the `/api/storage/view/` URL from `storage_key`.
+
+## Implementation
+
+### Step 1: Add `view` handler and route (`internal/api/storage.go`)
+
+Add route to `routes()` between `download` and `find`:
+
+```go
+{Method: "GET", Pattern: "/view/{key...}", Handler: h.view},
+```
+
+Add `view` method after the `download` method:
+
+```go
+func (h *storageHandler) view(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	result, err := h.store.Download(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			storage.MapHTTPStatus(err), err,
+		)
+		return
+	}
+	defer result.Body.Close()
+
+	w.Header().Set("Content-Type", result.ContentType)
+
+	if result.ContentLength > 0 {
+		w.Header().Set(
+			"Content-Length",
+			strconv.FormatInt(result.ContentLength, 10),
+		)
+	}
+	w.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf("inline; filename=%q", path.Base(key)),
+	)
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, result.Body)
+}
+```
+
+### Step 2: Add `view` to `StorageService` (`app/client/domains/storage/service.ts`)
+
+Add method to the service object:
+
+```typescript
+  /** Builds the inline view URL for a blob by storage key. */
+  view(key: string): string {
+    return `/api${base}/view/${key}`;
+  },
+```
+
+This keeps the `/api/storage/view/` route construction inside the service boundary. Callers never assemble API paths.
+
+### Step 3: Create `hd-blob-viewer` element (`app/client/ui/elements/blob-viewer.ts`)
+
+New file:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import styles from "./blob-viewer.module.css";
+
+@customElement("hd-blob-viewer")
+export class BlobViewer extends LitElement {
+  static styles = styles;
+
+  @property() override title = "Blob viewer";
+  @property() src?: string;
+
+  render() {
+    if (!this.src) return nothing;
+
+    return html`
+      <iframe
+        src=${this.src}
+        title=${this.title}
+      ></iframe>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-blob-viewer": BlobViewer;
+  }
+}
+```
+
+### Step 4: Create blob viewer styles (`app/client/ui/elements/blob-viewer.module.css`)
+
+New file:
+
+```css
+:host {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+iframe {
+  flex: 1;
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+}
+```
+
+### Step 5: Update elements barrel (`app/client/ui/elements/index.ts`)
+
+Add between existing exports (alphabetically before `ClassifyProgress`):
+
+```typescript
+export { BlobViewer } from "./blob-viewer";
+```
+
+### Step 6: Update review view (`app/client/ui/views/review-view.ts`)
+
+Replace the entire placeholder implementation:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { navigate } from "@core/router";
+import type { Document } from "@domains/documents";
+import { DocumentService } from "@domains/documents";
+import { StorageService } from "@domains/storage";
+
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./review-view.module.css";
+
+@customElement("hd-review-view")
+export class ReviewView extends LitElement {
+  static styles = [buttonStyles, styles];
+
+  @property() documentId?: string;
+  @state() private document?: Document;
+  @state() private error?: string;
+
+  async willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("documentId") && this.documentId) {
+      this.document = undefined;
+      this.error = undefined;
+
+      const result = await DocumentService.find(this.documentId);
+
+      if (result.ok) {
+        this.document = result.data;
+      } else {
+        this.error = result.error;
+      }
+    }
+  }
+
+  private handleBack() {
+    navigate("");
+  }
+
+  render() {
+    if (this.error) {
+      return html`
+        <div class="error">
+          <p>${this.error}</p>
+          <button class="button" @click=${this.handleBack}>
+            Back to Documents
+          </button>
+        </div>
+      `;
+    }
+
+    if (!this.document) {
+      return html`<div class="loading">Loading document...</div>`;
+    }
+
+    return html`
+      <div class="panel pdf-panel">
+        <hd-blob-viewer
+          .title=${this.document.filename}
+          .src=${StorageService.view(this.document.storage_key)}
+        ></hd-blob-viewer>
+      </div>
+      <div class="panel classification-panel">
+        <h2>${this.document.filename}</h2>
+        <p class="status">${this.document.status}</p>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-review-view": ReviewView;
+  }
+}
+```
+
+### Step 7: Update review view styles (`app/client/ui/views/review-view.module.css`)
+
+Replace all styles:
+
+```css
+:host {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pdf-panel {
+  flex: 3;
+}
+
+.classification-panel {
+  flex: 2;
+  padding: var(--space-4);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  overflow-y: auto;
+}
+
+.classification-panel h2 {
+  margin-bottom: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  word-break: break-all;
+}
+
+.classification-panel .status {
+  color: var(--color-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.loading,
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: var(--space-4);
+  color: var(--color-1);
+  font-family: var(--font-mono);
+}
+```
+
+## Remediation
+
+### R1: Missing route registration
+
+The `view` handler was implemented but the route `GET /view/{key...}` was not added to `routes()`. The `/{key...}` wildcard on `find` was catching view requests, returning "blob not found". Fixed by adding the route before the catch-all.
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `bun run build` succeeds
+- [ ] `GET /api/storage/view/{key}` streams PDF with `Content-Disposition: inline`
+- [ ] `hd-blob-viewer` renders content in iframe given a `src` URL
+- [ ] Navigate to `/app/review/:documentId` — PDF renders in the left panel

--- a/.claude/context/sessions/88-pdf-viewer-storage-inline.md
+++ b/.claude/context/sessions/88-pdf-viewer-storage-inline.md
@@ -1,0 +1,39 @@
+# 88 — PDF Viewer Element and Storage Inline Endpoint
+
+## Summary
+
+Added a `GET /api/storage/view/{key...}` endpoint that streams blobs with `Content-Disposition: inline` for native browser rendering. Created `hd-blob-viewer`, a generic pure element that renders any URL in an iframe. Added `StorageService.view()` to encapsulate the view URL construction. Composed everything into the review view with document loading, error handling, and a two-panel layout.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Generic element naming | `hd-blob-viewer` with `src` prop | Not coupled to PDFs or storage routes — reusable for any inline content |
+| URL construction in service | `StorageService.view(key)` | Services own the API boundary; callers don't assemble API paths |
+| `title` property | `override title` on BlobViewer | Semantic pass-through to iframe `title` attribute for accessibility |
+| Document loading | `willUpdate` with `changed.has("documentId")` | Fires on initial navigation and re-navigation; `@state` changes trigger re-render |
+
+## Files Modified
+
+- `internal/api/storage.go` — added `view` handler + route
+- `app/client/ui/elements/blob-viewer.ts` — new generic blob viewer element
+- `app/client/ui/elements/blob-viewer.module.css` — new blob viewer styles
+- `app/client/ui/elements/index.ts` — added barrel export
+- `app/client/ui/views/review-view.ts` — composed blob viewer with document loading
+- `app/client/ui/views/review-view.module.css` — two-panel flex layout
+- `app/client/domains/storage/service.ts` — added `view()` URL builder
+- `_project/api/storage/README.md` — added View Blob endpoint docs
+- `_project/api/storage/storage.http` — added View Blob request
+
+## Patterns Established
+
+- **Service URL builders**: Services can expose synchronous URL builder methods alongside async `Result<T>` methods. The API boundary is owned by services regardless of return type.
+- **Generic blob viewer**: `hd-blob-viewer` accepts `src` and `title` — caller constructs the URL. Reusable for any inline-renderable content.
+- **View data loading**: `willUpdate` + `changed.has()` for route-param-driven data fetching in view components.
+
+## Validation Results
+
+- `go vet ./...` — pass
+- `bun run build` — pass
+- `GET /api/storage/view/{key}` — streams PDF with `Content-Disposition: inline`
+- Review view at `/app/review/:documentId` — PDF renders in left panel with filename and status in right panel

--- a/.claude/plans/hashed-stirring-stardust.md
+++ b/.claude/plans/hashed-stirring-stardust.md
@@ -1,0 +1,75 @@
+# 88 — PDF Viewer Element and Storage Inline Endpoint
+
+## Context
+
+Sub-issue 1 of Objective 5 (Document Review View, #61). The review view needs to display PDFs inline. This requires a backend endpoint that streams blobs with `Content-Disposition: inline` and a pure Lit element that renders the PDF in an iframe.
+
+## Implementation
+
+### Step 1: Add `view` handler to storage (`internal/api/storage.go`)
+
+Copy the `download` method, change `attachment` to `inline` in the `Content-Disposition` header. Register route `GET /view/{key...}` in `routes()`.
+
+**Route registration** (add between download and find):
+```go
+{Method: "GET", Pattern: "/view/{key...}", Handler: h.view},
+```
+
+**Handler** — identical to `download` except line 116 uses `inline`:
+```go
+func (h *storageHandler) view(w http.ResponseWriter, r *http.Request) {
+    // same as download but Content-Disposition: inline
+}
+```
+
+### Step 2: Create `hd-pdf-viewer` element
+
+**`app/client/ui/elements/pdf-viewer.ts`** — pure element:
+- `@property() storageKey: string` — blob storage key
+- Renders `<iframe src="/api/storage/view/${this.storageKey}">`
+- Full-height flex layout
+- No services, no state
+
+**`app/client/ui/elements/pdf-viewer.module.css`** — styles:
+- `:host` — `display: flex; flex: 1; min-height: 0`
+- `iframe` — `flex: 1; border` styling with design tokens
+
+### Step 3: Update elements barrel
+
+Add `PdfViewer` export to `app/client/ui/elements/index.ts`.
+
+### Step 4: Compose `hd-pdf-viewer` into review view
+
+Update `app/client/ui/views/review-view.ts` to load the document by ID and render `hd-pdf-viewer` with its `storageKey`. The current review view is a placeholder — replace the placeholder content with a layout that fetches the document via `DocumentService.find()` and passes `document.storage_key` to `hd-pdf-viewer`.
+
+- Add `@state() document?: Document` — loaded in `willUpdate` when `documentId` changes
+- Render `hd-pdf-viewer` with the document's `storage_key` when loaded
+- Show loading/error states appropriately
+
+Update `app/client/ui/views/review-view.module.css` to use a full-height flex layout instead of the centered placeholder styles.
+
+### Step 5: Update API Cartographer docs
+
+Add "View Blob" section to `_project/api/storage/README.md` and corresponding request to `_project/api/storage/storage.http`.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `internal/api/storage.go` | Add `view` handler + route |
+| `app/client/ui/elements/pdf-viewer.ts` | New |
+| `app/client/ui/elements/pdf-viewer.module.css` | New |
+| `app/client/ui/elements/index.ts` | Add export |
+| `app/client/ui/views/review-view.ts` | Compose pdf-viewer |
+| `app/client/ui/views/review-view.module.css` | Update layout |
+| `_project/api/storage/README.md` | Add View Blob section |
+| `_project/api/storage/storage.http` | Add View Blob request |
+
+## Validation
+
+- [ ] `go vet ./...` passes
+- [ ] `bun run build` succeeds
+- [ ] `GET /api/storage/view/{key}` streams PDF with `Content-Disposition: inline`
+- [ ] `hd-pdf-viewer` renders PDF in iframe given a storage key
+- [ ] Navigate to `/app/review/:documentId` — PDF renders in the left panel
+- [ ] API Cartographer docs updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.61.88
+- Add `GET /api/storage/view/{key}` inline blob streaming endpoint, generic `hd-blob-viewer` pure element with caller-driven `src` URL, `StorageService.view()` URL builder, and review view composition with document loading and two-panel layout (#88)
+
 ## v0.3.0-dev.60.84
 - Add prompt form module with create/edit modes, FormData extraction, and error display; compose prompts view with split-panel layout coordinating list and form via custom events; add collapsible default prompt reference panel showing stage specification and hardcoded default instructions; add `?default=true` query param to instructions endpoint to bypass active DB overrides; establish custom event naming convention (simple action verbs, no domain prefix); remove unused `@lit-labs/signals` and `@lit/context` dependencies (#84)
 

--- a/_project/api/storage/README.md
+++ b/_project/api/storage/README.md
@@ -94,3 +94,31 @@ Downloads a file by storage key. Streams the blob with appropriate Content-Type 
 ```bash
 curl -s "$HERALD_API_BASE/api/storage/download/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf" -o report.pdf
 ```
+
+---
+
+## View Blob
+
+`GET /api/storage/view/{key...}`
+
+Streams a file by storage key for inline browser display. Sets `Content-Disposition: inline` so browsers render supported formats (e.g., PDFs) natively inside iframes.
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| key | string (wildcard) | Blob storage key (may contain slashes) |
+
+### Responses
+
+| Status | Description |
+|--------|-------------|
+| 200 | File stream with Content-Type, Content-Length, and Content-Disposition: inline headers |
+| 400 | Invalid key |
+| 404 | Blob not found |
+
+### Example
+
+```bash
+curl -s "$HERALD_API_BASE/api/storage/view/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf" -o report.pdf
+```

--- a/_project/api/storage/storage.http
+++ b/_project/api/storage/storage.http
@@ -20,3 +20,10 @@ GET {{HOST}}/api/storage/documents/550e8400-e29b-41d4-a716-446655440000/report.p
 # Replace with a valid storage key
 
 GET {{HOST}}/api/storage/download/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf HTTP/1.1
+
+
+### View Blob
+
+# Replace with a valid storage key
+
+GET {{HOST}}/api/storage/view/documents/550e8400-e29b-41d4-a716-446655440000/report.pdf HTTP/1.1

--- a/app/client/domains/storage/service.ts
+++ b/app/client/domains/storage/service.ts
@@ -34,6 +34,11 @@ export const StorageService = {
     return await request<BlobMeta>(`${base}/${key}`);
   },
 
+  /** Builds the inline view URL for `GET /api/storage/view/:key`. */
+  view(key: string): string {
+    return `/api${base}/view/${key}`;
+  },
+
   /** `GET /api/storage/download/:key` — download blob content. */
   async download(key: string): Promise<Result<Blob>> {
     return await request<Blob>(`${base}/download/${key}`, undefined, (res) =>

--- a/app/client/ui/elements/blob-viewer.module.css
+++ b/app/client/ui/elements/blob-viewer.module.css
@@ -1,0 +1,11 @@
+:host {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+iframe {
+  flex: 1;
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+}

--- a/app/client/ui/elements/blob-viewer.ts
+++ b/app/client/ui/elements/blob-viewer.ts
@@ -1,0 +1,28 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import styles from "./blob-viewer.module.css";
+
+/**
+ * Generic inline blob viewer. Renders an iframe pointed at the given `src` URL.
+ * Caller constructs the URL — the element has no knowledge of API routes or blob types.
+ */
+@customElement("hd-blob-viewer")
+export class BlobViewer extends LitElement {
+  static styles = styles;
+
+  @property() override title = "Blob viewer";
+  @property() src?: string;
+
+  render() {
+    if (!this.src) return nothing;
+
+    return html`<iframe src=${this.src} title=${this.title}></iframe>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-blob-viewer": BlobViewer;
+  }
+}

--- a/app/client/ui/elements/index.ts
+++ b/app/client/ui/elements/index.ts
@@ -1,3 +1,4 @@
+export { BlobViewer } from "./blob-viewer";
 export { ClassifyProgress } from "./classify-progress";
 export { ConfirmDialog } from "./confirm-dialog";
 export { DocumentCard } from "./document-card";

--- a/app/client/ui/views/review-view.module.css
+++ b/app/client/ui/views/review-view.module.css
@@ -1,17 +1,52 @@
 :host {
   display: flex;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pdf-panel {
+  flex: 3;
+}
+
+.classification-panel {
+  flex: 2;
+  padding: var(--space-4);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  overflow-y: auto;
+}
+
+.classification-panel h2 {
+  margin-bottom: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  word-break: break-all;
+}
+
+.classification-panel .status {
+  color: var(--color-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.loading,
+.error {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-}
-
-.container {
-  text-align: center;
-}
-
-h1 {
-  margin-bottom: var(--space-4);
-}
-
-p {
+  flex: 1;
+  gap: var(--space-4);
   color: var(--color-1);
+  font-family: var(--font-mono);
 }

--- a/app/client/ui/views/review-view.ts
+++ b/app/client/ui/views/review-view.ts
@@ -1,21 +1,68 @@
-import { LitElement, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { navigate } from "@core/router";
+import type { Document } from "@domains/documents";
+import { DocumentService } from "@domains/documents";
+import { StorageService } from "@domains/storage";
+
+import buttonStyles from "@styles/buttons.module.css";
 import styles from "./review-view.module.css";
 
 /** Route-level view for reviewing a document's classification result. */
 @customElement("hd-review-view")
 export class ReviewView extends LitElement {
-  static styles = styles;
+  static styles = [buttonStyles, styles];
 
-  @property({ type: String }) documentId?: string;
+  @property() documentId?: string;
+  @state() private document?: Document;
+  @state() private error?: string;
+
+  async willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("documentId") && this.documentId) {
+      this.document = undefined;
+      this.error = undefined;
+
+      const result = await DocumentService.find(this.documentId);
+
+      if (result.ok) {
+        this.document = result.data;
+      } else {
+        this.error = result.error;
+      }
+    }
+  }
+
+  private handleBack() {
+    navigate("");
+  }
 
   render() {
+    if (this.error) {
+      return html`
+        <div class="error">
+          <p>${this.error}</p>
+          <button class="button" @click=${this.handleBack}>
+            Back to Documents
+          </button>
+        </div>
+      `;
+    }
+
+    if (!this.document) {
+      return html`<div class="loading">Loading document...</div>`;
+    }
+
     return html`
-      <div class="container">
-        <h1>Review</h1>
-        <p>
-          Classification review for document ${this.documentId ?? "unknown"}.
-        </p>
+      <div class="panel pdf-panel">
+        <hd-blob-viewer
+          .title=${this.document.filename}
+          .src=${StorageService.view(this.document.storage_key)}
+        ></hd-blob-viewer>
+      </div>
+      <div class="panel classification-panel">
+        <h2>${this.document.filename}</h2>
+        <p class="status">${this.document.status}</p>
       </div>
     `;
   }

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -37,6 +37,7 @@ func (h *storageHandler) routes() routes.Group {
 		Routes: []routes.Route{
 			{Method: "GET", Pattern: "", Handler: h.list},
 			{Method: "GET", Pattern: "/download/{key...}", Handler: h.download},
+			{Method: "GET", Pattern: "/view/{key...}", Handler: h.view},
 			{Method: "GET", Pattern: "/{key...}", Handler: h.find},
 		},
 	}
@@ -88,6 +89,37 @@ func (h *storageHandler) find(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handlers.RespondJSON(w, http.StatusOK, meta)
+}
+
+// view streams a blob for inline browser display, setting Content-Disposition
+// to "inline" so browsers render supported formats (e.g., PDFs) natively.
+func (h *storageHandler) view(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+
+	result, err := h.store.Download(r.Context(), key)
+	if err != nil {
+		handlers.RespondError(
+			w, h.logger,
+			storage.MapHTTPStatus(err), err,
+		)
+		return
+	}
+	defer result.Body.Close()
+
+	w.Header().Set("Content-Type", result.ContentType)
+
+	if result.ContentLength > 0 {
+		w.Header().Set(
+			"Content-Length",
+			strconv.FormatInt(result.ContentLength, 10),
+		)
+	}
+	w.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf("inline; filename=%q", path.Base(key)),
+	)
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, result.Body)
 }
 
 func (h *storageHandler) download(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Add inline blob streaming endpoint, generic blob viewer element, and review view composition for document review.

Closes #88

## Changes

- Add `GET /api/storage/view/{key...}` endpoint with `Content-Disposition: inline` for native browser rendering
- Create `hd-blob-viewer` pure element — generic iframe wrapper accepting `src` and `title` props
- Add `StorageService.view()` URL builder to encapsulate API path construction
- Compose review view with document loading via `willUpdate`, error/loading states, and two-panel flex layout (60/40 PDF + classification)
- Update API Cartographer storage docs with View Blob endpoint