### PR TITLE
Harden Dockerfile and add production compose overlay

### DIFF
--- a/.claude/context/guides/.archive/101-harden-dockerfile-compose-overlay.md
+++ b/.claude/context/guides/.archive/101-harden-dockerfile-compose-overlay.md
@@ -1,0 +1,120 @@
+# 101 - Harden Dockerfile and Add Production Compose Overlay
+
+## Problem Context
+
+The current Dockerfile produces a minimal Alpine image that lacks ImageMagick and Ghostscript (required for PDF→image rendering in the classification workflow), runs as root, and has no health check. There is also no way to run the full stack (app + postgres + azurite) entirely in Docker for local integration testing.
+
+## Architecture Approach
+
+The image stays environment-agnostic — config files are mounted at runtime, not baked in. The compose overlay is opt-in via `-f` flag to preserve the existing dev workflow where only infrastructure runs in Docker and the Go server runs on the host.
+
+## Implementation
+
+### Step 1: Harden the Dockerfile
+
+Replace the runtime stage in `Dockerfile`:
+
+```dockerfile
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates curl imagemagick ghostscript
+RUN addgroup -S herald && adduser -S herald -G herald
+COPY --from=build /herald /usr/local/bin/herald
+WORKDIR /app
+USER herald
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+  CMD ["curl", "-f", "http://localhost:8080/healthz"]
+ENTRYPOINT ["herald"]
+```
+
+Key changes from current:
+- `imagemagick` and `ghostscript` packages added (ImageMagick delegates PDF rasterization to Ghostscript)
+- `curl` added for the HEALTHCHECK probe
+- Non-root `herald` user/group created and set as the runtime user
+- `WORKDIR /app` ensures predictable working directory for config file loading
+- `HEALTHCHECK` probes the existing `/healthz` endpoint
+
+### Step 2: Update `.dockerignore`
+
+Add `secrets.json` to the existing `.dockerignore`:
+
+```
+secrets.json
+```
+
+This prevents secrets from being copied into the Docker build context.
+
+### Step 3: Create `config.docker.json`
+
+Create `config.docker.json` in the project root. This is the environment overlay loaded when `HERALD_ENV=docker`. It overrides only the values that differ inside Docker Compose networking:
+
+```json
+{
+  "database": {
+    "host": "herald-postgres"
+  },
+  "storage": {
+    "connection_string": "DefaultEndpointsProtocol=http;AccountName=heraldstore;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://herald-azurite:10000/heraldstore;"
+  }
+}
+```
+
+The only differences from `config.json`:
+- `database.host`: `localhost` → `herald-postgres` (postgres container name)
+- `storage.connection_string`: `127.0.0.1:10000` → `herald-azurite:10000` (azurite container name)
+
+### Step 4: Create `compose/app.yml`
+
+Create `compose/app.yml`:
+
+```yaml
+services:
+  herald:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: herald-server
+    environment:
+      HERALD_ENV: docker
+    volumes:
+      - ../config.json:/app/config.json:ro
+      - ../config.docker.json:/app/config.docker.json:ro
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      azurite:
+        condition: service_healthy
+    networks:
+      - herald
+
+networks:
+  herald:
+    name: herald
+    driver: bridge
+```
+
+Notes:
+- `HERALD_ENV=docker` triggers config overlay loading of `config.docker.json`
+- Config files are bind-mounted read-only into `/app/` (the WORKDIR)
+- `depends_on` with health conditions ensures postgres and azurite are ready before herald starts
+- Joins the same `herald` network declared by the infrastructure compose files
+
+Usage: `docker compose -f docker-compose.yml -f compose/app.yml up --build`
+
+## Remediation
+
+### R1: Compose build context and volume paths
+
+The guide specified `context: ..` and `../config.json` paths in `compose/app.yml`, assuming paths resolve relative to the compose file's location. When using `-f docker-compose.yml -f compose/app.yml`, Docker sets the project directory to the first `-f` file's location (project root). All paths in overlay compose files resolve relative to the project root, not their own directory. Changed `..` to `.` for build context and volume mounts.
+
+## Validation Criteria
+
+- [ ] `docker build -t herald .` succeeds
+- [ ] Container runs as non-root user (`docker run --rm herald whoami` → `herald`)
+- [ ] `docker run --rm herald magick -version` shows ImageMagick 7.x
+- [ ] `docker run --rm herald gs --version` shows Ghostscript version
+- [ ] Docker HEALTHCHECK passes after startup
+- [ ] Full stack starts via `docker compose -f docker-compose.yml -f compose/app.yml up --build`
+- [ ] Web client accessible at `http://localhost:8080/app`

