### PR TITLE
Optimize web client shared styles and architecture

### DIFF
--- a/.claude/context/guides/.archive/90-web-client-review.md
+++ b/.claude/context/guides/.archive/90-web-client-review.md
@@ -1,0 +1,1023 @@
+# 90 — Web Client Review & Optimization
+
+## Context
+
+Final task in Objective 5 (Document Review View). The review view composition was completed as a remediation in #89. This guide captures source code optimizations identified during a holistic review of the web client architecture.
+
+## 1. Shared Styles — New CSS Modules
+
+Extract duplicated CSS patterns into `app/client/design/styles/`.
+
+### `inputs.module.css`
+
+Form input base styles shared across toolbar inputs, form fields, and upload fields.
+
+```css
+.input {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+```
+
+Consumers add the `.input` class to `<input>`, `<select>`, and `<textarea>` elements. Component CSS retains layout-specific overrides (e.g., `.search-input { flex: 1; min-width: 12rem; }`).
+
+### `labels.module.css`
+
+Section label typography for form labels and section headers.
+
+```css
+.label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+Consumers add the `.label` class to `<label>`, `<span>`, and heading elements that serve as section labels.
+
+### `cards.module.css`
+
+Card container pattern shared by document-card and prompt-card.
+
+```css
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s;
+}
+```
+
+### Button color variants in `buttons.module.css`
+
+Add semantic color variants to the existing `.btn` base:
+
+```css
+.btn-blue:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+  &:hover { background: var(--blue-bg); }
+}
+
+.btn-green:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+  &:hover { background: var(--green-bg); }
+}
+
+.btn-red:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+  &:hover { background: var(--red-bg); }
+}
+
+.btn-yellow:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+  &:hover { background: var(--yellow-bg); }
+}
+
+.btn-muted:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+  &:hover { background: var(--bg-2); }
+}
+```
+
+## 2. Component CSS — Consume Shared Styles
+
+For each component, import the relevant shared styles into `static styles`, add shared classes to template markup, and remove the duplicated CSS rules from the component's `.module.css`.
+
+---
+
+### `document-card.ts`
+
+**Imports** — add `cardStyles`:
+
+```typescript
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import cardStyles from "@styles/cards.module.css";
+import styles from "./document-card.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [buttonStyles, badgeStyles, cardStyles, styles];
+```
+
+**Template** — replace button class names:
+
+```html
+<button
+  class="btn btn-blue"
+  ?disabled=${this.classifyDisabled}
+  @click=${this.handleClassify}
+>
+  Classify
+</button>
+<button class="btn btn-green" @click=${this.handleReview}>
+  Review
+</button>
+<button
+  class="btn btn-red"
+  ?disabled=${this.classifying}
+  @click=${this.handleDelete}
+>
+  Delete
+</button>
+```
+
+**CSS removals** from `document-card.module.css`:
+
+Remove the `.card` base block (shared `cardStyles` provides it):
+```css
+/* REMOVE */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s;
+}
+```
+
+Remove all button color blocks:
+```css
+/* REMOVE */
+.classify-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.review-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.delete-btn:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+
+  &:hover {
+    background: var(--red-bg);
+  }
+}
+```
+
+---
+
+### `prompt-card.ts`
+
+**Imports** — add `cardStyles`:
+
+```typescript
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import cardStyles from "@styles/cards.module.css";
+import styles from "./prompt-card.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [buttonStyles, badgeStyles, cardStyles, styles];
+```
+
+**Template** — replace button class names:
+
+```html
+<button
+  class="btn ${p.active ? "btn-yellow" : "btn-green"}"
+  @click=${this.handleToggleActive}
+>
+  ${p.active ? "Deactivate" : "Activate"}
+</button>
+<button class="btn btn-red" @click=${this.handleDelete}>
+  Delete
+</button>
+```
+
+**CSS removals** from `prompt-card.module.css`:
+
+Remove the `.card` base block (identical to document-card):
+```css
+/* REMOVE */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s;
+}
+```
+
+Remove all button color blocks:
+```css
+/* REMOVE */
+.toggle-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.toggle-btn.deactivate:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+
+  &:hover {
+    background: var(--yellow-bg);
+  }
+}
+
+.delete-btn:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+
+  &:hover {
+    background: var(--red-bg);
+  }
+}
+```
+
+---
+
+### `confirm-dialog.ts`
+
+**Template** — replace button class name:
+
+```html
+<button class="btn btn-red" @click=${this.handleConfirm}>
+  Confirm
+</button>
+```
+
+**CSS removal** from `confirm-dialog.module.css`:
+
+```css
+/* REMOVE */
+.confirm-btn:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+
+  &:hover {
+    background: var(--red-bg);
+  }
+}
+```
+
+---
+
+### `document-grid.ts`
+
+**Imports** — add `inputStyles`:
+
+```typescript
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import styles from "./document-grid.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [buttonStyles, inputStyles, styles];
+```
+
+**Template** — add `.input` class to search/filter/sort elements, replace button class:
+
+```html
+<div class="toolbar">
+  <input
+    type="search"
+    class="input search-input"
+    placeholder="Search documents..."
+    .value=${this.search}
+    @input=${this.handleSearchInput}
+  />
+  <select class="input filter-select" @change=${this.handleStatusFilter}>
+    ...
+  </select>
+  <select class="input sort-select" @change=${this.handleSort}>
+    ...
+  </select>
+  ${this.selectedIds.size > 0
+    ? html`
+        <button class="btn btn-blue" @click=${this.handleBulkClassify}>
+          Classify ${this.selectedIds.size} Documents
+        </button>
+      `
+    : nothing}
+</div>
+```
+
+**CSS removals** from `document-grid.module.css`:
+
+Remove the base input styling block (shared `inputStyles` provides it):
+```css
+/* REMOVE */
+.search-input,
+.filter-select,
+.sort-select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+```
+
+Remove the button color block:
+```css
+/* REMOVE */
+.bulk-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+```
+
+**Retained** — layout-specific overrides stay in module CSS:
+```css
+/* KEEP */
+.search-input {
+  flex: 1;
+  min-width: 12rem;
+}
+```
+
+---
+
+### `prompt-list.ts`
+
+**Imports** — add `inputStyles`:
+
+```typescript
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import styles from "./prompt-list.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [buttonStyles, inputStyles, styles];
+```
+
+**Template** — add `.input` class to search/filter/sort elements, replace button class:
+
+```html
+<div class="toolbar">
+  <input
+    type="search"
+    class="input search-input"
+    placeholder="Search prompts..."
+    .value=${this.search}
+    @input=${this.handleSearchInput}
+  />
+  <button class="btn btn-blue" @click=${this.handleNew}>New</button>
+  <select class="input filter-select" @change=${this.handleStageFilter}>
+    ...
+  </select>
+  <select class="input sort-select" @change=${this.handleSort}>
+    ...
+  </select>
+</div>
+```
+
+**CSS removals** from `prompt-list.module.css`:
+
+Remove the base input styling block:
+```css
+/* REMOVE */
+.search-input,
+.filter-select,
+.sort-select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+```
+
+Remove the button color block:
+```css
+/* REMOVE */
+.new-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+```
+
+**Retained** — layout-specific overrides stay in module CSS:
+```css
+/* KEEP */
+.search-input {
+  grid-column: span 3;
+}
+
+.filter-select,
+.sort-select {
+  grid-column: span 2;
+}
+```
+
+---
+
+### `classification-panel.ts`
+
+**Imports** — add `inputStyles` and `labelStyles`:
+
+```typescript
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import labelStyles from "@styles/labels.module.css";
+import styles from "./classification-panel.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [badgeStyles, buttonStyles, inputStyles, labelStyles, styles];
+```
+
+**Template — `renderViewMode()`** — replace button classes, add `.label` to section labels:
+
+```html
+<div class="section">
+  <span class="label">Classification</span>
+  ...
+</div>
+
+<div class="section">
+  <span class="label">Markings Found</span>
+  ...
+</div>
+
+<div class="section">
+  <span class="label">Rationale</span>
+  ...
+</div>
+
+...
+
+<div class="actions">
+  <button
+    class="btn btn-green"
+    @click=${() => (this.mode = "validate")}
+  >
+    Validate
+  </button>
+  <button class="btn btn-blue" @click=${() => (this.mode = "update")}>
+    Update
+  </button>
+</div>
+```
+
+**Template — `renderValidateMode()`** — add `.label` to labels, `.input` to inputs, replace button classes:
+
+```html
+<div class="field">
+  <label class="label" for="validated_by">Your Name</label>
+  <input
+    class="input"
+    id="validated_by"
+    name="validated_by"
+    type="text"
+    required
+    .value=${this.classification?.validated_by ?? ""}
+  />
+</div>
+
+...
+
+<div class="actions">
+  <button
+    type="submit"
+    class="btn btn-green"
+    ?disabled=${this.submitting}
+  >
+    ${this.submitting ? "Validating..." : "Validate"}
+  </button>
+  <button
+    type="button"
+    class="btn btn-muted"
+    @click=${this.handleCancel}
+    ?disabled=${this.submitting}
+  >
+    Cancel
+  </button>
+</div>
+```
+
+**Template — `renderUpdateMode()`** — add `.label` to labels, `.input` to inputs, replace button classes:
+
+```html
+<div class="field">
+  <label class="label" for="classification">Classification</label>
+  <input
+    class="input"
+    id="classification"
+    name="classification"
+    type="text"
+    required
+    .value=${c.classification}
+  />
+</div>
+
+<div class="field">
+  <label class="label" for="rationale">Rationale</label>
+  <textarea
+    class="input"
+    id="rationale"
+    name="rationale"
+    required
+    .value=${c.rationale}
+  ></textarea>
+</div>
+
+<div class="field">
+  <label class="label" for="updated_by">Your Name</label>
+  <input class="input" id="updated_by" name="updated_by" type="text" required />
+</div>
+
+...
+
+<div class="actions">
+  <button
+    type="submit"
+    class="btn btn-blue"
+    ?disabled=${this.submitting}
+  >
+    ${this.submitting ? "Updating..." : "Update"}
+  </button>
+  <button
+    type="button"
+    class="btn btn-muted"
+    @click=${this.handleCancel}
+    ?disabled=${this.submitting}
+  >
+    Cancel
+  </button>
+</div>
+```
+
+**CSS removals** from `classification-panel.module.css`:
+
+Remove section label block:
+```css
+/* REMOVE */
+.section-label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+Remove field label block:
+```css
+/* REMOVE */
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+Remove field input/textarea block:
+```css
+/* REMOVE */
+.field input,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+```
+
+Remove all button color blocks:
+```css
+/* REMOVE */
+.validate-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.update-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+```
+
+**Retained** — textarea sizing override stays in module CSS:
+```css
+/* KEEP */
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+```
+
+---
+
+### `prompt-form.ts`
+
+**Imports** — add `inputStyles` and `labelStyles`:
+
+```typescript
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import labelStyles from "@styles/labels.module.css";
+import styles from "./prompt-form.module.css";
+```
+
+**Static styles:**
+
+```typescript
+static styles = [buttonStyles, inputStyles, labelStyles, styles];
+```
+
+**Template** — add `.label` to labels, `.input` to inputs/selects/textareas, replace button classes:
+
+```html
+<div class="field">
+  <label class="label" for="name">Name</label>
+  <input
+    class="input"
+    id="name"
+    name="name"
+    type="text"
+    required
+    .value=${p?.name ?? ""}
+  />
+</div>
+<div class="field">
+  <label class="label" for="stage">Stage</label>
+  <select
+    class="input"
+    id="stage"
+    name="stage"
+    required
+    ?disabled=${this.isEdit}
+    @change=${this.handleStageChange}
+  >
+    ...
+  </select>
+</div>
+${this.renderDefaults()}
+<div class="field">
+  <label class="label" for="instructions">Instructions</label>
+  <textarea
+    class="input instructions"
+    id="instructions"
+    name="instructions"
+    required
+    .value=${p?.instructions ?? ""}
+  ></textarea>
+</div>
+<div class="field">
+  <label class="label" for="description">Description</label>
+  <textarea
+    class="input"
+    id="descripion"
+    name="description"
+    .value=${p?.description ?? ""}
+  ></textarea>
+</div>
+${this.renderError()}
+<div class="actions">
+  <button
+    type="submit"
+    class="btn btn-green"
+    ?disabled=${this.submitting}
+  >
+    ${this.submitting ? "Saving..." : "Save"}
+  </button>
+  <button
+    type="button"
+    class="btn btn-muted"
+    @click=${this.handleCancel}
+    ?disabled=${this.submitting}
+  >
+    Cancel
+  </button>
+</div>
+```
+
+**`renderDefaults()`** — no changes. The `<h4>` headings inside the defaults panel are content headings, not form labels. They retain their own styling in component CSS.
+
+**CSS removals** from `prompt-form.module.css`:
+
+Remove field label block:
+```css
+/* REMOVE */
+.field label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+```
+
+Remove field input/select/textarea block:
+```css
+/* REMOVE */
+.field input,
+.field select,
+.field textarea {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+```
+
+**Retained** — defaults-content h4 stays as-is (content heading, not a form label):
+```css
+/* KEEP */
+.defaults-content h4 {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+```
+
+Remove all button color blocks:
+```css
+/* REMOVE */
+.save-btn:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.cancel-btn:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}
+```
+
+**Retained** — textarea sizing overrides stay in module CSS:
+```css
+/* KEEP */
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.field textarea.instructions {
+  min-height: 12rem;
+  flex: 1;
+}
+```
+
+---
+
+### `document-upload.ts`
+
+**Template** — replace button class names:
+
+```html
+<button
+  class="btn btn-yellow"
+  @click=${this.handleClear}
+  ?disabled=${this.uploading}
+>
+  ${allSettled ? "Done" : "Clear"}
+</button>
+
+<button
+  class="btn btn-blue"
+  @click=${this.handleUpload}
+  ?disabled=${!this.canUpload}
+>
+  Upload
+</button>
+
+<button
+  class="btn btn-red"
+  @click=${() => this.handleRemove(index)}
+>
+  Remove
+</button>
+```
+
+**CSS removals** from `document-upload.module.css`:
+
+```css
+/* REMOVE */
+.upload-btn:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.remove-btn {
+  padding: var(--space-1) var(--space-2);
+  border-color: var(--red);
+  color: var(--red);
+
+  &:hover:not(:disabled) {
+    background: var(--red-bg);
+  }
+}
+
+.clear-btn:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+
+  &:hover {
+    background: var(--yellow-bg);
+  }
+}
+```
+
+**Note**: The `.remove-btn` had `padding: var(--space-1) var(--space-2)` for compact sizing. After removal, add a component-specific padding override if the default `.btn` padding is too large. If it looks fine with the default, no override needed.
+
+**Note**: `.field-input` in upload uses different sizing (`--space-1`, `--text-xs`, `--bg` not `--bg-1`) — keep component-specific, do not extract to shared `inputStyles`.
+
+## 3. Classification Panel — Disable Actions When Validated
+
+In `classification-panel.ts`, `renderViewMode()`:
+
+```typescript
+private get isValidated(): boolean {
+  return !!this.classification?.validated_by;
+}
+```
+
+Add `?disabled=${this.isValidated}` to both the Validate and Update buttons.
+
+## 4. Document Card — Show External ID and Platform
+
+In `document-card.ts`, add to the `.meta` section in `render()`:
+
+```typescript
+<span>${doc.external_platform} #${doc.external_id}</span>
+```
+
+Renders as e.g. "GitHub #12345" alongside existing page count, size, and date metadata.
+
+## 5. Fix `querySelector<any>` Type Erasure
+
+**`documents-view.ts:16`**: Change `querySelector<any>("hd-document-grid")` → `querySelector("hd-document-grid")`
+
+**`prompts-view.ts:33`**: Change `querySelector<any>("hd-prompt-list")` → `querySelector("hd-prompt-list")`
+
+The `HTMLElementTagNameMap` declarations on each component already provide the correct return type when using the tag name string literal.
+
+## 6. Domain Barrel Exports — Named Exports Only
+
+**`app/client/domains/prompts/index.ts`**:
+```typescript
+export type {
+  Prompt,
+  PromptStage,
+  StageContent,
+  CreatePromptCommand,
+  UpdatePromptCommand,
+  SearchRequest,
+} from "./prompt";
+export { PromptService } from "./service";
+```
+
+**`app/client/domains/storage/index.ts`**:
+```typescript
+export type { BlobMeta, BlobList } from "./blob";
+export { StorageService } from "./service";
+export type { StorageListParams } from "./service";
+```
+
+## Verification
+
+1. `bun run build` succeeds
+2. `go vet ./...` passes
+3. Visual verification:
+   - Documents view: cards render with external_id/platform, button colors match
+   - Prompts view: form inputs, labels, button colors match
+   - Review view: classification panel validate/update disabled when validated
+   - All views: no visual regressions from CSS extraction

--- a/.claude/context/sessions/90-web-client-review.md
+++ b/.claude/context/sessions/90-web-client-review.md
@@ -1,0 +1,61 @@
+# 90 — Web Client Review & Optimization
+
+## Summary
+
+Holistic review of the web client architecture in its final Objective 5 state. Identified and extracted duplicated CSS patterns into shared styles, fixed component architecture friction points, and updated the web-development skill documentation to reflect the current codebase. No new features — purely optimization and documentation alignment.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Shared style granularity | 5 modules (badge, buttons, cards, inputs, labels) | Each targets a distinct, frequently duplicated pattern. Avoids a single monolithic shared file. |
+| Button color variants | `.btn-blue`, `.btn-green`, `.btn-red`, `.btn-yellow`, `.btn-muted` in `buttons.module.css` | Replaces 14+ component-specific button color classes with 5 composable variants |
+| Upload `.field-input` not extracted | Kept component-specific | Different sizing/background from the shared `.input` pattern — forced extraction would require overrides |
+| `querySelector` typing | Remove `<any>`, rely on `HTMLElementTagNameMap` | Tag name string literals already provide correct return types via the global interface declarations |
+| Barrel exports | Named exports only, no `export *` | Explicit exports make the public API clear and prevent accidental re-exports |
+| `defaults-content h4` not shared | Kept in prompt-form CSS | Content headings are semantically different from form labels despite identical typography |
+| Disable validated classification actions | `?disabled` bound to `!!classification.validated_by` | Prevents re-validation or update of already-validated classifications |
+
+## Files Modified
+
+### New Files
+- `app/client/design/styles/inputs.module.css` — shared form input styles
+- `app/client/design/styles/labels.module.css` — shared section label typography
+- `app/client/design/styles/cards.module.css` — shared card container pattern
+- `.claude/skills/web-development/references/lifecycles.md` — Lit lifecycle hooks reference
+
+### Modified Files — Source
+- `app/client/design/styles/buttons.module.css` — added `.btn-blue`, `.btn-green`, `.btn-red`, `.btn-yellow`, `.btn-muted`
+- `app/client/ui/elements/document-card.ts` + `.module.css` — shared styles, external_id/platform in meta
+- `app/client/ui/elements/prompt-card.ts` + `.module.css` — shared styles
+- `app/client/ui/elements/confirm-dialog.ts` + `.module.css` — shared button variant
+- `app/client/ui/modules/classification-panel.ts` + `.module.css` — shared styles, disable when validated
+- `app/client/ui/modules/document-grid.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/prompt-list.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/prompt-form.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/document-upload.ts` + `.module.css` — shared button variants
+- `app/client/ui/views/documents-view.ts` — querySelector typing fix
+- `app/client/ui/views/prompts-view.ts` — querySelector typing fix
+- `app/client/domains/prompts/index.ts` — named exports
+- `app/client/domains/storage/index.ts` — named exports
+
+### Modified Files — Documentation
+- `.claude/skills/web-development/SKILL.md` — directory tree, lifecycles reference link
+- `.claude/skills/web-development/references/build.md` — path aliases
+- `.claude/skills/web-development/references/css.md` — layer count, shared styles section
+- `.claude/skills/web-development/references/services.md` — import paths, barrel convention
+- `.claude/skills/web-development/references/state.md` — event name, querySelector
+- `.claude/skills/web-development/references/components.md` — querySelector
+
+## Patterns Established
+
+- Shared styles compose with component CSS via `static styles` arrays — shared provides base, component retains layout overrides
+- Button color variants use semantic names (`.btn-blue`) not domain names (`.classify-btn`) for reusability
+- `querySelector` on tag name strings returns typed results via `HTMLElementTagNameMap` — no `<any>` needed
+- Domain barrel exports use explicit named exports, never `export *`
+
+## Validation Results
+
+- `bun run build` succeeds
+- `go vet ./...` passes
+- Playwright browser verification: all three views render correctly with shared styles, disabled validation buttons confirmed, external_id/platform metadata visible on document cards

--- a/.claude/plans/happy-herding-origami.md
+++ b/.claude/plans/happy-herding-origami.md
@@ -1,0 +1,138 @@
+# Task #90 — Web Client Review & Optimization
+
+## Context
+
+This is the final task in Objective 5 (Document Review View). The review view composition was completed as a remediation in #89. This session focuses on a holistic review of the web client, identifying optimization opportunities, and producing an implementation guide for source code changes. Documentation/skill updates are applied directly (not in the guide).
+
+## Execution Strategy
+
+Two phases: (1) implementation guide for source code changes, (2) documentation/skill updates reflecting the final implementation.
+
+---
+
+## Phase 1: Implementation Guide (Source Code Changes)
+
+### 1A. Shared Styles — New CSS Modules
+
+Extract duplicated CSS patterns into `app/client/design/styles/`:
+
+**`inputs.module.css`** — Form input base styles
+- Classes: `.input` (covers `input`, `select`, `textarea`)
+- Extracted from: `classification-panel.module.css:140-159`, `prompt-form.module.css:51-71`, `document-grid.module.css:17-32`, `prompt-list.module.css:17-32`, `document-upload.module.css:129-147`
+- Includes: padding, border, border-radius, background, color, font, focus-visible, disabled states
+
+**`labels.module.css`** — Section label typography
+- Classes: `.label`
+- Extracted from: `classification-panel.module.css:37-43,132-138`, `prompt-form.module.css:43-49,108-113`
+- Includes: text-xs, font-mono, color-1, uppercase, letter-spacing
+
+**`cards.module.css`** — Card container pattern
+- Classes: `.card`
+- Extracted from: `document-card.module.css:5-14`, `prompt-card.module.css:5-14` (identical)
+- Includes: flex column, gap-3, padding-4, bg-1, border, radius-md, transition
+
+**Button color variants in `buttons.module.css`**
+- Add: `.btn-blue`, `.btn-green`, `.btn-red`, `.btn-yellow`, `.btn-muted`
+- Pattern: `border-color`, `color`, `:hover { background }` with `:not(:disabled)` guard
+- Replaces: `.classify-btn`, `.review-btn`, `.delete-btn`, `.validate-btn`, `.update-btn`, `.cancel-btn`, `.save-btn`, `.toggle-btn`, `.upload-btn`, `.clear-btn`, `.bulk-btn`, `.new-btn`, `.confirm-btn`, `.remove-btn`
+
+### 1B. Component CSS — Consume Shared Styles
+
+Update each component to import and use the new shared styles, removing duplicated CSS:
+
+| Component | Import | Replace |
+|-----------|--------|---------|
+| `document-card.ts` + `.module.css` | `cardStyles` | Remove `.card` block, use `.btn-blue`, `.btn-green`, `.btn-red` |
+| `prompt-card.ts` + `.module.css` | `cardStyles` | Remove `.card` block, use `.btn-green`, `.btn-yellow`, `.btn-red` |
+| `confirm-dialog.ts` + `.module.css` | — | Use `.btn-red` |
+| `document-grid.ts` + `.module.css` | `inputStyles` | Remove `.search-input/.filter-select/.sort-select` base block, use `.btn-blue` |
+| `prompt-list.ts` + `.module.css` | `inputStyles` | Remove `.search-input/.filter-select/.sort-select` base block, use `.btn-blue` |
+| `classification-panel.ts` + `.module.css` | `inputStyles`, `labelStyles` | Remove `.field input/textarea`, `.field label`, `.section-label` base blocks, use `.btn-green`, `.btn-blue`, `.btn-muted` |
+| `prompt-form.ts` + `.module.css` | `inputStyles`, `labelStyles` | Remove `.field input/select/textarea`, `.field label`, `.defaults-content h4` base blocks, use `.btn-green`, `.btn-muted` |
+| `document-upload.ts` + `.module.css` | — | Use `.btn-blue`, `.btn-yellow`, `.btn-red` |
+
+### 1C. Classification Panel — Disable Actions When Validated
+
+In `classification-panel.ts`, disable the Validate and Update buttons when `this.classification?.validated_by` is truthy. The `renderViewMode()` method (line 188-198) should add `?disabled` bindings.
+
+### 1D. Document Card — Show External ID and Platform
+
+In `document-card.ts`, add `external_id` and `external_platform` to the card's meta section. These fields exist on the `Document` type already (`document.ts:11-12`).
+
+### 1E. Fix `querySelector<any>` Type Erasure
+
+In `documents-view.ts:16` and `prompts-view.ts:33`, replace `querySelector<any>` with proper type assertions using `HTMLElementTagNameMap`:
+
+```typescript
+// documents-view.ts
+this.renderRoot.querySelector("hd-document-grid")?.refresh();
+// prompts-view.ts
+this.renderRoot.querySelector("hd-prompt-list")?.refresh();
+```
+
+`querySelector` with the tag name string already returns the correct type via `HTMLElementTagNameMap` declaration — no `<any>` or cast needed.
+
+### 1F. Domain Barrel Exports — Named Exports Only
+
+Fix `prompts/index.ts` and `storage/index.ts` to use named exports instead of `export *`:
+
+```typescript
+// prompts/index.ts
+export type { Prompt, PromptStage, StageContent, CreatePromptCommand, UpdatePromptCommand, SearchRequest } from "./prompt";
+export { PromptService } from "./service";
+
+// storage/index.ts
+export type { BlobMeta, BlobList } from "./blob";
+export { StorageService } from "./service";
+export type { StorageListParams } from "./service";
+```
+
+Then verify no consumers rely on barrel imports that would break.
+
+---
+
+## Verification
+
+1. `bun run build` succeeds
+2. `go vet ./...` passes
+3. Visual verification:
+   - Documents view: cards render with external_id/platform, button colors match
+   - Prompts view: form inputs, labels, button colors match
+   - Review view: classification panel validate/update disabled when validated
+   - All views: no visual regressions from CSS extraction
+
+## Files Modified
+
+**New files:**
+- `app/client/design/styles/inputs.module.css`
+- `app/client/design/styles/labels.module.css`
+- `app/client/design/styles/cards.module.css`
+
+**Modified files:**
+- `app/client/design/styles/buttons.module.css` — add color variants
+- `app/client/ui/elements/document-card.ts` + `.module.css` — external_id/platform, shared styles
+- `app/client/ui/elements/prompt-card.ts` + `.module.css` — shared styles
+- `app/client/ui/elements/confirm-dialog.module.css` — shared button variant
+- `app/client/ui/modules/classification-panel.ts` + `.module.css` — disable when validated, shared styles
+- `app/client/ui/modules/document-grid.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/prompt-list.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/prompt-form.ts` + `.module.css` — shared styles
+- `app/client/ui/modules/document-upload.module.css` — shared button variants
+- `app/client/ui/views/documents-view.ts` — fix querySelector typing
+- `app/client/ui/views/prompts-view.ts` — fix querySelector typing
+- `app/client/domains/prompts/index.ts` — named exports
+- `app/client/domains/storage/index.ts` — named exports
+
+---
+
+## Phase 2: Documentation & Skill Updates (Post-Implementation)
+
+Applied after implementation to reflect the actual final state of the codebase:
+
+- `.claude/skills/web-development/SKILL.md` — update directory tree with all current components
+- `.claude/skills/web-development/references/build.md` — fix stale `@app/*` alias → current path aliases
+- `.claude/skills/web-development/references/css.md` — fix "three layers" → "four layers", update code example, document new shared style modules
+- `.claude/skills/web-development/references/services.md` — fix `@app/` import paths → `@core`/`@domains/*`, update barrel export convention (named exports only)
+- `.claude/skills/web-development/references/state.md` — fix `prompt-select` → `select` event name
+- `.claude/skills/web-development/references/components.md` — update querySelector examples to reflect proper typing, update code examples for shared styles
+- `.claude/skills/web-development/references/lifecycles.md` (new) — Lit lifecycle hook patterns: `connectedCallback`, `disconnectedCallback`, `updated`, `willUpdate`

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -83,6 +83,10 @@ History API router at `app/client/core/router/`. Routes are defined in `app/clie
 
 Native `Bun.build()` API (no Vite). CSS modules plugin at `app/plugins/css-modules.ts` intercepts `*.module.css` and emits `CSSStyleSheet`. Two-terminal dev workflow: `bun run watch` rebuilds client assets, `air` rebuilds Go on dist/ changes. Output: fixed `app.js` + `app.css` for stable `go:embed`.
 
+### Lifecycles — [references/lifecycles.md](references/lifecycles.md)
+
+Lit lifecycle hooks and when to use each: `connectedCallback` for initial data fetch, `disconnectedCallback` for cleanup, `updated(changed)` for host attribute reflection and property-change reactions, `willUpdate(changed)` for route parameter change handling in views.
+
 ### Go Integration — [references/go-integration.md](references/go-integration.md)
 
 Single shell pattern: `app/app.go` embeds `dist/*`, `server/layouts/*`, `server/views/*`. Catch-all `/{path...}` route serves the HTML shell. Template variables: `{{ .BasePath }}`, `{{ .Title }}`, `{{ .Bundle }}`. `<base href>` tag enables client-side router path resolution.
@@ -124,7 +128,7 @@ app/client/
 │   └── router/                        # History API router, navigate()
 ├── design/                            # global design system
 │   ├── core/                          # tokens.css, reset.css, theme.css
-│   ├── styles/                        # shared component styles (badge, buttons)
+│   ├── styles/                        # shared component styles (badge, buttons, cards, inputs, labels)
 │   ├── app/                           # app-shell styles
 │   └── index.css                      # layer declarations + imports
 ├── domains/                           # data types and service contracts
@@ -134,13 +138,16 @@ app/client/
 │   └── storage/                       # BlobMeta, StorageService
 └── ui/                                # everything that renders (flat per tier)
     ├── elements/                      # pure elements — props in, events out
-    │   ├── confirm-dialog.ts
+    │   ├── blob-viewer.ts
     │   ├── classify-progress.ts
+    │   ├── confirm-dialog.ts
     │   ├── document-card.ts
+    │   ├── markings-list.ts
     │   ├── pagination-controls.ts
     │   ├── prompt-card.ts
     │   └── index.ts                   # barrel
     ├── modules/                       # stateful capability units
+    │   ├── classification-panel.ts
     │   ├── document-grid.ts
     │   ├── document-upload.ts
     │   ├── prompt-form.ts

--- a/.claude/skills/web-development/references/build.md
+++ b/.claude/skills/web-development/references/build.md
@@ -62,19 +62,26 @@ Air's `.air.toml` configuration:
 
 This separation means Bun handles TypeScript/CSS compilation and Air handles Go compilation + server restart. Changes to client source trigger Bun → writes to `dist/` → Air detects dist change → restarts server.
 
-## Path Alias
+## Path Aliases
 
-`@app/*` resolves to `app/client/*` via `tsconfig.json` paths:
+Defined in `tsconfig.json` paths and mirrored in the Bun build plugin:
 
 ```json
 {
     "compilerOptions": {
-        "paths": { "@app/*": ["./client/*"] }
+        "paths": {
+            "@core": ["./client/core/index.ts"],
+            "@core/*": ["./client/core/*"],
+            "@design/*": ["./client/design/*"],
+            "@domains/*": ["./client/domains/*"],
+            "@styles/*": ["./client/design/styles/*"],
+            "@ui/*": ["./client/ui/*"]
+        }
     }
 }
 ```
 
-Use for all cross-directory imports within the client source.
+See SKILL.md **Import Convention** for usage patterns.
 
 ## TypeScript Configuration
 

--- a/.claude/skills/web-development/references/components.md
+++ b/.claude/skills/web-development/references/components.md
@@ -22,7 +22,7 @@ export class DocumentsView extends LitElement {
 
   private handleUploadComplete() {
     this.showUpload = false;
-    this.renderRoot.querySelector<any>("hd-document-grid")?.refresh();
+    this.renderRoot.querySelector("hd-document-grid")?.refresh();
   }
 
   render() {

--- a/.claude/skills/web-development/references/css.md
+++ b/.claude/skills/web-development/references/css.md
@@ -2,19 +2,20 @@
 
 ## Cascade Layers
 
-Herald uses three layers with explicit precedence. Tokens are lowest priority (easily overridden), theme is highest (final say on body-level styling).
+Herald uses four layers with explicit precedence. Tokens are lowest priority (easily overridden), app is highest.
 
 ```css
 /* design/index.css */
