### PR TITLE
Add token-based database authentication

### DIFF
--- a/.claude/context/guides/.archive/106-add-token-based-database-authentication.md
+++ b/.claude/context/guides/.archive/106-add-token-based-database-authentication.md
@@ -1,0 +1,154 @@
+# 106 — Add Token-Based Database Authentication
+
+## Problem Context
+
+Part of Objective #97 (Managed Identity for Azure Services). Herald needs an alternate database constructor that authenticates to Azure PostgreSQL using Entra tokens instead of a static password. This enables managed identity deployments where no credentials are stored in configuration.
+
+## Architecture Approach
+
+Follow the dual-constructor pattern from `pkg/storage/storage.go` (#105). Add `NewWithCredential` alongside the existing `New` constructor. The new constructor uses pgx's `stdlib.OpenDB` with a `BeforeConnect` hook that acquires a fresh Entra token on every new connection, injecting it as the password.
+
+A configurable `TokenLifetime` field on `Config` (default 45m) controls `ConnMaxLifetime` in credential mode, providing a safety net against Entra token expiry (~1 hour). This is separate from `ConnMaxLifetime`, which applies to connection-string auth via `New`.
+
+The existing `New` constructor remains unchanged — it continues to use `sql.Open("pgx", dsn)` for connection-string auth.
+
+## Implementation
+
+### Step 1: Create `pkg/database/constants.go`
+
+New file with the OAuth2 token scope for Azure Database for PostgreSQL:
+
+```go
+package database
+
+const TokenScope = "https://ossrdbms-aad.database.windows.net/.default"
+```
+
+### Step 2: Add `TokenLifetime` to `pkg/database/config.go`
+
+Add the `TokenLifetime` field to `Config`, `Env`, and all config lifecycle methods.
+
+**Config struct** — add after `ConnTimeout`:
+
+```go
+TokenLifetime string `json:"token_lifetime"`
+```
+
+**Env struct** — add after `ConnTimeout`:
+
+```go
+TokenLifetime string
+```
+
+**`TokenLifetimeDuration` accessor** — add after `ConnTimeoutDuration`:
+
+```go
+func (c *Config) TokenLifetimeDuration() time.Duration {
+	d, _ := time.ParseDuration(c.TokenLifetime)
+	return d
+}
+```
+
+**`loadDefaults`** — add at the end:
+
+```go
+if c.TokenLifetime == "" {
+	c.TokenLifetime = "45m"
+}
+```
+
+**`loadEnv`** — add at the end:
+
+```go
+if env.TokenLifetime != "" {
+	if v := os.Getenv(env.TokenLifetime); v != "" {
+		c.TokenLifetime = v
+	}
+}
+```
+
+**`Merge`** — add at the end:
+
+```go
+if overlay.TokenLifetime != "" {
+	c.TokenLifetime = overlay.TokenLifetime
+}
+```
+
+**`validate`** — add before the final `return nil`:
+
+```go
+if _, err := time.ParseDuration(c.TokenLifetime); err != nil {
+	return fmt.Errorf("invalid token_lifetime: %w", err)
+}
+```
+
+### Step 3: Update imports and add `NewWithCredential` to `pkg/database/database.go`
+
+Update the import block. The blank import `_ "github.com/jackc/pgx/v5/stdlib"` becomes a named import since we now call `stdlib.OpenDB` directly (it still registers the `pgx` driver as a side effect). Add Azure SDK imports for token acquisition.
+
+Replace the existing import block:
+
+```go
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/JaimeStill/herald/pkg/lifecycle"
+)
+```
+
+Add the `NewWithCredential` constructor after the existing `New` function:
+
+```go
+func NewWithCredential(cfg *Config, cred azcore.TokenCredential, logger *slog.Logger) (System, error) {
+	connConfig, err := pgx.ParseConfig(cfg.Dsn())
+	if err != nil {
+		return nil, fmt.Errorf("parse database config: %w", err)
+	}
+
+	beforeConnect := stdlib.OptionBeforeConnect(
+		func(ctx context.Context, cc *pgx.ConnConfig) error {
+			token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+				Scopes: []string{TokenScope},
+			})
+			if err != nil {
+				return fmt.Errorf("acquire database token: %w", err)
+			}
+
+			cc.Password = token.Token
+			return nil
+		},
+	)
+
+	db := stdlib.OpenDB(*connConfig, beforeConnect)
+
+	db.SetMaxOpenConns(cfg.MaxOpenConns)
+	db.SetMaxIdleConns(cfg.MaxIdleConns)
+	db.SetConnMaxLifetime(cfg.TokenLifetimeDuration())
+
+	return &database{
+		conn:        db,
+		logger:      logger.With("system", "database"),
+		connTimeout: cfg.ConnTimeoutDuration(),
+	}, nil
+}
+```
+
+## Validation Criteria
+
+- [ ] `TokenLifetime` field on Config with 45m default, env override, merge, and validation
+- [ ] `NewWithCredential` constructor compiles with correct signature
+- [ ] `BeforeConnect` hook uses correct OSSRDBMS AAD scope
+- [ ] `NewWithCredential` uses `cfg.TokenLifetimeDuration()` for `ConnMaxLifetime`
+- [ ] `New` constructor unchanged — still uses `sql.Open("pgx", dsn)` with `ConnMaxLifetimeDuration()`
+- [ ] Blank `_ "github.com/jackc/pgx/v5/stdlib"` import removed (now imported directly)
+- [ ] `go vet ./...` passes

--- a/.claude/context/sessions/106-add-token-based-database-authentication.md
+++ b/.claude/context/sessions/106-add-token-based-database-authentication.md
@@ -1,0 +1,31 @@
+# 106 — Add Token-Based Database Authentication
+
+## Summary
+
+Added `NewWithCredential` constructor to `pkg/database/` that authenticates to Azure PostgreSQL using Entra tokens via a pgx `BeforeConnect` hook. The hook acquires a fresh token on each new connection using the `azcore.TokenCredential` interface. A configurable `TokenLifetime` field (default 45m) controls `ConnMaxLifetime` to force connection recycling before Entra token expiry (~1 hour).
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Token scope | Package-level `TokenScope` constant | Same across all Azure cloud instances; provides a single reference point |
+| Token lifetime | Configurable `TokenLifetime` on Config (default 45m) | Allows tuning per environment while preserving the safety net against token expiry |
+| Constructor pattern | `NewWithCredential` alongside `New` | Mirrors `pkg/storage/` dual-constructor pattern from #105 |
+| Hook mechanism | `stdlib.OptionBeforeConnect` | pgx v5 stdlib provides this option for `OpenDB`, avoids switching to `pgxpool` |
+
+## Files Modified
+
+- `pkg/database/constants.go` (new) — `TokenScope` constant
+- `pkg/database/config.go` — `TokenLifetime` field, `TokenLifetimeDuration()` accessor, defaults/env/merge/validate
+- `pkg/database/database.go` — `NewWithCredential` constructor, updated imports (blank → named stdlib, added azcore/pgx)
+- `internal/config/config.go` — `HERALD_DB_TOKEN_LIFETIME` env var mapping
+
+## Patterns Established
+
+- Database token scope as a package-level constant (`TokenScope`) for reuse by infrastructure wiring
+- Configurable token lifetime separate from connection max lifetime — each auth mode controls its own pool recycling
+
+## Validation Results
+
+- `go vet ./...` passes clean
+- No integration tests (requires Azure credentials + PostgreSQL — per project convention)

--- a/.claude/plans/golden-roaming-papert.md
+++ b/.claude/plans/golden-roaming-papert.md
@@ -1,0 +1,53 @@
+# 106 — Add Token-Based Database Authentication
+
+## Context
+
+Issue #106 is part of Objective #97 (Managed Identity for Azure Services). It adds a `NewWithCredential` constructor to `pkg/database/` that uses pgx's `BeforeConnect` hook to acquire Entra tokens for PostgreSQL authentication, with forced 45-minute `ConnMaxLifetime` as a token expiry safety net.
+
+## Files Modified
+
+- `pkg/database/database.go` — Add `NewWithCredential` constructor
+
+## Architecture Approach
+
+Follow the same dual-constructor pattern established by `pkg/storage/storage.go` (#105). The existing `New` constructor is unchanged. `NewWithCredential` uses `pgx.ParseConfig()` → `stdlib.OpenDB()` with `stdlib.OptionBeforeConnect()` to inject a fresh Entra token as the connection password on every new connection.
+
+Key details:
+- `pgx.ParseConfig(dsn)` parses the DSN (password will be empty — that's fine)
+- `stdlib.OptionBeforeConnect` injects a callback that calls `cred.GetToken()` with the OSSRDBMS AAD scope and sets `cc.Password = token.Token`
+- `stdlib.OpenDB(connConfig, beforeConnectOpt)` returns `*sql.DB` — preserves the existing interface
+- `ConnMaxLifetime` forced to 45 minutes regardless of config (Entra tokens expire ~1 hour)
+- `validate()` already does not require password — no change needed
+
+## Implementation
+
+### Step 1: Add `NewWithCredential` to `pkg/database/database.go`
+
+New imports needed:
+- `github.com/Azure/azure-sdk-for-go/sdk/azcore`
+- `github.com/Azure/azure-sdk-for-go/sdk/azcore/policy`
+- `github.com/jackc/pgx/v5` (already indirect dep, now direct)
+- `github.com/jackc/pgx/v5/stdlib` (already imported via blank import, now used directly)
+
+Constructor signature mirrors storage:
+```go
+func NewWithCredential(cfg *Config, cred azcore.TokenCredential, logger *slog.Logger) (System, error)
+```
+
+Body:
+1. `pgx.ParseConfig(cfg.Dsn())` — parse DSN into `*pgx.ConnConfig`
+2. Build `OptionBeforeConnect` callback that acquires token via `cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{"https://ossrdbms-aad.database.windows.net/.default"}})`
+3. `stdlib.OpenDB(*connConfig, beforeConnectOpt)` → `*sql.DB`
+4. Configure pool: `SetMaxOpenConns`, `SetMaxIdleConns`, force `SetConnMaxLifetime(45 * time.Minute)`
+5. Return `&database{conn, logger, connTimeout}`
+
+The blank import `_ "github.com/jackc/pgx/v5/stdlib"` changes to a named import `"github.com/jackc/pgx/v5/stdlib"` since we now call `stdlib.OpenDB` directly. The blank import is no longer needed — `stdlib.OpenDB` registers the driver as a side effect of the package being imported.
+
+## Validation Criteria
+
+- [ ] `NewWithCredential` constructor compiles with correct signature
+- [ ] `BeforeConnect` hook uses correct OSSRDBMS AAD scope
+- [ ] `ConnMaxLifetime` forced to 45 minutes in credential mode
+- [ ] `New` constructor unchanged — still uses `sql.Open("pgx", dsn)`
+- [ ] Blank `_ "github.com/jackc/pgx/v5/stdlib"` import removed (now imported directly)
+- [ ] `go vet ./...` passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.97.106
+- Add token-based database authentication with `NewWithCredential` constructor, pgx `BeforeConnect` hook for Entra token injection, configurable `TokenLifetime` (default 45m), and `TokenScope` constant (#106)
+
 ## v0.4.0-dev.97.105
 - Add credential-based storage constructor with `NewWithCredential` for managed identity auth, `ServiceURL` config field with env var override, and relaxed config validation (#105)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ var databaseEnv = &database.Env{
 	MaxIdleConns:    "HERALD_DB_MAX_IDLE_CONNS",
 	ConnMaxLifetime: "HERALD_DB_CONN_MAX_LIFETIME",
 	ConnTimeout:     "HERALD_DB_CONN_TIMEOUT",
+	TokenLifetime:   "HERALD_DB_TOKEN_LIFETIME",
 }
 
 var storageEnv = &storage.Env{

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	MaxIdleConns    int    `json:"max_idle_conns"`
 	ConnMaxLifetime string `json:"conn_max_lifetime"`
 	ConnTimeout     string `json:"conn_timeout"`
+	TokenLifetime   string `json:"token_lifetime"`
 }
 
 // Env maps config fields to environment variable names for override injection.
@@ -33,6 +34,7 @@ type Env struct {
 	MaxIdleConns    string
 	ConnMaxLifetime string
 	ConnTimeout     string
+	TokenLifetime   string
 }
 
 // ConnMaxLifetimeDuration returns ConnMaxLifetime as a time.Duration.
@@ -44,6 +46,12 @@ func (c *Config) ConnMaxLifetimeDuration() time.Duration {
 // ConnTimeoutDuration returns ConnTimeout as a time.Duration.
 func (c *Config) ConnTimeoutDuration() time.Duration {
 	d, _ := time.ParseDuration(c.ConnTimeout)
+	return d
+}
+
+// TokenLifetimeDuration returns TokenLifetime as a time.Duration.
+func (c *Config) TokenLifetimeDuration() time.Duration {
+	d, _ := time.ParseDuration(c.TokenLifetime)
 	return d
 }
 
@@ -96,6 +104,9 @@ func (c *Config) Merge(overlay *Config) {
 	if overlay.ConnTimeout != "" {
 		c.ConnTimeout = overlay.ConnTimeout
 	}
+	if overlay.TokenLifetime != "" {
+		c.TokenLifetime = overlay.TokenLifetime
+	}
 }
 
 func (c *Config) loadDefaults() {
@@ -119,6 +130,9 @@ func (c *Config) loadDefaults() {
 	}
 	if c.ConnTimeout == "" {
 		c.ConnTimeout = "5s"
+	}
+	if c.TokenLifetime == "" {
+		c.TokenLifetime = "45m"
 	}
 }
 
@@ -179,6 +193,11 @@ func (c *Config) loadEnv(env *Env) {
 			c.ConnTimeout = v
 		}
 	}
+	if env.TokenLifetime != "" {
+		if v := os.Getenv(env.TokenLifetime); v != "" {
+			c.TokenLifetime = v
+		}
+	}
 }
 
 func (c *Config) validate() error {
@@ -193,6 +212,9 @@ func (c *Config) validate() error {
 	}
 	if _, err := time.ParseDuration(c.ConnTimeout); err != nil {
 		return fmt.Errorf("invalid conn_timeout: %w", err)
+	}
+	if _, err := time.ParseDuration(c.TokenLifetime); err != nil {
+		return fmt.Errorf("invalid token_lifetime: %w", err)
 	}
 	return nil
 }

--- a/pkg/database/constants.go
+++ b/pkg/database/constants.go
@@ -1,0 +1,4 @@
+package database
+
+// TokenScope is the OAuth2 scope for Azure Database for PostgreSQL Entra authentication.
+const TokenScope = "https://ossrdbms-aad.database.windows.net/.default"

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -8,7 +8,10 @@ import (
 	"log/slog"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/JaimeStill/herald/pkg/lifecycle"
 )
@@ -39,6 +42,47 @@ func New(cfg *Config, logger *slog.Logger) (System, error) {
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
 	db.SetConnMaxLifetime(cfg.ConnMaxLifetimeDuration())
+
+	return &database{
+		conn:        db,
+		logger:      logger.With("system", "database"),
+		connTimeout: cfg.ConnTimeoutDuration(),
+	}, nil
+}
+
+// NewWithCredential creates a database system using an Azure token credential.
+// It configures a BeforeConnect hook that acquires a fresh Entra token on each
+// new connection. ConnMaxLifetime is set to TokenLifetime (default 45m) to force
+// connection recycling before token expiry.
+func NewWithCredential(
+	cfg *Config,
+	cred azcore.TokenCredential,
+	logger *slog.Logger,
+) (System, error) {
+	connConfig, err := pgx.ParseConfig(cfg.Dsn())
+	if err != nil {
+		return nil, fmt.Errorf("parse database config: %w", err)
+	}
+
+	beforeConnect := stdlib.OptionBeforeConnect(
+		func(ctx context.Context, cc *pgx.ConnConfig) error {
+			token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+				Scopes: []string{TokenScope},
+			})
+			if err != nil {
+				return fmt.Errorf("acquire database token: %w", err)
+			}
+
+			cc.Password = token.Token
+			return nil
+		},
+	)
+
+	db := stdlib.OpenDB(*connConfig, beforeConnect)
+
+	db.SetMaxOpenConns(cfg.MaxOpenConns)
+	db.SetMaxIdleConns(cfg.MaxIdleConns)
+	db.SetConnMaxLifetime(cfg.TokenLifetimeDuration())
 
 	return &database{
 		conn:        db,


### PR DESCRIPTION
## Summary

Add `NewWithCredential` constructor to `pkg/database/` for Entra token-based PostgreSQL authentication via managed identity. Uses pgx stdlib `BeforeConnect` hook to inject fresh tokens on each connection, with configurable `TokenLifetime` (default 45m) as a safety net against token expiry.

Closes #106

## Changes

- Add `TokenScope` constant (`pkg/database/constants.go`) for the OSSRDBMS AAD OAuth2 scope
- Add `TokenLifetime` config field with 45m default, env override (`HERALD_DB_TOKEN_LIFETIME`), merge, and validation
- Add `NewWithCredential(cfg, cred, logger)` constructor using `pgx.ParseConfig` → `stdlib.OpenDB` with `OptionBeforeConnect`
- Replace blank `_ "github.com/jackc/pgx/v5/stdlib"` import with named imports for `pgx/v5` and `pgx/v5/stdlib`
- Wire `HERALD_DB_TOKEN_LIFETIME` env var in `internal/config/config.go`