### PR TITLE
Add credential-based storage constructor

### DIFF
--- a/.claude/context/guides/.archive/105-add-credential-based-storage-constructor.md
+++ b/.claude/context/guides/.archive/105-add-credential-based-storage-constructor.md
@@ -1,0 +1,135 @@
+# 105 — Add credential-based storage constructor
+
+## Problem Context
+
+The `pkg/storage/` package only supports connection string auth via `New()`. Managed identity (Objective #97) requires creating the Azure Blob client with `azblob.NewClient(serviceURL, cred, nil)`. This task adds a `NewWithCredential` constructor and relaxes config validation so each constructor validates its own requirements.
+
+## Architecture Approach
+
+Dual-constructor pattern: `New` for connection strings, `NewWithCredential` for managed identity credentials. Both produce the same `azure` struct — only client construction differs. Config validation is split: `validate()` checks universal invariants (ContainerName, MaxListSize), each constructor guards its own required fields.
+
+## Implementation
+
+### Step 1: Add `ServiceURL` to storage config
+
+**`pkg/storage/config.go`**
+
+Add `ServiceURL` field to `Config`:
+
+```go
+type Config struct {
+	ContainerName    string `json:"container_name"`
+	ConnectionString string `json:"connection_string"`
+	ServiceURL       string `json:"service_url"`
+	MaxListSize      int32  `json:"max_list_size"`
+}
+```
+
+Add `ServiceURL` to `Env`:
+
+```go
+type Env struct {
+	ContainerName    string
+	ConnectionString string
+	ServiceURL       string
+	MaxListSize      string
+}
+```
+
+Add `ServiceURL` to `Merge` (after the `ConnectionString` block):
+
+```go
+if overlay.ServiceURL != "" {
+	c.ServiceURL = overlay.ServiceURL
+}
+```
+
+Add `ServiceURL` to `loadEnv` (after the `ConnectionString` block):
+
+```go
+if env.ServiceURL != "" {
+	if v := os.Getenv(env.ServiceURL); v != "" {
+		c.ServiceURL = v
+	}
+}
+```
+
+Relax `validate()` — remove `ConnectionString` requirement:
+
+```go
+func (c *Config) validate() error {
+	if c.ContainerName == "" {
+		return fmt.Errorf("container_name required")
+	}
+	return nil
+}
+```
+
+### Step 2: Add `NewWithCredential` constructor and guard `New`
+
+**`pkg/storage/storage.go`**
+
+Add `azcore` import:
+
+```go
+"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+```
+
+Add connection string guard at the top of existing `New`:
+
+```go
+func New(cfg *Config, logger *slog.Logger) (System, error) {
+	if cfg.ConnectionString == "" {
+		return nil, fmt.Errorf("connection_string required for connection string auth")
+	}
+
+	client, err := azblob.NewClientFromConnectionString(cfg.ConnectionString, nil)
+	// ... rest unchanged
+```
+
+Add `NewWithCredential` constructor after `New`:
+
+```go
+func NewWithCredential(cfg *Config, cred azcore.TokenCredential, logger *slog.Logger) (System, error) {
+	if cfg.ServiceURL == "" {
+		return nil, fmt.Errorf("service_url required for credential auth")
+	}
+
+	client, err := azblob.NewClient(cfg.ServiceURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create storage client: %w", err)
+	}
+
+	return &azure{
+		client:    client,
+		container: cfg.ContainerName,
+		logger:    logger.With("system", "storage"),
+	}, nil
+}
+```
+
+### Step 3: Add `ServiceURL` env var mapping
+
+**`internal/config/config.go`**
+
+Update `storageEnv`:
+
+```go
+var storageEnv = &storage.Env{
+	ContainerName:    "HERALD_STORAGE_CONTAINER_NAME",
+	ConnectionString: "HERALD_STORAGE_CONNECTION_STRING",
+	ServiceURL:       "HERALD_STORAGE_SERVICE_URL",
+	MaxListSize:      "HERALD_STORAGE_MAX_LIST_SIZE",
+}
+```
+
+## Validation Criteria
+
+- [ ] `storage.Config` has `ServiceURL` field with JSON tag, env override, and merge support
+- [ ] `validate()` only checks `ContainerName` (universal invariant)
+- [ ] `New()` guards `ConnectionString` internally before creating the client
+- [ ] `NewWithCredential()` guards `ServiceURL`, accepts `azcore.TokenCredential`, creates client via `azblob.NewClient`
+- [ ] `HERALD_STORAGE_SERVICE_URL` env var is mapped in `internal/config/config.go`
+- [ ] `go vet ./...` passes
+- [ ] `go build ./cmd/server/` succeeds
+- [ ] `go test ./tests/...` passes

--- a/.claude/context/sessions/105-add-credential-based-storage-constructor.md
+++ b/.claude/context/sessions/105-add-credential-based-storage-constructor.md
@@ -1,0 +1,29 @@
+# 105 — Add credential-based storage constructor
+
+## Summary
+
+Added a `NewWithCredential` constructor to `pkg/storage/` that accepts `azcore.TokenCredential` + service URL for managed identity connections to Azure Blob Storage. Relaxed config validation so each constructor guards its own requirements while `validate()` only checks universal invariants.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Validation split | `validate()` checks universal invariants; constructors guard their own fields | Prevents `Finalize()` from requiring fields only one auth mode needs |
+| Separate `ServiceURL` field | New field rather than parsing connection string | Different formats, different deployment configurations — managed identity environments won't have connection strings |
+
+## Files Modified
+
+- `pkg/storage/config.go` — Added `ServiceURL` field to `Config` and `Env`, added merge/env support, relaxed `validate()`
+- `pkg/storage/storage.go` — Added `NewWithCredential` constructor, added `ConnectionString` guard in `New`, added `azcore` import
+- `internal/config/config.go` — Added `HERALD_STORAGE_SERVICE_URL` env var mapping
+- `tests/storage/config_test.go` — Updated validation tests for relaxed `validate()`, added `ServiceURL` env and merge tests
+
+## Patterns Established
+
+- Dual-constructor pattern (`New` / `NewWithCredential`) for connection string vs credential auth — same pattern will apply to `pkg/database/` in #106
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go build ./cmd/server/` — success
+- `go test ./tests/...` — all pass (20/20 packages)

--- a/.claude/plans/resilient-questing-sundae.md
+++ b/.claude/plans/resilient-questing-sundae.md
@@ -1,0 +1,115 @@
+# 105 — Add credential-based storage constructor
+
+## Context
+
+Issue #105, part of Objective #97 (Managed Identity for Azure Services). The `pkg/storage/` package currently only supports connection string auth via `New()`. Azure managed identity requires creating the client with `azblob.NewClient(serviceURL, cred, nil)` instead of `azblob.NewClientFromConnectionString()`. This task adds a `NewWithCredential` constructor and relaxes config validation so each constructor validates its own requirements.
+
+## Plan
+
+### 1. Update `pkg/storage/config.go`
+
+**Add `ServiceURL` field to `Config`:**
+```go
+type Config struct {
+    ContainerName    string `json:"container_name"`
+    ConnectionString string `json:"connection_string"`
+    ServiceURL       string `json:"service_url"`
+    MaxListSize      int32  `json:"max_list_size"`
+}
+```
+
+**Add `ServiceURL` to `Env`:**
+```go
+type Env struct {
+    ContainerName    string
+    ConnectionString string
+    ServiceURL       string
+    MaxListSize      string
+}
+```
+
+**Add `ServiceURL` to `Merge`:**
+```go
+if overlay.ServiceURL != "" {
+    c.ServiceURL = overlay.ServiceURL
+}
+```
+
+**Add `ServiceURL` to `loadEnv`:**
+```go
+if env.ServiceURL != "" {
+    if v := os.Getenv(env.ServiceURL); v != "" {
+        c.ServiceURL = v
+    }
+}
+```
+
+**Relax `validate()`** — remove `ConnectionString` requirement, keep only universal invariants:
+```go
+func (c *Config) validate() error {
+    if c.ContainerName == "" {
+        return fmt.Errorf("container_name required")
+    }
+    return nil
+}
+```
+
+### 2. Update `pkg/storage/storage.go`
+
+**Add `NewWithCredential` constructor:**
+```go
+func NewWithCredential(cfg *Config, cred azcore.TokenCredential, logger *slog.Logger) (System, error) {
+    if cfg.ServiceURL == "" {
+        return nil, fmt.Errorf("service_url required for credential auth")
+    }
+
+    client, err := azblob.NewClient(cfg.ServiceURL, cred, nil)
+    if err != nil {
+        return nil, fmt.Errorf("create storage client: %w", err)
+    }
+
+    return &azure{
+        client:    client,
+        container: cfg.ContainerName,
+        logger:    logger.With("system", "storage"),
+    }, nil
+}
+```
+
+**Update `New` to validate `ConnectionString` internally:**
+```go
+func New(cfg *Config, logger *slog.Logger) (System, error) {
+    if cfg.ConnectionString == "" {
+        return nil, fmt.Errorf("connection_string required for connection string auth")
+    }
+    // ... rest unchanged
+}
+```
+
+New import: `"github.com/Azure/azure-sdk-for-go/sdk/azcore"`
+
+### 3. Update `internal/config/config.go`
+
+Add `ServiceURL` env var to `storageEnv`:
+```go
+var storageEnv = &storage.Env{
+    ContainerName:    "HERALD_STORAGE_CONTAINER_NAME",
+    ConnectionString: "HERALD_STORAGE_CONNECTION_STRING",
+    ServiceURL:       "HERALD_STORAGE_SERVICE_URL",
+    MaxListSize:      "HERALD_STORAGE_MAX_LIST_SIZE",
+}
+```
+
+### Files
+
+| File | Change |
+|------|--------|
+| `pkg/storage/config.go` | Add `ServiceURL` field, env, merge, relax validate |
+| `pkg/storage/storage.go` | Add `NewWithCredential`, guard `ConnectionString` in `New` |
+| `internal/config/config.go` | Add `ServiceURL` env var mapping |
+
+### Validation
+
+- `go vet ./...` passes
+- `go build ./cmd/server/` succeeds
+- `go test ./tests/...` passes (existing tests unaffected)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.97.105
+- Add credential-based storage constructor with `NewWithCredential` for managed identity auth, `ServiceURL` config field with env var override, and relaxed config validation (#105)
+
 ## v0.4.0-dev.96.103
 - Add AuthConfig with typed AuthMode enum, Azure Identity credential provider factory, and Infrastructure/Runtime credential propagation (#103)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ var databaseEnv = &database.Env{
 var storageEnv = &storage.Env{
 	ContainerName:    "HERALD_STORAGE_CONTAINER_NAME",
 	ConnectionString: "HERALD_STORAGE_CONNECTION_STRING",
+	ServiceURL:       "HERALD_STORAGE_SERVICE_URL",
 	MaxListSize:      "HERALD_STORAGE_MAX_LIST_SIZE",
 }
 

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	ContainerName    string `json:"container_name"`
 	ConnectionString string `json:"connection_string"`
+	ServiceURL       string `json:"service_url"`
 	MaxListSize      int32  `json:"max_list_size"`
 }
 
@@ -17,6 +18,7 @@ type Config struct {
 type Env struct {
 	ContainerName    string
 	ConnectionString string
+	ServiceURL       string
 	MaxListSize      string
 }
 
@@ -37,9 +39,13 @@ func (c *Config) Merge(overlay *Config) {
 	if overlay.ConnectionString != "" {
 		c.ConnectionString = overlay.ConnectionString
 	}
+	if overlay.ServiceURL != "" {
+		c.ServiceURL = overlay.ServiceURL
+	}
 	if overlay.MaxListSize != 0 {
 		c.MaxListSize = overlay.MaxListSize
 	}
+
 }
 
 func (c *Config) loadDefaults() {
@@ -65,6 +71,11 @@ func (c *Config) loadEnv(env *Env) {
 			c.ConnectionString = v
 		}
 	}
+	if env.ServiceURL != "" {
+		if v := os.Getenv(env.ServiceURL); v != "" {
+			c.ServiceURL = v
+		}
+	}
 	if env.MaxListSize != "" {
 		if v := os.Getenv(env.MaxListSize); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -77,9 +88,6 @@ func (c *Config) loadEnv(env *Env) {
 func (c *Config) validate() error {
 	if c.ContainerName == "" {
 		return fmt.Errorf("container_name required")
-	}
-	if c.ConnectionString == "" {
-		return fmt.Errorf("connection_string required")
 	}
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -79,7 +80,31 @@ type azure struct {
 // It validates the connection string and creates the Azure client
 // but does not establish a connection until Start is called.
 func New(cfg *Config, logger *slog.Logger) (System, error) {
+	if cfg.ConnectionString == "" {
+		return nil, fmt.Errorf("connection_string required for connection string auth")
+	}
+
 	client, err := azblob.NewClientFromConnectionString(cfg.ConnectionString, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create storage client: %w", err)
+	}
+
+	return &azure{
+		client:    client,
+		container: cfg.ContainerName,
+		logger:    logger.With("system", "storage"),
+	}, nil
+}
+
+// NewWithCredential creates a storage system using an Azure token credential.
+// It requires ServiceURL in the config and creates the client via azblob.NewClient.
+// Connection is not established until Start is called.
+func NewWithCredential(cfg *Config, cred azcore.TokenCredential, logger *slog.Logger) (System, error) {
+	if cfg.ServiceURL == "" {
+		return nil, fmt.Errorf("service_url required for credential auth")
+	}
+
+	client, err := azblob.NewClient(cfg.ServiceURL, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create storage client: %w", err)
 	}

--- a/tests/storage/config_test.go
+++ b/tests/storage/config_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/JaimeStill/herald/pkg/storage"
@@ -44,40 +43,19 @@ func TestFinalizeEnvOverrides(t *testing.T) {
 }
 
 func TestFinalizeValidation(t *testing.T) {
-	tests := []struct {
-		name    string
-		cfg     storage.Config
-		wantErr string
-	}{
-		{
-			name:    "missing connection_string",
-			cfg:     storage.Config{ContainerName: "docs"},
-			wantErr: "connection_string required",
-		},
-		{
-			name:    "missing container_name after clearing default",
-			cfg:     storage.Config{ConnectionString: "conn"},
-			wantErr: "",
-		},
-	}
+	t.Run("no connection_string is valid after validate relaxation", func(t *testing.T) {
+		cfg := storage.Config{ContainerName: "docs"}
+		if err := cfg.Finalize(nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cfg.Finalize(nil)
-			if tt.wantErr == "" {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
-			}
-		})
-	}
+	t.Run("missing container_name after clearing default", func(t *testing.T) {
+		cfg := storage.Config{ConnectionString: "conn"}
+		if err := cfg.Finalize(nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestFinalizeMaxListSizeCap(t *testing.T) {
@@ -133,6 +111,23 @@ func TestFinalizeMaxListSizeEnvCapped(t *testing.T) {
 	}
 }
 
+func TestFinalizeServiceURLEnvOverride(t *testing.T) {
+	t.Setenv("TEST_SERVICE_URL", "https://myaccount.blob.core.windows.net")
+
+	env := &storage.Env{
+		ServiceURL: "TEST_SERVICE_URL",
+	}
+
+	cfg := storage.Config{}
+	if err := cfg.Finalize(env); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.ServiceURL != "https://myaccount.blob.core.windows.net" {
+		t.Errorf("service_url: got %s, want https://myaccount.blob.core.windows.net", cfg.ServiceURL)
+	}
+}
+
 func TestMerge(t *testing.T) {
 	base := storage.Config{
 		ContainerName:    "documents",
@@ -154,6 +149,25 @@ func TestMerge(t *testing.T) {
 	}
 	if base.MaxListSize != 100 {
 		t.Errorf("max_list_size: got %d, want 100", base.MaxListSize)
+	}
+}
+
+func TestMergeServiceURL(t *testing.T) {
+	base := storage.Config{
+		ContainerName: "documents",
+		MaxListSize:   50,
+	}
+
+	overlay := storage.Config{
+		ServiceURL: "https://myaccount.blob.core.windows.net",
+	}
+	base.Merge(&overlay)
+
+	if base.ServiceURL != "https://myaccount.blob.core.windows.net" {
+		t.Errorf("service_url: got %s, want https://myaccount.blob.core.windows.net", base.ServiceURL)
+	}
+	if base.ContainerName != "documents" {
+		t.Errorf("container_name should remain documents, got %s", base.ContainerName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `NewWithCredential` constructor to `pkg/storage/` for managed identity auth via `azcore.TokenCredential` + service URL
- Add `ServiceURL` field to `storage.Config` with `HERALD_STORAGE_SERVICE_URL` env var override
- Relax `validate()` to check only universal invariants; each constructor guards its own required fields
- Update tests for relaxed validation, add `ServiceURL` env and merge coverage

Closes #105