-@layer tokens, reset, theme;
+@layer tokens, reset, theme, app;
 
 @import url(./core/tokens.css);
 @import url(./core/reset.css);
 @import url(./core/theme.css);
+
 @import url(./app/app.css);
 ```
 
-`app.css` is unlayered (highest implicit priority) and handles the application shell layout.
+`app.css` is in the `app` layer (highest priority) and handles the application shell layout.
 
 ## Design Tokens
 
@@ -84,6 +85,31 @@ Use `:host` for component-level layout and design tokens for all values:
 h3 { color: var(--color); }
 p { color: var(--color-1); }
 ```
+
+## Shared Component Styles
+
+Reusable CSS modules in `app/client/design/styles/` imported via `@styles/*`. Components add these to `static styles` arrays alongside their own `*.module.css`.
+
+| Module | Class | Purpose |
+|--------|-------|---------|
+| `badge.module.css` | `.badge` + status variants (`.pending`, `.review`, `.complete`, etc.) | Status badges with semantic colors |
+| `buttons.module.css` | `.btn` + color variants (`.btn-blue`, `.btn-green`, `.btn-red`, `.btn-yellow`, `.btn-muted`) | Button base with semantic color overlays |
+| `cards.module.css` | `.card` | Flex column container with gap, padding, border, radius, transition |
+| `inputs.module.css` | `.input` | Text inputs, selects, and textareas with focus/disabled states |
+| `labels.module.css` | `.label` | Uppercase monospace section labels (form field labels, section headers) |
+
+Usage pattern:
+
+```typescript
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import cardStyles from "@styles/cards.module.css";
+import styles from "./document-card.module.css";
+
+static styles = [buttonStyles, badgeStyles, cardStyles, styles];
+```
+
+Shared styles provide base appearance. Component CSS retains layout-specific overrides (e.g., `.search-input { flex: 1; min-width: 12rem; }`). Button color variants compose with the `.btn` base: `class="btn btn-blue"`.
 
 ## Global CSS
 