--- a/.claude/context/sessions/101-harden-dockerfile-compose-overlay.md
+++ b/.claude/context/sessions/101-harden-dockerfile-compose-overlay.md
@@ -1,0 +1,35 @@
+# 101 - Harden Dockerfile and Add Production Compose Overlay
+
+## Summary
+
+Hardened the Dockerfile for production deployment by adding ImageMagick, Ghostscript, and curl packages, creating a non-root `herald` user, setting `WORKDIR /app`, and adding a `HEALTHCHECK` instruction. Created a Docker Compose overlay (`compose/app.yml`) and config overlay (`config.docker.json`) for running the full stack in Docker. Updated `README.md` with development workflow, containerized usage, mise tasks, and configuration documentation.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| HEALTHCHECK probe | `curl -f` to `/healthz` | Existing endpoint, `curl` is lightweight and already added for this purpose |
+| Compose overlay approach | Separate `compose/app.yml` with `-f` flag | Preserves existing dev workflow where only infra runs in Docker |
+| Config overlay | `config.docker.json` with container hostnames | Image stays environment-agnostic; config mounted at runtime |
+| Build context paths | `.` not `..` in compose overlay | `-f` flag sets project dir to first file's location; overlay paths resolve from project root |
+
+## Files Modified
+
+- `Dockerfile` — added packages, non-root user, WORKDIR, HEALTHCHECK
+- `.dockerignore` — added `secrets.json`
+- `config.docker.json` — new, Docker network config overlay
+- `compose/app.yml` — new, Herald server compose service
+- `README.md` — added development, containerized, tasks, and configuration sections
+
+## Patterns Established
+
+- **Compose overlay pattern**: Infrastructure compose files in `compose/` are included by `docker-compose.yml` for dev. The app overlay is opt-in via `-f` flag for full-stack Docker usage.
+- **Compose path resolution**: When using `-f` overlays, all paths resolve relative to the project root (location of the first `-f` file), not relative to each compose file's directory.
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go test ./tests/...` — all 20 packages pass
+- Docker build succeeds
+- Full stack starts and serves web client at `http://localhost:8080/app`
+- Classification workflow completes end-to-end in containerized environment

--- a/.claude/plans/validated-sprouting-puddle.md
+++ b/.claude/plans/validated-sprouting-puddle.md
@@ -1,0 +1,58 @@
+# Plan: Harden Dockerfile and Add Production Compose Overlay (#101)
+
+## Context
+
+Issue #101 under Objective #95 (Docker Production Image). The current Dockerfile produces a minimal Alpine image without ImageMagick/Ghostscript (required for PDF rendering), runs as root, and has no health check. There's no way to run the full stack (app + postgres + azurite) entirely in Docker for integration testing.
+
+## Changes
+
+### 1. Harden Dockerfile (`Dockerfile`)
+
+Current runtime stage is bare `alpine:3.21` with only `ca-certificates`. Update to:
+
+- Add `imagemagick` and `ghostscript` packages (Alpine 3.21 repos provide ImageMagick 7.x)
+- Create non-root `herald` user/group with `addgroup`/`adduser`
+- Set `WORKDIR /app` for predictable config file loading
+- Set `USER herald`
+- Add `HEALTHCHECK` instruction: `curl` to `/healthz` (10s interval, 5s timeout, 5 retries) — need to add `curl` package too
+
+### 2. Update `.dockerignore`
+
+Add `secrets.json` to prevent secrets from being copied into the build context.
+
+### 3. Create `config.docker.json`
+
+Environment overlay for Docker Compose networking. Overrides only what differs from `config.json`:
+
+- `database.host` → `herald-postgres` (container name from `compose/postgres.yml`)
+- `storage.connection_string` → replace `127.0.0.1:10000` with `herald-azurite:10000`
+
+### 4. Create `compose/app.yml`
+
+Herald server service compose file:
+
+- Build from project root Dockerfile
+- `depends_on` postgres and azurite with `condition: service_healthy`
+- `HERALD_ENV=docker` environment variable (triggers `config.docker.json` overlay)
+- Bind-mount `config.json` and `config.docker.json` into `/app/`
+- Port 8080
+- Joins the `herald` network
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `Dockerfile` | Edit — add packages, non-root user, WORKDIR, HEALTHCHECK |
+| `.dockerignore` | Edit — add `secrets.json` |
+| `config.docker.json` | Create — Docker network overlay |
+| `compose/app.yml` | Create — Herald server service |
+
+## Verification
+
+1. `docker build -t herald .` succeeds
+2. `docker run --rm herald magick -version` shows ImageMagick 7.x
+3. `docker run --rm herald gs --version` shows Ghostscript version
+4. `docker run --rm herald whoami` shows `herald` (non-root)
+5. Full stack: `docker compose -f docker-compose.yml -f compose/app.yml up --build` starts all services
+6. Health check passes (visible in `docker ps` HEALTH column)
+7. Web client accessible at `http://localhost:8080/app`

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ docker-compose.yml
 compose/
 CHANGELOG.md
 _project/
