### PR TITLE
Add markings list element and classification panel module

### DIFF
--- a/.claude/context/guides/.archive/89-markings-list-classification-panel.md
+++ b/.claude/context/guides/.archive/89-markings-list-classification-panel.md
@@ -1,0 +1,712 @@
+# 89 - Markings List Element and Classification Panel Module
+
+## Problem Context
+
+Sub-issue 2 of Objective 5: Document Review View (#61). The review view needs a panel to display classification data alongside a PDF viewer. This issue creates the classification panel module (loads and displays classification, with validate/update actions) and a markings list element (renders security markings as badge tags).
+
+## Architecture Approach
+
+Two components following existing patterns:
+- **`hd-markings-list`** — pure element like `prompt-card.ts`: receives data via `@property()`, renders badges, no events
+- **`hd-classification-panel`** — stateful module like `prompt-form.ts`: loads data in `updated()`, manages mode state for view/validate/update, calls services, dispatches events
+
+Confidence values (`HIGH`, `MEDIUM`, `LOW`) need badge color mapping. Since these don't match existing badge classes, we add three CSS classes in the panel's module CSS to keep badge styling self-contained.
+
+## Implementation
+
+### Step 1: `markings-list.module.css`
+
+Create `app/client/ui/elements/markings-list.module.css`:
+
+```css
+:host {
+  display: block;
+}
+
+.markings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.empty {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  font-style: italic;
+}
+```
+
+### Step 2: `markings-list.ts`
+
+Create `app/client/ui/elements/markings-list.ts`:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import badgeStyles from "@styles/badge.module.css";
+import styles from "./markings-list.module.css";
+
+@customElement("hd-markings-list")
+export class MarkingsList extends LitElement {
+  static styles = [badgeStyles, styles];
+
+  @property({ type: Array }) markings: string[] = [];
+
+  render() {
+    if (!this.markings.length) {
+      return html`<span class="empty">No markings found</span>`;
+    }
+
+    return html`
+      <div class="markings">
+        ${this.markings.map(
+          (m) => html`<span class="badge">${m}</span>`,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-markings-list": MarkingsList;
+  }
+}
+```
+
+### Step 3: `classification-panel.module.css`
+
+Create `app/client/ui/modules/classification-panel.module.css`:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.panel-header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-inline: var(--space-2);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.section-label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.classification-value {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.classification-name {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.confidence.high {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.confidence.medium {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.confidence.low {
+  color: var(--red);
+  background: var(--red-bg);
+}
+
+.rationale {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-2);
+  white-space: pre-wrap;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.meta span {
+  font-family: var(--font-mono);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.validate-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.update-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.field input,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.error {
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--red);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  color: var(--color-2);
+  text-align: center;
+}
+
+.empty-state a {
+  color: var(--blue);
+  text-decoration: none;
+  font-family: var(--font-mono);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.loading {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  font-style: italic;
+}
+
+.validated {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--green);
+  font-family: var(--font-mono);
+}
+```
+
+### Step 4: `classification-panel.ts`
+
+Create `app/client/ui/modules/classification-panel.ts`:
+
+```typescript
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { formatDate } from "@core/formatting";
+import { navigate } from "@core/router";
+import { ClassificationService } from "@domains/classifications";
+import type { Classification } from "@domains/classifications";
+
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./classification-panel.module.css";
+
+type PanelMode = "view" | "validate" | "update";
+
+@customElement("hd-classification-panel")
+export class ClassificationPanel extends LitElement {
+  static styles = [buttonStyles, badgeStyles, styles];
+
+  @property() documentId = "";
+
+  @state() private classification: Classification | null = null;
+  @state() private loading = true;
+  @state() private error = "";
+  @state() private mode: PanelMode = "view";
+  @state() private submitting = false;
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has("documentId") && this.documentId) {
+      this.loadClassification();
+    }
+  }
+
+  private async loadClassification() {
+    this.loading = true;
+    this.error = "";
+    this.classification = null;
+
+    const result = await ClassificationService.findByDocument(this.documentId);
+
+    this.loading = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+  }
+
+  private async handleValidate(e: SubmitEvent) {
+    e.preventDefault();
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+    const validated_by = (data.get("validated_by") as string).trim();
+
+    const result = await ClassificationService.validate(
+      this.classification!.id,
+      { validated_by },
+    );
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+    this.mode = "view";
+    this.error = "";
+
+    this.dispatchEvent(
+      new CustomEvent("validate", {
+        detail: { classification: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private async handleUpdate(e: SubmitEvent) {
+    e.preventDefault();
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+
+    const command = {
+      classification: (data.get("classification") as string).trim(),
+      rationale: (data.get("rationale") as string).trim(),
+      updated_by: (data.get("updated_by") as string).trim(),
+    };
+
+    const result = await ClassificationService.update(
+      this.classification!.id,
+      command,
+    );
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+    this.mode = "view";
+    this.error = "";
+
+    this.dispatchEvent(
+      new CustomEvent("update", {
+        detail: { classification: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleBack() {
+    navigate("");
+  }
+
+  private handleCancel() {
+    this.mode = "view";
+    this.error = "";
+  }
+
+  private renderError() {
+    if (!this.error) return nothing;
+    return html`<div class="error">${this.error}</div>`;
+  }
+
+  private renderValidated() {
+    const c = this.classification;
+    if (!c?.validated_by) return nothing;
+
+    return html`
+      <div class="validated">
+        <span>Validated by ${c.validated_by}</span>
+        ${c.validated_at ? html`<span>on ${formatDate(c.validated_at)}</span>` : nothing}
+      </div>
+    `;
+  }
+
+  private renderViewMode() {
+    const c = this.classification!;
+
+    return html`
+      <div class="panel-body">
+        <div class="section">
+          <span class="section-label">Classification</span>
+          <div class="classification-value">
+            <span class="classification-name">${c.classification}</span>
+            <span class="badge confidence ${c.confidence.toLowerCase()}">${c.confidence}</span>
+          </div>
+        </div>
+
+        <div class="section">
+          <span class="section-label">Markings Found</span>
+          <hd-markings-list .markings=${c.markings_found}></hd-markings-list>
+        </div>
+
+        <div class="section">
+          <span class="section-label">Rationale</span>
+          <pre class="rationale">${c.rationale}</pre>
+        </div>
+
+        ${this.renderValidated()}
+
+        <div class="meta">
+          <span>${c.model_name} / ${c.provider_name}</span>
+          <span>Classified ${formatDate(c.classified_at)}</span>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button
+          class="btn validate-btn"
+          @click=${() => (this.mode = "validate")}
+        >
+          Validate
+        </button>
+        <button
+          class="btn update-btn"
+          @click=${() => (this.mode = "update")}
+        >
+          Update
+        </button>
+      </div>
+    `;
+  }
+
+  private renderValidateMode() {
+    return html`
+      <form class="panel-body" @submit=${this.handleValidate}>
+        <p>Confirm that the AI classification is correct.</p>
+
+        <div class="field">
+          <label for="validated_by">Your Name</label>
+          <input
+            id="validated_by"
+            name="validated_by"
+            type="text"
+            required
+            .value=${this.classification?.validated_by ?? ""}
+          />
+        </div>
+
+        ${this.renderError()}
+
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn validate-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Validating..." : "Validate"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  private renderUpdateMode() {
+    const c = this.classification!;
+
+    return html`
+      <form class="panel-body" @submit=${this.handleUpdate}>
+        <p>Manually update the classification result.</p>
+
+        <div class="field">
+          <label for="classification">Classification</label>
+          <input
+            id="classification"
+            name="classification"
+            type="text"
+            required
+            .value=${c.classification}
+          />
+        </div>
+
+        <div class="field">
+          <label for="rationale">Rationale</label>
+          <textarea
+            id="rationale"
+            name="rationale"
+            required
+            .value=${c.rationale}
+          ></textarea>
+        </div>
+
+        <div class="field">
+          <label for="updated_by">Your Name</label>
+          <input
+            id="updated_by"
+            name="updated_by"
+            type="text"
+            required
+          />
+        </div>
+
+        ${this.renderError()}
+
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn update-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Updating..." : "Update"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  render() {
+    if (this.loading) {
+      return html`<span class="loading">Loading classification...</span>`;
+    }
+
+    if (!this.classification) {
+      return html`
+        <div class="empty-state">
+          <span>No classification found for this document.</span>
+          <button class="button" @click=${this.handleBack}>
+            Back to Documents
+          </button>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="panel-header">
+        <h2>Classification</h2>
+      </div>
+
+      ${this.mode === "view"
+        ? this.renderViewMode()
+        : this.mode === "validate"
+          ? this.renderValidateMode()
+          : this.renderUpdateMode()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-classification-panel": ClassificationPanel;
+  }
+}
+```
+
+### Step 5: Barrel Updates
+
+**`app/client/ui/elements/index.ts`** — add:
+
+```typescript
+export { MarkingsList } from "./markings-list";
+```
+
+**`app/client/ui/modules/index.ts`** — add:
+
+```typescript
+export { ClassificationPanel } from "./classification-panel";
+```
+
+## Remediation
+
+### R1: Integrate classification panel into review view
+
+The classification panel cannot be verified in isolation — it needs the review view to host it. The view already has two-panel flex layout with a placeholder right panel. Replace the placeholder with `<hd-classification-panel>` and wire up `validate`/`update` event listeners to re-fetch the document (for status changes). Remove the now-unused placeholder CSS rules.
+
+> **Note:** This completes the review view composition originally scoped for Task #90. That task will be repurposed as a comprehensive evaluation of the overall web application architecture, layout, and functionality.
+
+**`app/client/ui/views/review-view.ts`** — replace placeholder content with classification panel.
+
+`app.ts` already imports `@ui/elements` and `@ui/modules` which registers all custom elements globally, so no component-level barrel imports are needed. Remove the redundant imports:
+
+- `app/client/ui/modules/classification-panel.ts` — remove `import "@ui/elements";`
+- `app/client/ui/views/review-view.ts` — remove `import "@ui/modules";` (if present from #88)
+
+Add a `handleClassificationChange` method that re-fetches the document to reflect status transitions:
+
+```typescript
+private async handleClassificationChange() {
+  if (!this.documentId) return;
+
+  const result = await DocumentService.find(this.documentId);
+
+  if (result.ok) {
+    this.document = result.data;
+  }
+}
+```
+
+Replace the right panel content in `render()`:
+
+```typescript
+<div class="panel classification-panel">
+  <hd-classification-panel
+    .documentId=${this.documentId ?? ""}
+    @validate=${this.handleClassificationChange}
+    @update=${this.handleClassificationChange}
+  ></hd-classification-panel>
+</div>
+```
+
+**`app/client/ui/views/review-view.module.css`** — remove the placeholder rules that the panel module now owns:
+
+Remove these rules (the `.classification-panel` container rule stays):
+
+```css
+.classification-panel h2 {
+  margin-bottom: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  word-break: break-all;
+}
+
+.classification-panel .status {
+  color: var(--color-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+## Validation Criteria
+
+- [ ] `bun run build` succeeds from `app/`
+- [ ] `hd-markings-list` renders string array as styled badge tags
+- [ ] `hd-markings-list` shows empty state when no markings
+- [ ] `hd-classification-panel` loads and displays classification data for a document
+- [ ] Validate action calls API and dispatches `validate` event with updated classification
+- [ ] Update action expands form, calls API, dispatches `update` event with updated classification
+- [ ] Empty state shown when no classification exists
+- [ ] Review view renders classification panel in right panel
+- [ ] Validate/update events trigger document re-fetch in review view

--- a/.claude/context/sessions/89-markings-list-classification-panel.md
+++ b/.claude/context/sessions/89-markings-list-classification-panel.md
@@ -1,0 +1,37 @@
+# 89 - Markings List Element and Classification Panel Module
+
+## Summary
+
+Created the `hd-markings-list` pure element and `hd-classification-panel` stateful module for the document review view. The markings list renders security marking strings as badge tags. The classification panel loads a document's classification, displays it with sections for classification/confidence, markings, rationale, metadata, and validation status, and provides validate (agree with AI) and update (manual revision) actions. Also integrated the panel into the review view as a remediation, completing the review view composition originally scoped for #90.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Confidence badge colors | Custom `.confidence.high/medium/low` classes in panel CSS | Existing badge classes map to workflow stages, not confidence levels |
+| Empty state navigation | `navigate("")` via button, not anchor tag | Consistent with client-side routing pattern |
+| Review view composition in this task | Remediation R1 instead of deferring to #90 | Panel is unverifiable in isolation; composition is trivial (swap placeholder) |
+| No component-level barrel imports | Removed `import "@ui/elements"` and `import "@ui/modules"` from components | `app.ts` registers all custom elements globally |
+
+## Files Modified
+
+- `app/client/ui/elements/markings-list.ts` (new)
+- `app/client/ui/elements/markings-list.module.css` (new)
+- `app/client/ui/modules/classification-panel.ts` (new)
+- `app/client/ui/modules/classification-panel.module.css` (new)
+- `app/client/ui/elements/index.ts` (barrel update)
+- `app/client/ui/modules/index.ts` (barrel update)
+- `app/client/ui/views/review-view.ts` (R1: replaced placeholder with classification panel)
+- `app/client/ui/views/review-view.module.css` (R1: removed placeholder CSS rules)
+
+## Patterns Established
+
+- Confidence badge color mapping: `.confidence.high` (green), `.confidence.medium` (yellow), `.confidence.low` (red) — reusable if confidence badges appear elsewhere
+- Module mode pattern: `@state() mode: "view" | "validate" | "update"` with dedicated render methods per mode — clean separation of view/form states
+
+## Validation Results
+
+- `bun run build` succeeds
+- `go vet ./...` passes
+- Visual verification: classification panel renders all sections correctly in review view
+- Two-panel layout (PDF viewer + classification panel) displays as expected

--- a/.claude/plans/shimmering-purring-origami.md
+++ b/.claude/plans/shimmering-purring-origami.md
@@ -1,0 +1,89 @@
+# Issue #89 — Markings List Element and Classification Panel Module
+
+## Context
+
+Sub-issue 2 of Objective 5: Document Review View (#61). Creates two UI components: a pure element for rendering security marking badges, and a stateful module for displaying/interacting with classification data (validate and update actions). These will be composed into the review view in issue #90.
+
+## Files to Create
+
+1. `app/client/ui/elements/markings-list.ts` — pure element
+2. `app/client/ui/elements/markings-list.module.css` — element styles
+3. `app/client/ui/modules/classification-panel.ts` — stateful module
+4. `app/client/ui/modules/classification-panel.module.css` — module styles
+
+## Files to Modify
+
+5. `app/client/ui/elements/index.ts` — add `MarkingsList` export
+6. `app/client/ui/modules/index.ts` — add `ClassificationPanel` export
+
+## Implementation
+
+### Step 1: `hd-markings-list` Element
+
+Pure element receiving `markings: string[]`. Renders each marking as a badge tag. Empty state when array is empty/undefined.
+
+- `@property({ type: Array }) markings: string[] = []`
+- Import `badgeStyles` from `@styles/badge.module.css`
+- Each marking rendered as `<span class="badge">${marking}</span>`
+- Markings badges use a neutral/marking-specific style (not tied to workflow stage colors)
+- No events dispatched — display only
+
+CSS: Flex-wrap container for badges, gap spacing, empty state message.
+
+### Step 2: `hd-classification-panel` Module
+
+Stateful module following `prompt-form.ts` patterns.
+
+**Props:**
+- `@property() documentId: string` — used to load classification
+- `@property({ type: Object }) document: Document | null` — document context from parent
+
+**State:**
+- `@state() classification: Classification | null = null`
+- `@state() loading = true`
+- `@state() error = ""`
+- `@state() mode: "view" | "validate" | "update" = "view"`
+- `@state() submitting = false`
+
+**Lifecycle:**
+- `updated()` watches `documentId` changes, calls `ClassificationService.findByDocument()`
+- On success: sets classification, clears loading
+- On error: sets error, shows empty state with "Back to Documents" link
+
+**Display (mode = "view"):**
+- Classification value + confidence badge (reuse badge styles with confidence class)
+- `<hd-markings-list>` with `classification.markings_found`
+- Rationale in preformatted text
+- Model/provider metadata row
+- Timestamps (classified_at, validated_at) using `formatDate()`
+- Validated-by (if present)
+- Action buttons: "Validate" and "Update" to switch modes
+
+**Validate mode:**
+- Name input for `validated_by`
+- "Validate" submit + "Cancel" button
+- On submit: `ClassificationService.validate(id, { validated_by })` → update `@state()` from response → dispatch `validate` event → return to view mode
+
+**Update mode:**
+- Form fields: classification (text input), rationale (textarea), updated_by (text input)
+- "Update" submit + "Cancel" button
+- On submit: `ClassificationService.update(id, { classification, rationale, updated_by })` → update `@state()` from response → dispatch `update` event → return to view mode
+
+**Key services/types used:**
+- `ClassificationService` from `@domains/classifications` — `findByDocument`, `validate`, `update`
+- `Classification` type from `@domains/classifications`
+- `ValidateCommand`, `UpdateCommand` from `@domains/classifications`
+- `formatDate` from `@core`
+- `Document` type from `@domains/documents`
+
+### Step 3: Barrel Updates
+
+Add exports to element and module index files.
+
+## Verification
+
+- `bun run build` succeeds from `app/`
+- Visual review: classification panel renders all sections
+- Validate flow: enter name → submit → state updates, event dispatches
+- Update flow: expand form → fill fields → submit → state updates, event dispatches
+- Empty state: shows message when no classification exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.0-dev.61.89
+- Add markings list pure element rendering security markings as badge tags, classification panel module with view/validate/update modes and event-driven state refresh, and integrate panel into review view replacing placeholder content (#89)
+
 ## v0.3.0-dev.61.88
 - Add `GET /api/storage/view/{key}` inline blob streaming endpoint, generic `hd-blob-viewer` pure element with caller-driven `src` URL, `StorageService.view()` URL builder, and review view composition with document loading and two-panel layout (#88)
 

--- a/app/client/ui/elements/index.ts
+++ b/app/client/ui/elements/index.ts
@@ -2,5 +2,6 @@ export { BlobViewer } from "./blob-viewer";
 export { ClassifyProgress } from "./classify-progress";
 export { ConfirmDialog } from "./confirm-dialog";
 export { DocumentCard } from "./document-card";
+export { MarkingsList } from "./markings-list";
 export { PaginationControls } from "./pagination-controls";
 export { PromptCard } from "./prompt-card";

--- a/app/client/ui/elements/markings-list.module.css
+++ b/app/client/ui/elements/markings-list.module.css
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.markings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.empty {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  font-style: italic;
+}

--- a/app/client/ui/elements/markings-list.ts
+++ b/app/client/ui/elements/markings-list.ts
@@ -1,0 +1,34 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import badgeStyles from "@styles/badge.module.css";
+import styles from "./markings-list.module.css";
+
+/**
+ * Pure element that renders an array of security marking strings as
+ * badge tags. Displays an empty-state message when no markings are present.
+ */
+@customElement("hd-markings-list")
+export class MarkingsList extends LitElement {
+  static styles = [badgeStyles, styles];
+
+  @property({ type: Array }) markings: string[] = [];
+
+  render() {
+    if (!this.markings.length) {
+      return html`<span class="empty">No markings found</span>`;
+    }
+
+    return html`
+      <div class="markings">
+        ${this.markings.map((m) => html`<span class="badge">${m}</span>`)}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-markings-list": MarkingsList;
+  }
+}

--- a/app/client/ui/modules/classification-panel.module.css
+++ b/app/client/ui/modules/classification-panel.module.css
@@ -1,0 +1,205 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.panel-header h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-inline: var(--space-2);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.section-label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.classification-value {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.classification-name {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.confidence.high {
+  color: var(--green);
+  background: var(--green-bg);
+}
+
+.confidence.medium {
+  color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.confidence.low {
+  color: var(--red);
+  background: var(--red-bg);
+}
+
+.rationale {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-2);
+  white-space: pre-wrap;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-2);
+}
+
+.meta span {
+  font-family: var(--font-mono);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.validate-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.update-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.field input,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.error {
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--red);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  color: var(--color-2);
+  text-align: center;
+}
+
+.empty-state a {
+  color: var(--blue);
+  text-decoration: none;
+  font-family: var(--font-mono);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.loading {
+  font-size: var(--text-sm);
+  color: var(--color-2);
+  font-style: italic;
+}
+
+.validated {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--green);
+  font-family: var(--font-mono);
+}

--- a/app/client/ui/modules/classification-panel.ts
+++ b/app/client/ui/modules/classification-panel.ts
@@ -1,0 +1,331 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { formatDate } from "@core/formatting";
+import { navigate } from "@core/router";
+import { ClassificationService } from "@domains/classifications";
+import type { Classification } from "@domains/classifications";
+
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import styles from "./classification-panel.module.css";
+
+type PanelMode = "view" | "validate" | "update";
+
+/**
+ * Stateful module that loads and displays a document's classification result.
+ * Supports three modes: view (read-only display), validate (confirm AI result),
+ * and update (manually revise classification). Dispatches `validate` and `update`
+ * custom events with the updated classification on successful submission.
+ */
+@customElement("hd-classification-panel")
+export class ClassificationPanel extends LitElement {
+  static styles = [badgeStyles, buttonStyles, styles];
+
+  @property() documentId = "";
+
+  @state() private classification: Classification | null = null;
+  @state() private loading = true;
+  @state() private error = "";
+  @state() private mode: PanelMode = "view";
+  @state() private submitting = false;
+
+  updated(changed: Map<string, unknown>) {
+    if (changed.has("documentId") && this.documentId) {
+      this.loadClassification();
+    }
+  }
+
+  private async loadClassification() {
+    this.loading = true;
+    this.error = "";
+    this.classification = null;
+
+    const result = await ClassificationService.findByDocument(this.documentId);
+
+    this.loading = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+  }
+
+  private async handleValidate(e: SubmitEvent) {
+    e.preventDefault();
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+    const validated_by = (data.get("validated_by") as string).trim();
+
+    const result = await ClassificationService.validate(
+      this.classification!.id,
+      { validated_by },
+    );
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+    this.mode = "view";
+    this.error = "";
+
+    this.dispatchEvent(
+      new CustomEvent("validate", {
+        detail: { classification: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private async handleUpdate(e: SubmitEvent) {
+    e.preventDefault();
+    this.submitting = true;
+
+    const form = e.target as HTMLFormElement;
+    const data = new FormData(form);
+
+    const command = {
+      classification: (data.get("classification") as string).trim(),
+      rationale: (data.get("rationale") as string).trim(),
+      updated_by: (data.get("updated_by") as string).trim(),
+    };
+
+    const result = await ClassificationService.update(
+      this.classification!.id,
+      command,
+    );
+
+    this.submitting = false;
+
+    if (!result.ok) {
+      this.error = result.error;
+      return;
+    }
+
+    this.classification = result.data;
+    this.mode = "view";
+    this.error = "";
+
+    this.dispatchEvent(
+      new CustomEvent("update", {
+        detail: { classification: result.data },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleBack() {
+    navigate("");
+  }
+
+  private handleCancel() {
+    this.mode = "view";
+    this.error = "";
+  }
+
+  private renderError() {
+    if (!this.error) return nothing;
+    return html`<div class="error">${this.error}</div>`;
+  }
+
+  private renderValidated() {
+    const c = this.classification;
+    if (!c?.validated_by) return nothing;
+
+    return html`
+      <div class="validated">
+        <span>Validated by ${c.validated_by}</span>
+        ${c.validated_at
+          ? html`<span>on ${formatDate(c.validated_at)}</span>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderViewMode() {
+    const c = this.classification!;
+
+    return html`
+      <div class="panel-body">
+        <div class="section">
+          <span class="section-label">Classification</span>
+          <div class="classification-value">
+            <span class="classification-name">${c.classification}</span>
+            <span class="badge confidence ${c.confidence.toLowerCase()}">
+              ${c.confidence.toLowerCase()}
+            </span>
+          </div>
+        </div>
+
+        <div class="section">
+          <span class="section-label">Markings Found</span>
+          <hd-markings-list .markings=${c.markings_found}></hd-markings-list>
+        </div>
+
+        <div class="section">
+          <span class="section-label">Rationale</span>
+          <pre class="rationale">${c.rationale}</pre>
+        </div>
+
+        ${this.renderValidated()}
+
+        <div class="meta">
+          <span>${c.model_name} / ${c.provider_name}</span>
+          <span>Classified ${formatDate(c.classified_at)}</span>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button
+          class="btn validate-btn"
+          @click=${() => (this.mode = "validate")}
+        >
+          Validate
+        </button>
+        <button class="btn update-btn" @click=${() => (this.mode = "update")}>
+          Update
+        </button>
+      </div>
+    `;
+  }
+
+  private renderValidateMode() {
+    return html`
+      <form class="panel-body" @submit=${this.handleValidate}>
+        <p>Confirm that the classification is correct.</p>
+
+        <div class="field">
+          <label for="validated_by">Your Name</label>
+          <input
+            id="validated_by"
+            name="validated_by"
+            type="text"
+            required
+            .value=${this.classification?.validated_by ?? ""}
+          />
+        </div>
+
+        ${this.renderError()}
+
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn validate-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Validating..." : "Validate"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  private renderUpdateMode() {
+    const c = this.classification!;
+
+    return html`
+      <form class="panel-body" @submit=${this.handleUpdate}>
+        <p>Manually update the classification result.</p>
+
+        <div class="field">
+          <label for="classification">Classification</label>
+          <input
+            id="classification"
+            name="classification"
+            type="text"
+            required
+            .value=${c.classification}
+          />
+        </div>
+
+        <div class="field">
+          <label for="rationale">Rationale</label>
+          <textarea
+            id="rationale"
+            name="rationale"
+            required
+            .value=${c.rationale}
+          ></textarea>
+        </div>
+
+        <div class="field">
+          <label for="updated_by">Your Name</label>
+          <input id="updated_by" name="updated_by" type="text" required />
+        </div>
+
+        ${this.renderError()}
+
+        <div class="actions">
+          <button
+            type="submit"
+            class="btn update-btn"
+            ?disabled=${this.submitting}
+          >
+            ${this.submitting ? "Updating..." : "Update"}
+          </button>
+          <button
+            type="button"
+            class="btn cancel-btn"
+            @click=${this.handleCancel}
+            ?disabled=${this.submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  render() {
+    if (this.loading) {
+      return html`<span class="loading">Loading classifications...</span>`;
+    }
+
+    if (!this.classification) {
+      return html`
+        <div class="empty-state">
+          <span>No classification found for this document.</span>
+          <button class="button" @click=${this.handleBack}>
+            Back to Documents
+          </button>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="panel-header">
+        <h2>Classification</h2>
+      </div>
+
+      ${this.mode === "view"
+        ? this.renderViewMode()
+        : this.mode === "validate"
+          ? this.renderValidateMode()
+          : this.renderUpdateMode()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-classification-panel": ClassificationPanel;
+  }
+}

--- a/app/client/ui/modules/index.ts
+++ b/app/client/ui/modules/index.ts
@@ -1,3 +1,4 @@
+export { ClassificationPanel } from "./classification-panel";
 export { DocumentGrid } from "./document-grid";
 export { DocumentUpload } from "./document-upload";
 export { PromptForm } from "./prompt-form";

--- a/app/client/ui/views/review-view.module.css
+++ b/app/client/ui/views/review-view.module.css
@@ -24,21 +24,6 @@
   overflow-y: auto;
 }
 
-.classification-panel h2 {
-  margin-bottom: var(--space-2);
-  font-family: var(--font-mono);
-  font-size: var(--text-base);
-  word-break: break-all;
-}
-
-.classification-panel .status {
-  color: var(--color-1);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
 .loading,
 .error {
   display: flex;

--- a/app/client/ui/views/review-view.ts
+++ b/app/client/ui/views/review-view.ts
@@ -23,18 +23,28 @@ export class ReviewView extends LitElement {
       this.document = undefined;
       this.error = undefined;
 
-      const result = await DocumentService.find(this.documentId);
+      await this.loadDocument(this.documentId);
+    }
+  }
 
-      if (result.ok) {
-        this.document = result.data;
-      } else {
-        this.error = result.error;
-      }
+  private async loadDocument(documentId: string) {
+    const result = await DocumentService.find(documentId);
+
+    if (result.ok) {
+      this.document = result.data;
+    } else {
+      this.error = result.error;
     }
   }
 
   private handleBack() {
     navigate("");
+  }
+
+  private async handleClassificationChange() {
+    if (!this.documentId) return;
+
+    await this.loadDocument(this.documentId);
   }
 
   render() {
@@ -61,8 +71,11 @@ export class ReviewView extends LitElement {
         ></hd-blob-viewer>
       </div>
       <div class="panel classification-panel">
-        <h2>${this.document.filename}</h2>
-        <p class="status">${this.document.status}</p>
+        <hd-classification-panel
+          .documentId=${this.documentId ?? ""}
+          @validate=${this.handleClassificationChange}
+          @update=${this.handleClassificationChange}
+        ></hd-classification-panel>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

- Add `hd-markings-list` pure element rendering security marking strings as badge tags with empty state
- Add `hd-classification-panel` stateful module with view/validate/update modes, event-driven state refresh
- Integrate classification panel into review view, replacing placeholder content with full composition
- Remove redundant component-level barrel imports and orphaned placeholder CSS rules

Closes #89

## Changes

- **New**: `app/client/ui/elements/markings-list.ts` + `.module.css` — pure element, badge-styled marking tags
- **New**: `app/client/ui/modules/classification-panel.ts` + `.module.css` — three-mode panel (view, validate, update) with confidence badge colors, form handling, and custom event dispatch
- **Modified**: `app/client/ui/views/review-view.ts` — replaced placeholder with `<hd-classification-panel>`, added `handleClassificationChange` for document re-fetch on validate/update
- **Modified**: `app/client/ui/views/review-view.module.css` — removed orphaned `.classification-panel h2` and `.status` rules
- **Modified**: barrel files — added `MarkingsList` and `ClassificationPanel` exports

## Note

This PR also completes the review view composition originally scoped for #90. That task will be repurposed as a comprehensive evaluation of the overall web application architecture, layout, and functionality.