--- a/.claude/skills/web-development/references/lifecycles.md
+++ b/.claude/skills/web-development/references/lifecycles.md
@@ -1,0 +1,92 @@
+# Lit Lifecycle Hooks
+
+Herald components use Lit's lifecycle hooks for data loading, cleanup, and reactive side effects. Each hook has a specific role — using the wrong one creates bugs (e.g., async work in `updated()` causes double-fetches).
+
+## `connectedCallback()`
+
+Called when the element is added to the DOM. Use for initial data fetching in modules that own their data.
+
+```typescript
+connectedCallback() {
+  super.connectedCallback();
+  this.fetchDocuments();
+}
+```
+
+Always call `super.connectedCallback()` first. This is the standard entry point for modules that load data on mount.
+
+## `disconnectedCallback()`
+
+Called when the element is removed from the DOM. Use for cleanup: timers, abort controllers, blob URLs, event listeners.
+
+```typescript
+disconnectedCallback() {
+  super.disconnectedCallback();
+  clearTimeout(this.searchTimer);
+  for (const controller of this.abortControllers.values()) {
+    controller.abort();
+  }
+}
+```
+
+Always call `super.disconnectedCallback()` first. Forgetting cleanup here causes memory leaks and orphaned network requests.
+
+## `updated(changed)`
+
+Called synchronously after the component re-renders. Receives a `Map<string, unknown>` of changed properties (keys are property names, values are previous values).
+
+**Use for synchronous side effects** — host attribute reflection, DOM measurements, focus management.
+
+```typescript
+updated(changed: Map<string, unknown>) {
+  if (changed.has("dragover")) {
+    this.toggleAttribute("dragover", this.dragover);
+  }
+}
+```
+
+**Also used for property-change reactions in modules** that need to trigger data loading when a `@property()` changes:
+
+```typescript
+updated(changed: Map<string, unknown>) {
+  if (changed.has("documentId") && this.documentId) {
+    this.loadClassification();
+  }
+}
+```
+
+This pattern is used by modules like `classification-panel` that receive a property from a parent view and need to load data when it changes. The async work happens in the called method, not in `updated()` itself.
+
+## `willUpdate(changed)`
+
+Called before the render cycle. Can be async but Lit does not await it — the render proceeds immediately. Use sparingly.
+
+**Use for async data loading triggered by route parameter changes** in views:
+
+```typescript
+async willUpdate(changed: Map<string, unknown>) {
+  if (changed.has("documentId") && this.documentId) {
+    this.document = undefined;
+    this.error = undefined;
+    await this.loadDocument(this.documentId);
+  }
+}
+```
+
+This pattern is used by `review-view` where the router sets `documentId` as an HTML attribute. The view clears state and loads data when the parameter changes.
+
+## When to Use Which
+
+| Scenario | Hook | Example |
+|----------|------|---------|
+| Initial data fetch on mount | `connectedCallback` | `document-grid`, `prompt-list` |
+| Cleanup timers/controllers/URLs | `disconnectedCallback` | `document-grid`, `document-upload` |
+| Host attribute reflection | `updated` | `document-upload` (dragover) |
+| React to `@property()` change in a module | `updated` | `classification-panel` (documentId) |
+| React to route param change in a view | `willUpdate` | `review-view` (documentId) |
+
+## Anti-Patterns
+
+- **Don't fetch data in `connectedCallback` when it depends on a property** — the property may not be set yet. Use `updated()` with a `changed.has()` guard instead.
+- **Don't use `willUpdate` for synchronous side effects** — use `updated()` which runs after render.
+- **Don't forget `super.*Callback()`** — Lit's base class needs these calls for internal bookkeeping.