+secrets.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.95.101
+- Harden Dockerfile with ImageMagick, Ghostscript, non-root user, WORKDIR, and HEALTHCHECK; add Docker Compose production overlay and config overlay for full-stack containerized deployment; add README with development, containerized, tasks, and configuration documentation (#101)
+
 ## v0.3.0
 
 ### Web Infrastructure

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,12 @@ COPY --from=client /src/app/dist/ ./app/dist/
 RUN CGO_ENABLED=0 go build -o /herald ./cmd/server
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl imagemagick ghostscript
+RUN addgroup -S herald && adduser -S herald -G herald
 COPY --from=build /herald /usr/local/bin/herald
+WORKDIR /app
+USER herald
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+  CMD ["curl", "-f", "http://localhost:8080/healthz"]
 ENTRYPOINT ["herald"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,86 @@
 # Herald
 
 One who reads and announces markings.
+
+Go web service for classifying PDF documents' security markings using Azure AI Foundry GPT vision models. See [`_project/README.md`](_project/README.md) for full architecture and roadmap.
+
+## Prerequisites
+
+- [Go](https://go.dev/) 1.26+
+- [Bun](https://bun.sh/)
+- [ImageMagick](https://imagemagick.org/) 7.0+ with Ghostscript (for PDF rendering)
+- [Docker](https://www.docker.com/) and Docker Compose
+- [Air](https://github.com/air-verse/air) (for Go hot reload in development)
+- [mise](https://mise.jdx.dev/) (optional, for task runner shortcuts)
+
+## Development
+
+Development runs the Go server on the host with infrastructure (PostgreSQL, Azurite) in Docker.
+
+**Start infrastructure:**
+
+```bash
+docker compose up -d
+```
+
+**Run database migrations:**
+
+```bash
+go run ./cmd/migrate -up
+```
+
+**Start the dev server (two terminals):**
+
+```bash
+# Terminal 1 — watch and rebuild the web client
+cd app && bun run watch
+
+# Terminal 2 — hot reload the Go server
+air
+```
+
+The web client is available at `http://localhost:8080/app`.
+
+## Containerized
+
+Run the full stack entirely in Docker (app + PostgreSQL + Azurite):
+
+```bash
+docker compose -f docker-compose.yml -f compose/app.yml up --build
+```
+
+This builds the Herald Docker image and starts all services with health-conditioned dependencies. The app loads `config.docker.json` via the `HERALD_ENV=docker` overlay to resolve container hostnames.
+
+To stop:
+
+```bash
+docker compose -f docker-compose.yml -f compose/app.yml down
+```
+
+## Tasks
+
+Herald uses [mise](https://mise.jdx.dev/) as a task runner. All tasks can also be run directly with the underlying commands.
+
+| Task | Command | Description |
+|------|---------|-------------|
+| `mise run dev` | `go run ./cmd/server` | Run the server in development mode |
+| `mise run build` | `go build -o bin/server ./cmd/server` | Build the server binary |
+| `mise run test` | `go test ./tests/...` | Run all tests |
+| `mise run vet` | `go vet ./...` | Run go vet |
+| `mise run migrate:up` | `go run ./cmd/migrate -up` | Run all up migrations |
+| `mise run migrate:down` | `go run ./cmd/migrate -down` | Run all down migrations |
+| `mise run migrate:version` | `go run ./cmd/migrate -version` | Print current migration version |
+| `mise run web:fmt` | `cd app && bunx prettier --write client/` | Format web client source files |
+| `mise run web:build` | `cd app && bun run build` | Build the web client |
+| `mise run web:watch` | `cd app && bun run watch` | Watch and rebuild the web client |
+
+## Configuration
+
+Config loading follows a layered overlay pattern:
+
+1. `config.json` — base configuration
+2. `config.<HERALD_ENV>.json` — environment overlay (e.g., `config.docker.json`)
+3. `secrets.json` — gitignored secrets
+4. `HERALD_*` environment variables — final overrides
+
+All environment variables use the `HERALD_` prefix (e.g., `HERALD_SERVER_PORT`, `HERALD_DB_HOST`).

--- a/compose/app.yml
+++ b/compose/app.yml
@@ -1,0 +1,25 @@
+services:
+  herald:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: herald-server
+    environment:
+      HERALD_ENV: docker
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./config.docker.json:/app/config.docker.json:ro
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      azurite:
+        condition: service_healthy
+    networks:
+      - herald
+
+networks:
+  herald:
+    name: herald
+    driver: bridge

--- a/config.docker.json
+++ b/config.docker.json
@@ -1,0 +1,8 @@
+{
+  "database": {
+    "host": "herald-postgres"
+  },
+  "storage": {
+    "connection_string": "DefaultEndpointsProtocol=http;AccountName=heraldstore;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://herald-azurite:10000/heraldstore;"
+  }
+}


### PR DESCRIPTION
## Summary

Hardens the Dockerfile for production deployment and adds compose infrastructure for local full-stack testing.

Closes #101

## Changes

- **Dockerfile**: Add `imagemagick`, `ghostscript`, `curl` packages; create non-root `herald` user/group; set `WORKDIR /app`; add `HEALTHCHECK` probing `/healthz`
- **`.dockerignore`**: Add `secrets.json`
- **`config.docker.json`**: Environment overlay pointing `database.host` to `herald-postgres` and `storage.connection_string` to `herald-azurite:10000`
- **`compose/app.yml`**: Herald server service with health-conditioned `depends_on`, `HERALD_ENV=docker`, and read-only config bind-mounts
- **`README.md`**: Add development workflow, containerized usage, mise tasks, and configuration documentation