--- a/.claude/skills/web-development/references/services.md
+++ b/.claude/skills/web-development/references/services.md
@@ -19,13 +19,13 @@ export interface SearchRequest {
 }
 ```
 
-`toQueryString()` in `@app/core` is generic (`<T extends object>`) and serializes any `SearchRequest` variant to query params.
+`toQueryString()` in `@core` is generic (`<T extends object>`) and serializes any `SearchRequest` variant to query params.
 
 ## Service Pattern
 
 ```typescript
 // documents/service.ts
-import { request, toQueryString, type Result, type PageResult } from '@app/core';
+import { request, toQueryString, type Result, type PageResult } from '@core';
 import type { Document, SearchRequest } from './document';
 
 const base = '/documents';
@@ -79,7 +79,7 @@ SSE endpoints return `AbortController`. The caller provides `StreamOptions` call
 
 ```typescript
 // classifications/service.ts
-import { stream, type StreamOptions } from '@app/core';
+import { stream, type StreamOptions } from '@core';
 
 const base = '/classifications';
 
@@ -99,14 +99,14 @@ export const ClassificationService = {
 - **`Result<T>` returns**: Request-response methods return `Result<T>` directly from `request()`
 - **`AbortController` returns**: Streaming methods return the controller from `stream()`
 - **No state**: Services never import `Signal`, `createContext`, or `@lit/context`
-- **Domain directories**: Services live in `app/client/<domain>/service.ts`, not in view directories
+- **Domain directories**: Services live in `app/client/domains/<domain>/service.ts`, not in view directories
 - **Barrel exports**: `export { DocumentService } from './service'` — named export, not `export *`
 
 ## Available Services
 
 | Service | Domain | Import |
 |---------|--------|--------|
-| `DocumentService` | `documents/` | `import { DocumentService } from '@app/documents'` |
-| `ClassificationService` | `classifications/` | `import { ClassificationService } from '@app/classifications'` |
-| `PromptService` | `prompts/` | `import { PromptService } from '@app/prompts'` |
-| `StorageService` | `storage/` | `import { StorageService } from '@app/storage'` |
+| `DocumentService` | `documents/` | `import { DocumentService } from '@domains/documents'` |
+| `ClassificationService` | `classifications/` | `import { ClassificationService } from '@domains/classifications'` |
+| `PromptService` | `prompts/` | `import { PromptService } from '@domains/prompts'` |
+| `StorageService` | `storage/` | `import { StorageService } from '@domains/storage'` |

--- a/.claude/skills/web-development/references/state.md
+++ b/.claude/skills/web-development/references/state.md
@@ -64,7 +64,7 @@ export class DocumentsView extends LitElement {
 
   private handleUploadComplete() {
     this.showUpload = false;
-    this.renderRoot.querySelector<any>("hd-document-grid")?.refresh();
+    this.renderRoot.querySelector("hd-document-grid")?.refresh();
   }
 
   render() {
@@ -100,7 +100,7 @@ Views call public methods on modules to trigger refreshes or state changes:
 // View refreshes the grid after an upload
 private handleUploadComplete() {
   this.showUpload = false;
-  this.renderRoot.querySelector<any>("hd-document-grid")?.refresh();
+  this.renderRoot.querySelector("hd-document-grid")?.refresh();
 }
 ```
 
@@ -120,8 +120,8 @@ Children dispatch `CustomEvent` with `bubbles: true, composed: true` to notify p
 ```typescript
 // Child dispatches
 this.dispatchEvent(
-  new CustomEvent("prompt-select", {
-    detail: { id: this.prompt.id },
+  new CustomEvent("select", {
+    detail: { prompt: this.prompt },
     bubbles: true,
     composed: true,
   }),
@@ -129,7 +129,7 @@ this.dispatchEvent(
 
 // Parent listens
 html`<hd-prompt-list
-  @prompt-select=${this.handleSelect}
+  @select=${this.handleSelect}
 ></hd-prompt-list>`;
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 secrets.json
 
+.playwright-cli
+
 # Binaries
 /bin/
 *.exe

--- a/app/client/design/styles/buttons.module.css
+++ b/app/client/design/styles/buttons.module.css
@@ -19,3 +19,48 @@
     cursor: not-allowed;
   }
 }
+
+.btn-blue:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+
+  &:hover {
+    background: var(--blue-bg);
+  }
+}
+
+.btn-green:not(:disabled) {
+  border-color: var(--green);
+  color: var(--green);
+
+  &:hover {
+    background: var(--green-bg);
+  }
+}
+
+.btn-red:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+
+  &:hover {
+    background: var(--red-bg);
+  }
+}
+
+.btn-yellow:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+
+  &:hover {
+    background: var(--yellow-bg);
+  }
+}
+
+.btn-muted:not(:disabled) {
+  border-color: var(--color-2);
+  color: var(--color-2);
+
+  &:hover {
+    background: var(--bg-2);
+  }
+}

--- a/app/client/design/styles/cards.module.css
+++ b/app/client/design/styles/cards.module.css
@@ -1,0 +1,10 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-1);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s;
+}

--- a/app/client/design/styles/inputs.module.css
+++ b/app/client/design/styles/inputs.module.css
@@ -1,0 +1,19 @@
+.input {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}

--- a/app/client/design/styles/labels.module.css
+++ b/app/client/design/styles/labels.module.css
@@ -1,0 +1,7 @@
+.label {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}

--- a/app/client/domains/prompts/index.ts
+++ b/app/client/domains/prompts/index.ts
@@ -1,2 +1,10 @@
-export * from "./prompt";
+export type {
+  CreatePromptCommand,
+  Prompt,
+  PromptStage,
+  SearchRequest,
+  StageContent,
+  UpdatePromptCommand,
+} from "./prompt";
+
 export { PromptService } from "./service";

--- a/app/client/domains/storage/index.ts
+++ b/app/client/domains/storage/index.ts
@@ -1,3 +1,3 @@
-export * from "./blob";
+export type { BlobMeta, BlobList } from "./blob";
 export { StorageService } from "./service";
 export type { StorageListParams } from "./service";

--- a/app/client/ui/elements/confirm-dialog.module.css
+++ b/app/client/ui/elements/confirm-dialog.module.css
@@ -30,12 +30,3 @@
   justify-content: flex-end;
   gap: var(--space-2);
 }
-
-.confirm-btn:not(:disabled) {
-  border-color: var(--red);
-  color: var(--red);
-
-  &:hover {
-    background: var(--red-bg);
-  }
-}

--- a/app/client/ui/elements/confirm-dialog.ts
+++ b/app/client/ui/elements/confirm-dialog.ts
@@ -33,7 +33,7 @@ export class ConfirmDialog extends LitElement {
           <p class="message">${this.message}</p>
           <div class="actions">
             <button class="btn" @click=${this.handleCancel}>Cancel</button>
-            <button class="btn confirm-btn" @click=${this.handleConfirm}>
+            <button class="btn btn-red" @click=${this.handleConfirm}>
               Confirm
             </button>
           </div>

--- a/app/client/ui/elements/document-card.module.css
+++ b/app/client/ui/elements/document-card.module.css
@@ -2,17 +2,6 @@
   display: block;
 }
 
-.card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  background: var(--bg-1);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-md);
-  transition: border-color 0.15s;
-}
-
 .card.selected {
   border-color: var(--blue);
 }
@@ -56,31 +45,4 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.classify-btn:not(:disabled) {
-  border-color: var(--blue);
-  color: var(--blue);
-
-  &:hover {
-    background: var(--blue-bg);
-  }
-}
-
-.review-btn:not(:disabled) {
-  border-color: var(--green);
-  color: var(--green);
-
-  &:hover {
-    background: var(--green-bg);
-  }
-}
-
-.delete-btn:not(:disabled) {
-  border-color: var(--red);
-  color: var(--red);
-
-  &:hover {
-    background: var(--red-bg);
-  }
 }

--- a/app/client/ui/elements/document-card.ts
+++ b/app/client/ui/elements/document-card.ts
@@ -7,6 +7,7 @@ import type { Document } from "@domains/documents";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
+import cardStyles from "@styles/cards.module.css";
 import styles from "./document-card.module.css";
 
 /**
@@ -15,7 +16,7 @@ import styles from "./document-card.module.css";
  */
 @customElement("hd-document-card")
 export class DocumentCard extends LitElement {
-  static styles = [buttonStyles, badgeStyles, styles];
+  static styles = [buttonStyles, badgeStyles, cardStyles, styles];
 
   @property({ type: Object }) document!: Document;
   @property({ type: Boolean }) classifying = false;
@@ -106,21 +107,22 @@ export class DocumentCard extends LitElement {
             : nothing}
           <span>${formatBytes(doc.size_bytes)}</span>
           <span>${formatDate(doc.uploaded_at)}</span>
+          <span>${doc.external_platform} #${doc.external_id}</span>
         </div>
 
         <div class="actions">
           <button
-            class="btn classify-btn"
+            class="btn btn-blue"
             ?disabled=${this.classifyDisabled}
             @click=${this.handleClassify}
           >
             Classify
           </button>
-          <button class="btn review-btn" @click=${this.handleReview}>
+          <button class="btn btn-green" @click=${this.handleReview}>
             Review
           </button>
           <button
-            class="btn delete-btn"
+            class="btn btn-red"
             ?disabled=${this.classifying}
             @click=${this.handleDelete}
           >

--- a/app/client/ui/elements/prompt-card.module.css
+++ b/app/client/ui/elements/prompt-card.module.css
@@ -2,17 +2,6 @@
   display: block;
 }
 
-.card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  background: var(--bg-1);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-md);
-  transition: border-color 0.15s;
-}
-
 .card.selected {
   border-color: var(--blue);
 }
@@ -58,31 +47,4 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-}
-
-.toggle-btn:not(:disabled) {
-  border-color: var(--green);
-  color: var(--green);
-
-  &:hover {
-    background: var(--green-bg);
-  }
-}
-
-.toggle-btn.deactivate:not(:disabled) {
-  border-color: var(--yellow);
-  color: var(--yellow);
-
-  &:hover {
-    background: var(--yellow-bg);
-  }
-}
-
-.delete-btn:not(:disabled) {
-  border-color: var(--red);
-  color: var(--red);
-
-  &:hover {
-    background: var(--red-bg);
-  }
 }

--- a/app/client/ui/elements/prompt-card.ts
+++ b/app/client/ui/elements/prompt-card.ts
@@ -5,6 +5,7 @@ import type { Prompt } from "@domains/prompts";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
+import cardStyles from "@styles/cards.module.css";
 import styles from "./prompt-card.module.css";
 
 /**
@@ -13,7 +14,7 @@ import styles from "./prompt-card.module.css";
  */
 @customElement("hd-prompt-card")
 export class PromptCard extends LitElement {
-  static styles = [buttonStyles, badgeStyles, styles];
+  static styles = [buttonStyles, badgeStyles, cardStyles, styles];
 
   @property({ type: Object }) prompt!: Prompt;
   @property({ type: Boolean }) selected = false;
@@ -72,12 +73,12 @@ export class PromptCard extends LitElement {
 
         <div class="actions">
           <button
-            class="btn toggle-btn ${p.active ? "deactivate" : ""}"
+            class="btn ${p.active ? "btn-yellow" : "btn-green"}"
             @click=${this.handleToggleActive}
           >
             ${p.active ? "Deactivate" : "Activate"}
           </button>
-          <button class="btn delete-btn" @click=${this.handleDelete}>
+          <button class="btn btn-red" @click=${this.handleDelete}>
             Delete
           </button>
         </div>

--- a/app/client/ui/modules/classification-panel.module.css
+++ b/app/client/ui/modules/classification-panel.module.css
@@ -34,14 +34,6 @@
   gap: var(--space-1);
 }
 
-.section-label {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  color: var(--color-1);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
 .classification-value {
   display: flex;
   align-items: center;
@@ -96,66 +88,10 @@
   flex-shrink: 0;
 }
 
-.validate-btn:not(:disabled) {
-  border-color: var(--green);
-  color: var(--green);
-
-  &:hover {
-    background: var(--green-bg);
-  }
-}
-
-.update-btn:not(:disabled) {
-  border-color: var(--blue);
-  color: var(--blue);
-
-  &:hover {
-    background: var(--blue-bg);
-  }
-}
-
-.cancel-btn:not(:disabled) {
-  border-color: var(--color-2);
-  color: var(--color-2);
-
-  &:hover {
-    background: var(--bg-2);
-  }
-}
-
 .field {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-}
-
-.field label {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  color: var(--color-1);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.field input,
-.field textarea {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-sm);
-  background: var(--bg-1);
-  color: var(--color);
-  font-size: var(--text-sm);
-  font-family: var(--font-mono);
-
-  &:focus-visible {
-    outline: 2px solid var(--blue);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
 }
 
 .field textarea {

--- a/app/client/ui/modules/classification-panel.ts
+++ b/app/client/ui/modules/classification-panel.ts
@@ -8,6 +8,8 @@ import type { Classification } from "@domains/classifications";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import labelStyles from "@styles/labels.module.css";
 import styles from "./classification-panel.module.css";
 
 type PanelMode = "view" | "validate" | "update";
@@ -20,7 +22,7 @@ type PanelMode = "view" | "validate" | "update";
  */
 @customElement("hd-classification-panel")
 export class ClassificationPanel extends LitElement {
-  static styles = [badgeStyles, buttonStyles, styles];
+  static styles = [badgeStyles, buttonStyles, inputStyles, labelStyles, styles];
 
   @property() documentId = "";
 
@@ -34,6 +36,10 @@ export class ClassificationPanel extends LitElement {
     if (changed.has("documentId") && this.documentId) {
       this.loadClassification();
     }
+  }
+
+  private get isValidated(): boolean {
+    return !!this.classification?.validated_by;
   }
 
   private async loadClassification() {
@@ -158,7 +164,7 @@ export class ClassificationPanel extends LitElement {
     return html`
       <div class="panel-body">
         <div class="section">
-          <span class="section-label">Classification</span>
+          <span class="label">Classification</span>
           <div class="classification-value">
             <span class="classification-name">${c.classification}</span>
             <span class="badge confidence ${c.confidence.toLowerCase()}">
@@ -168,12 +174,12 @@ export class ClassificationPanel extends LitElement {
         </div>
 
         <div class="section">
-          <span class="section-label">Markings Found</span>
+          <span class="label">Markings Found</span>
           <hd-markings-list .markings=${c.markings_found}></hd-markings-list>
         </div>
 
         <div class="section">
-          <span class="section-label">Rationale</span>
+          <span class="label">Rationale</span>
           <pre class="rationale">${c.rationale}</pre>
         </div>
 
@@ -187,12 +193,17 @@ export class ClassificationPanel extends LitElement {
 
       <div class="actions">
         <button
-          class="btn validate-btn"
+          class="btn btn-green"
           @click=${() => (this.mode = "validate")}
+          ?disabled=${this.isValidated}
         >
           Validate
         </button>
-        <button class="btn update-btn" @click=${() => (this.mode = "update")}>
+        <button
+          class="btn btn-blue"
+          @click=${() => (this.mode = "update")}
+          ?disabled=${this.isValidated}
+        >
           Update
         </button>
       </div>
@@ -205,8 +216,9 @@ export class ClassificationPanel extends LitElement {
         <p>Confirm that the classification is correct.</p>
 
         <div class="field">
-          <label for="validated_by">Your Name</label>
+          <label class="label" for="validated_by">Your Name</label>
           <input
+            class="input"
             id="validated_by"
             name="validated_by"
             type="text"
@@ -220,14 +232,14 @@ export class ClassificationPanel extends LitElement {
         <div class="actions">
           <button
             type="submit"
-            class="btn validate-btn"
+            class="btn btn-green"
             ?disabled=${this.submitting}
           >
             ${this.submitting ? "Validating..." : "Validate"}
           </button>
           <button
             type="button"
-            class="btn cancel-btn"
+            class="btn btn-muted"
             @click=${this.handleCancel}
             ?disabled=${this.submitting}
           >
@@ -246,8 +258,9 @@ export class ClassificationPanel extends LitElement {
         <p>Manually update the classification result.</p>
 
         <div class="field">
-          <label for="classification">Classification</label>
+          <label class="label" for="classification">Classification</label>
           <input
+            class="input"
             id="classification"
             name="classification"
             type="text"
@@ -257,8 +270,9 @@ export class ClassificationPanel extends LitElement {
         </div>
 
         <div class="field">
-          <label for="rationale">Rationale</label>
+          <label class="label" for="rationale">Rationale</label>
           <textarea
+            class="input"
             id="rationale"
             name="rationale"
             required
@@ -267,8 +281,14 @@ export class ClassificationPanel extends LitElement {
         </div>
 
         <div class="field">
-          <label for="updated_by">Your Name</label>
-          <input id="updated_by" name="updated_by" type="text" required />
+          <label class="label" for="updated_by">Your Name</label>
+          <input
+            class="input"
+            id="updated_by"
+            name="updated_by"
+            type="text"
+            required
+          />
         </div>
 
         ${this.renderError()}
@@ -276,14 +296,14 @@ export class ClassificationPanel extends LitElement {
         <div class="actions">
           <button
             type="submit"
-            class="btn update-btn"
+            class="btn btn-blue"
             ?disabled=${this.submitting}
           >
             ${this.submitting ? "Updating..." : "Update"}
           </button>
           <button
             type="button"
-            class="btn cancel-btn"
+            class="btn btn-muted"
             @click=${this.handleCancel}
             ?disabled=${this.submitting}
           >
@@ -303,7 +323,7 @@ export class ClassificationPanel extends LitElement {
       return html`
         <div class="empty-state">
           <span>No classification found for this document.</span>
-          <button class="button" @click=${this.handleBack}>
+          <button class="btn btn-muted" @click=${this.handleBack}>
             Back to Documents
           </button>
         </div>

--- a/app/client/ui/modules/document-grid.module.css
+++ b/app/client/ui/modules/document-grid.module.css
@@ -14,23 +14,6 @@
   flex-wrap: wrap;
 }
 
-.search-input,
-.filter-select,
-.sort-select {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-sm);
-  background: var(--bg-1);
-  color: var(--color);
-  font-size: var(--text-sm);
-  font-family: var(--font-mono);
-
-  &:focus-visible {
-    outline: 2px solid var(--blue);
-    outline-offset: 2px;
-  }
-}
-
 .search-input {
   flex: 1;
   min-width: 12rem;
@@ -55,13 +38,4 @@
   flex: 1;
   font-size: var(--text-sm);
   color: var(--color-2);
-}
-
-.bulk-btn:not(:disabled) {
-  border-color: var(--blue);
-  color: var(--blue);
-
-  &:hover {
-    background: var(--blue-bg);
-  }
 }

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -9,6 +9,7 @@ import { DocumentService } from "@domains/documents";
 import type { Document, SearchRequest } from "@domains/documents";
 
 import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
 import styles from "./document-grid.module.css";
 
 interface ClassifyProgress {
@@ -23,7 +24,7 @@ interface ClassifyProgress {
  */
 @customElement("hd-document-grid")
 export class DocumentGrid extends LitElement {
-  static styles = [buttonStyles, styles];
+  static styles = [buttonStyles, inputStyles, styles];
 
   @state() private documents: PageResult<Document> | null = null;
   @state() private page = 1;
@@ -208,12 +209,12 @@ export class DocumentGrid extends LitElement {
       <div class="toolbar">
         <input
           type="search"
-          class="search-input"
+          class="input search-input"
           placeholder="Search documents..."
           .value=${this.search}
           @input=${this.handleSearchInput}
         />
-        <select class="filter-select" @change=${this.handleStatusFilter}>
+        <select class="input filter-select" @change=${this.handleStatusFilter}>
           <option value="">---</option>
           <option value="pending" ?selected=${this.status === "pending"}>
             Pending
@@ -225,7 +226,7 @@ export class DocumentGrid extends LitElement {
             Complete
           </option>
         </select>
-        <select class="sort-select" @change=${this.handleSort}>
+        <select class="input sort-select" @change=${this.handleSort}>
           <option value="-UploadedAt" ?selected=${this.sort === "-UploadedAt"}>
             Newest
           </option>
@@ -241,7 +242,7 @@ export class DocumentGrid extends LitElement {
         </select>
         ${this.selectedIds.size > 0
           ? html`
-              <button class="btn bulk-btn" @click=${this.handleBulkClassify}>
+              <button class="btn btn-blue" @click=${this.handleBulkClassify}>
                 Classify ${this.selectedIds.size} Documents
               </button>
             `
@@ -292,7 +293,8 @@ export class DocumentGrid extends LitElement {
       ${this.deleteDocument
         ? html`
             <hd-confirm-dialog
-              message="Are you sure you want to delete ${this.deleteDocument.filename}?"
+              message="Are you sure you want to delete ${this.deleteDocument
+                .filename}?"
               @confirm=${this.confirmDelete}
               @cancel=${this.cancelDelete}
             ></hd-confirm-dialog>

--- a/app/client/ui/modules/document-upload.module.css
+++ b/app/client/ui/modules/document-upload.module.css
@@ -154,31 +154,3 @@
   font-size: var(--text-xs);
   color: var(--red);
 }
-
-.upload-btn:not(:disabled) {
-  border-color: var(--blue);
-  color: var(--blue);
-
-  &:hover {
-    background: var(--blue-bg);
-  }
-}
-
-.remove-btn {
-  padding: var(--space-1) var(--space-2);
-  border-color: var(--red);
-  color: var(--red);
-
-  &:hover:not(:disabled) {
-    background: var(--red-bg);
-  }
-}
-
-.clear-btn:not(:disabled) {
-  border-color: var(--yellow);
-  color: var(--yellow);
-
-  &:hover {
-    background: var(--yellow-bg);
-  }
-}

--- a/app/client/ui/modules/document-upload.ts
+++ b/app/client/ui/modules/document-upload.ts
@@ -210,7 +210,7 @@ export class DocumentUpload extends LitElement {
           ${editable
             ? html`
                 <button
-                  class="btn remove-btn"
+                  class="btn btn-red"
                   @click=${() => this.handleRemove(index)}
                 >
                   Remove
@@ -234,7 +234,7 @@ export class DocumentUpload extends LitElement {
     return html`
       <div class="queue-actions">
         <button
-          class="btn clear-btn"
+          class="btn btn-yellow"
           @click=${this.handleClear}
           ?disabled=${this.uploading}
         >
@@ -243,7 +243,7 @@ export class DocumentUpload extends LitElement {
         ${!allSettled
           ? html`
               <button
-                class="btn upload-btn"
+                class="btn btn-blue"
                 @click=${this.handleUpload}
                 ?disabled=${!this.canUpload}
               >

--- a/app/client/ui/modules/prompt-form.module.css
+++ b/app/client/ui/modules/prompt-form.module.css
@@ -40,36 +40,6 @@
   gap: var(--space-1);
 }
 
-.field label {
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  color: var(--color-1);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.field input,
-.field select,
-.field textarea {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-sm);
-  background: var(--bg-1);
-  color: var(--color);
-  font-size: var(--text-sm);
-  font-family: var(--font-mono);
-
-  &:focus-visible {
-    outline: 2px solid var(--blue);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-}
-
 .field textarea {
   resize: vertical;
   min-height: 6rem;
@@ -126,24 +96,6 @@
   align-items: center;
   gap: var(--space-2);
   flex-shrink: 0;
-}
-
-.save-btn:not(:disabled) {
-  border-color: var(--green);
-  color: var(--green);
-
-  &:hover {
-    background: var(--green-bg);
-  }
-}
-
-.cancel-btn:not(:disabled) {
-  border-color: var(--color-2);
-  color: var(--color-2);
-
-  &:hover {
-    background: var(--bg-2);
-  }
 }
 
 .error {

--- a/app/client/ui/modules/prompt-form.ts
+++ b/app/client/ui/modules/prompt-form.ts
@@ -5,6 +5,8 @@ import { PromptService } from "@domains/prompts";
 import type { Prompt } from "@domains/prompts";
 
 import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import labelStyles from "@styles/labels.module.css";
 import styles from "./prompt-form.module.css";
 
 /**
@@ -15,7 +17,7 @@ import styles from "./prompt-form.module.css";
  */
 @customElement("hd-prompt-form")
 export class PromptForm extends LitElement {
-  static styles = [buttonStyles, styles];
+  static styles = [buttonStyles, inputStyles, labelStyles, styles];
 
   @property({ type: Object }) prompt: Prompt | null = null;
 
@@ -147,8 +149,9 @@ export class PromptForm extends LitElement {
       </div>
       <form class="form-body" @submit=${this.handleSubmit}>
         <div class="field">
-          <label for="name">Name</label>
+          <label class="label" for="name">Name</label>
           <input
+            class="input"
             id="name"
             name="name"
             type="text"
@@ -157,8 +160,9 @@ export class PromptForm extends LitElement {
           />
         </div>
         <div class="field">
-          <label for="stage">Stage</label>
+          <label class="label" for="stage">Stage</label>
           <select
+            class="input"
             id="stage"
             name="stage"
             required
@@ -179,18 +183,19 @@ export class PromptForm extends LitElement {
         </div>
         ${this.renderDefaults()}
         <div class="field">
-          <label for="instructions">Instructions</label>
+          <label class="label" for="instructions">Instructions</label>
           <textarea
+            class="input instructions"
             id="instructions"
             name="instructions"
-            class="instructions"
             required
             .value=${p?.instructions ?? ""}
           ></textarea>
         </div>
         <div class="field">
-          <label for="description">Description</label>
+          <label class="label" for="description">Description</label>
           <textarea
+            class="input"
             id="descripion"
             name="description"
             .value=${p?.description ?? ""}
@@ -200,14 +205,14 @@ export class PromptForm extends LitElement {
         <div class="actions">
           <button
             type="submit"
-            class="btn save-btn"
+            class="btn btn-green"
             ?disabled=${this.submitting}
           >
             ${this.submitting ? "Saving..." : "Save"}
           </button>
           <button
             type="button"
-            class="btn cancel-btn"
+            class="btn btn-muted"
             @click=${this.handleCancel}
             ?disabled=${this.submitting}
           >

--- a/app/client/ui/modules/prompt-list.module.css
+++ b/app/client/ui/modules/prompt-list.module.css
@@ -14,23 +14,6 @@
   padding: var(--space-2);
 }
 
-.search-input,
-.filter-select,
-.sort-select {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--divider);
-  border-radius: var(--radius-sm);
-  background: var(--bg-1);
-  color: var(--color);
-  font-size: var(--text-sm);
-  font-family: var(--font-mono);
-
-  &:focus-visible {
-    outline: 2px solid var(--blue);
-    outline-offset: 2px;
-  }
-}
-
 .search-input {
   grid-column: span 3;
 }
@@ -57,13 +40,4 @@
   flex: 1;
   font-size: var(--text-sm);
   color: var(--color-2);
-}
-
-.new-btn:not(:disabled) {
-  border-color: var(--blue);
-  color: var(--blue);
-
-  &:hover {
-    background: var(--blue-bg);
-  }
 }

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -6,6 +6,7 @@ import { PromptService } from "@domains/prompts";
 import type { Prompt, SearchRequest } from "@domains/prompts";
 
 import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
 import styles from "./prompt-list.module.css";
 
 /**
@@ -15,7 +16,7 @@ import styles from "./prompt-list.module.css";
  */
 @customElement("hd-prompt-list")
 export class PromptList extends LitElement {
-  static styles = [buttonStyles, styles];
+  static styles = [buttonStyles, inputStyles, styles];
 
   @property({ type: Object }) selected: Prompt | null = null;
 
@@ -146,13 +147,13 @@ export class PromptList extends LitElement {
       <div class="toolbar">
         <input
           type="search"
-          class="search-input"
+          class="input search-input"
           placeholder="Search prompts..."
           .value=${this.search}
           @input=${this.handleSearchInput}
         />
-        <button class="btn new-btn" @click=${this.handleNew}>New</button>
-        <select class="filter-select" @change=${this.handleStageFilter}>
+        <button class="btn btn-blue" @click=${this.handleNew}>New</button>
+        <select class="input filter-select" @change=${this.handleStageFilter}>
           <option value="">---</option>
           <option value="classify" ?selected=${this.stage === "classify"}>
             Classify
@@ -164,7 +165,7 @@ export class PromptList extends LitElement {
             Finalize
           </option>
         </select>
-        <select class="sort-select" @change=${this.handleSort}>
+        <select class="input sort-select" @change=${this.handleSort}>
           <option value="Name" ?selected=${this.sort === "Name"}>
             Name (A-Z)
           </option>

--- a/app/client/ui/views/documents-view.ts
+++ b/app/client/ui/views/documents-view.ts
@@ -13,7 +13,7 @@ export class DocumentsView extends LitElement {
 
   private handleUploadComplete() {
     this.showUpload = false;
-    this.renderRoot.querySelector<any>("hd-document-grid")?.refresh();
+    this.renderRoot.querySelector("hd-document-grid")?.refresh();
   }
 
   render() {

--- a/app/client/ui/views/prompts-view.ts
+++ b/app/client/ui/views/prompts-view.ts
@@ -30,7 +30,7 @@ export class PromptsView extends LitElement {
 
   private handlePromptSaved() {
     this.reset();
-    this.renderRoot.querySelector<any>("hd-prompt-list").refresh();
+    this.renderRoot.querySelector("hd-prompt-list")?.refresh();
   }
 
   private handleCancel() {


### PR DESCRIPTION
## Summary

- Extract duplicated CSS into shared style modules (`inputs`, `labels`, `cards`, button color variants in `buttons`)
- Disable classification panel Validate/Update actions when already validated
- Add `external_id` and `external_platform` to document card metadata
- Fix `querySelector<any>` type erasure in `documents-view` and `prompts-view`
- Enforce named barrel exports in `prompts` and `storage` domain packages
- Update web-development skill: path aliases, CSS layers, shared styles docs, lifecycles reference, querySelector patterns

Closes #90

## Test plan

- [ ] `bun run build` succeeds
- [ ] `go vet ./...` passes
- [ ] Documents view: cards show external platform/ID, button colors correct
- [ ] Review view: Validate/Update disabled on validated classifications
- [ ] Prompts view: form inputs/labels/buttons use shared styles consistently
- [ ] No visual regressions across all views