### PR TITLE
Add agent token provider for AI Foundry bearer auth

### DIFF
--- a/.claude/context/guides/.archive/107-add-agent-token-provider.md
+++ b/.claude/context/guides/.archive/107-add-agent-token-provider.md
@@ -1,0 +1,287 @@
+# 107 - Add agent token provider for AI Foundry bearer auth
+
+## Problem Context
+
+Herald's workflow nodes create agents via `agent.New(&rt.Agent)`, directly coupling the workflow package to `gaconfig.AgentConfig`. When managed identity is enabled (issue #108), agents need fresh Entra bearer tokens injected per-creation. This task replaces the direct config dependency with a `NewAgent` factory closure that encapsulates auth-mode-aware agent creation.
+
+## Architecture Approach
+
+`workflow.Runtime` receives a `NewAgent func(ctx context.Context) (agent.Agent, error)` factory closure built at the infrastructure layer during cold start. The factory resolves the auth strategy once — API key mode captures the config by value and delegates to `agent.New`, bearer mode (wired in #108) will acquire a cached token and inject it into a stack-local config copy. Workflow nodes call `rt.NewAgent(ctx)` without auth awareness.
+
+`Model` and `Provider` string fields on `Runtime` store the config-derived names for classification DB records.
+
+## Implementation
+
+### Step 1: Update workflow.Runtime
+
+**File:** `internal/workflow/runtime.go`
+
+Replace the entire file contents with:
+
+```go
+package workflow
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
+
+	"github.com/JaimeStill/herald/internal/documents"
+	"github.com/JaimeStill/herald/internal/prompts"
+	"github.com/JaimeStill/herald/pkg/storage"
+)
+
+type Runtime struct {
+	NewAgent func(ctx context.Context) (agent.Agent, error)
+	Model    string
+	Provider string
+	Storage  storage.System
+	Documents documents.System
+	Prompts   prompts.System
+	Logger    *slog.Logger
+}
+```
+
+### Step 2: Update classify node
+
+**File:** `internal/workflow/classify.go`
+
+Replace the `agent` import with nothing (remove it), and update the agent creation call.
+
+In the import block, remove:
+```go
+"github.com/JaimeStill/go-agents/pkg/agent"
+```
+
+In `classifyPages`, replace:
+```go
+a, err := agent.New(&rt.Agent)
+if err != nil {
+    return fmt.Errorf("page %d: create agent: %w", i+1, err)
+}
+```
+
+With:
+```go
+a, err := rt.NewAgent(gctx)
+if err != nil {
+    return fmt.Errorf("page %d: create agent: %w", i+1, err)
+}
+```
+
+### Step 3: Update enhance node
+
+**File:** `internal/workflow/enhance.go`
+
+In the import block, remove:
+```go
+"github.com/JaimeStill/go-agents/pkg/agent"
+```
+
+In `enhancePages`, replace:
+```go
+a, err := agent.New(&rt.Agent)
+if err != nil {
+    return fmt.Errorf("page %d: create agent: %w", cs.Pages[i].PageNumber, err)
+}
+```
+
+With:
+```go
+a, err := rt.NewAgent(gctx)
+if err != nil {
+    return fmt.Errorf("page %d: create agent: %w", cs.Pages[i].PageNumber, err)
+}
+```
+
+### Step 4: Update finalize node
+
+**File:** `internal/workflow/finalize.go`
+
+In the import block, remove:
+```go
+"github.com/JaimeStill/go-agents/pkg/agent"
+```
+
+In `synthesize`, replace:
+```go
+a, err := agent.New(&rt.Agent)
+if err != nil {
+    return fmt.Errorf("%w: create agent: %w", ErrFinalizeFailed, err)
+}
+```
+
+With:
+```go
+a, err := rt.NewAgent(ctx)
+if err != nil {
+    return fmt.Errorf("%w: create agent: %w", ErrFinalizeFailed, err)
+}
+```
+
+### Step 5: Update classification repository
+
+**File:** `internal/classifications/repository.go`
+
+Update the `New` function signature — replace the `agent gaconfig.AgentConfig` parameter with three parameters and update the `workflow.Runtime` construction:
+
+Replace:
+```go
+func New(
+	db *sql.DB,
+	agent gaconfig.AgentConfig,
+	logger *slog.Logger,
+	pagination pagination.Config,
+	storage storage.System,
+	docs documents.System,
+	prompts prompts.System,
+) System {
+	rt := &workflow.Runtime{
+		Agent:     agent,
+		Storage:   storage,
+		Documents: docs,
+		Prompts:   prompts,
+		Logger:    logger.With("workflow", "classify"),
+	}
+```
+
+With:
+```go
+func New(
+	db *sql.DB,
+	newAgent func(ctx context.Context) (agent.Agent, error),
+	modelName string,
+	providerName string,
+	logger *slog.Logger,
+	pagination pagination.Config,
+	storage storage.System,
+	docs documents.System,
+	prompts prompts.System,
+) System {
+	rt := &workflow.Runtime{
+		NewAgent:     newAgent,
+		Model:    modelName,
+		Provider: providerName,
+		Storage:      storage,
+		Documents:    docs,
+		Prompts:      prompts,
+		Logger:       logger.With("workflow", "classify"),
+	}
+```
+
+Update the imports — replace:
+```go
+gaconfig "github.com/JaimeStill/go-agents/pkg/config"
+```
+
+With:
+```go
+"github.com/JaimeStill/go-agents/pkg/agent"
+```
+
+Update the upsert args in the `Classify` method. Replace:
+```go
+r.rt.Agent.Model.Name,
+r.rt.Agent.Provider.Name,
+```
+
+With:
+```go
+r.rt.Model,
+r.rt.Provider,
+```
+
+### Step 6: Add NewAgent factory to Infrastructure
+
+**File:** `internal/infrastructure/infrastructure.go`
+
+Add `NewAgent` field to the struct:
+
+```go
+type Infrastructure struct {
+	Lifecycle  *lifecycle.Coordinator
+	Logger     *slog.Logger
+	Database   database.System
+	Storage    storage.System
+	Agent      gaconfig.AgentConfig
+	Credential azcore.TokenCredential
+	NewAgent   func(ctx context.Context) (agent.Agent, error)
+}
+```
+
+Add `"context"` to the import block.
+
+In the `New` function, after the agent validation block and before the return statement, build the factory:
+
+```go
+agentCfg := cfg.Agent
+newAgent := func(ctx context.Context) (agent.Agent, error) {
+	return agent.New(&agentCfg)
+}
+```
+
+Add `NewAgent: newAgent,` to the returned `Infrastructure` struct literal.
+
+### Step 7: Thread NewAgent through API runtime
+
+**File:** `internal/api/runtime.go`
+
+Add `NewAgent` to the inner `Infrastructure` struct in `NewRuntime`:
+
+```go
+return &Runtime{
+    Infrastructure: &infrastructure.Infrastructure{
+        Agent:      cfg.Agent,
+        Credential: infra.Credential,
+        Lifecycle:  infra.Lifecycle,
+        Logger:     infra.Logger.With("module", "api"),
+        Database:   infra.Database,
+        Storage:    infra.Storage,
+        NewAgent:   infra.NewAgent,
+    },
+    Pagination: cfg.API.Pagination,
+}
+```
+
+### Step 8: Update domain wiring
+
+**File:** `internal/api/domain.go`
+
+Update the `classifications.New()` call to pass the factory and metadata strings instead of the raw config:
+
+Replace:
+```go
+classificationsSystem := classifications.New(
+    runtime.Database.Connection(),
+    runtime.Agent,
+    runtime.Logger,
+    runtime.Pagination,
+    runtime.Storage,
+    docsSystem,
+    promptsSystem,
+)
+```
+
+With:
+```go
+classificationsSystem := classifications.New(
+    runtime.Database.Connection(),
+    runtime.NewAgent,
+    runtime.Agent.Model.Name,
+    runtime.Agent.Provider.Name,
+    runtime.Logger,
+    runtime.Pagination,
+    runtime.Storage,
+    docsSystem,
+    promptsSystem,
+)
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./cmd/server/` succeeds
+- [ ] No direct `agent.New` calls remain in `internal/workflow/`
+- [ ] `workflow.Runtime` has no `gaconfig.AgentConfig` dependency
+- [ ] `internal/api/domain.go` does not import `workflow`

--- a/.claude/context/sessions/107-add-agent-token-provider.md
+++ b/.claude/context/sessions/107-add-agent-token-provider.md
@@ -1,0 +1,37 @@
+# 107 - Add agent token provider for AI Foundry bearer auth
+
+## Summary
+
+Replaced direct `agent.New(&rt.Agent)` calls in workflow nodes with a `NewAgent` factory closure on `workflow.Runtime`. The factory is built at the infrastructure layer during cold start, encapsulating auth-mode-aware agent creation. Currently wires the API key path; issue #108 will add the bearer token branch based on `managed_identity` flag. Also extracted `Model` and `Provider` string fields onto `Runtime` for classification DB record metadata, removing `workflow`'s dependency on `gaconfig.AgentConfig`.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Factory closure vs TokenProvider field | Factory closure built at infrastructure layer | Resolves auth strategy once at cold start; workflow nodes just call `rt.NewAgent(ctx)` without auth awareness |
+| Config cloning scope | Stack-local ProviderConfig + Options map clone per call (bearer path, wired in #108) | Avoids concurrent map writes from errgroup goroutines; minimal clone scope |
+| Metadata access | `Model` and `Provider` string fields on Runtime | Extracted from config at wiring time; avoids Runtime depending on full AgentConfig |
+
+## Files Modified
+
+- `internal/workflow/runtime.go` — replaced `Agent gaconfig.AgentConfig` with `NewAgent` factory + `Model`/`Provider` strings
+- `internal/workflow/classify.go` — `rt.NewAgent(gctx)` replaces `agent.New(&rt.Agent)`
+- `internal/workflow/enhance.go` — same swap
+- `internal/workflow/finalize.go` — same swap
+- `internal/classifications/repository.go` — updated `New()` signature and metadata access
+- `internal/infrastructure/infrastructure.go` — added `NewAgent` factory field, built closure in `New()`
+- `internal/api/runtime.go` — threaded `NewAgent` through
+- `internal/api/domain.go` — passes factory + metadata to `classifications.New()`
+- `tests/infrastructure/infrastructure_test.go` — added `TestNewAgentFactory`
+
+## Patterns Established
+
+- **Agent factory closure**: Infrastructure builds `NewAgent func(ctx context.Context) (agent.Agent, error)` at cold start. Downstream consumers receive the factory, not raw config. This pattern scales to bearer auth (issue #108) by swapping the closure implementation without touching workflow code.
+
+## Validation Results
+
+- `go vet ./...` — passes
+- `go build ./cmd/server/` — passes
+- `go test ./tests/...` — all 20 packages pass
+- No direct `agent.New` calls in `internal/workflow/`
+- `workflow.Runtime` has no `gaconfig` dependency

--- a/.claude/plans/robust-snacking-lobster.md
+++ b/.claude/plans/robust-snacking-lobster.md
@@ -1,0 +1,83 @@
+# 107 - Add agent token provider for AI Foundry bearer auth
+
+## Context
+
+Part of Objective #97 (Managed Identity for Azure Services). When Herald runs with managed identity enabled, workflow agents need fresh Entra bearer tokens instead of a static API key. This task adds a `NewAgent` factory closure to `workflow.Runtime` that encapsulates auth-mode-aware agent creation, keeping workflow nodes clean.
+
+## Architecture Approach
+
+Replace `Runtime.Agent` (used as a template for `agent.New`) with a `NewAgent func(ctx context.Context) (agent.Agent, error)` factory closure built at the infrastructure/wiring layer. The factory resolves the auth strategy once at cold start:
+
+- **API key mode** (nil credential): closure captures config by value, returns `agent.New(&cfg)` — token already in config from startup
+- **Bearer mode** (non-nil credential): closure captures config + credential, acquires a cached token via Azure SDK, creates a stack-local `ProviderConfig` copy with the token injected (avoids concurrent map writes from errgroup goroutines), returns `agent.New(&cfg)`
+
+`workflow.Runtime` retains `ModelName` and `ProviderName` strings for classification DB records (replacing direct `Agent.Model.Name` / `Agent.Provider.Name` access).
+
+## Implementation
+
+### Step 1: Update workflow.Runtime
+
+**File:** `internal/workflow/runtime.go`
+
+- Replace `Agent gaconfig.AgentConfig` with:
+  - `NewAgent func(ctx context.Context) (agent.Agent, error)` — factory closure
+  - `ModelName string` — for classification DB records
+  - `ProviderName string` — for classification DB records
+- Remove `gaconfig` import, add `context` and agent imports
+
+### Step 2: Replace agent.New calls in workflow nodes
+
+**File:** `internal/workflow/classify.go` (line 82)
+- Replace `agent.New(&rt.Agent)` with `rt.NewAgent(gctx)`
+- Remove `agent` import
+
+**File:** `internal/workflow/enhance.go` (line 109)
+- Replace `agent.New(&rt.Agent)` with `rt.NewAgent(gctx)`
+- Remove `agent` import
+
+**File:** `internal/workflow/finalize.go` (line 48)
+- Replace `agent.New(&rt.Agent)` with `rt.NewAgent(ctx)`
+- Remove `agent` import
+
+### Step 3: Update classification repository metadata access
+
+**File:** `internal/classifications/repository.go`
+- Update `New()` signature: replace `agent gaconfig.AgentConfig` with `newAgent func(ctx context.Context) (agent.Agent, error)`, `modelName string`, `providerName string`
+- Set `NewAgent`, `ModelName`, `ProviderName` on `workflow.Runtime`
+- Update upsert args (lines 166-167): `r.rt.Agent.Model.Name` → `r.rt.ModelName`, `r.rt.Agent.Provider.Name` → `r.rt.ProviderName`
+- Remove `gaconfig` import
+
+### Step 4: Build factory closure in infrastructure wiring
+
+**File:** `internal/infrastructure/infrastructure.go`
+- Add `NewAgent func(ctx context.Context) (agent.Agent, error)` field to `Infrastructure`
+- Build the factory in `New()`:
+  - Current behavior (no managed identity): captures `cfg.Agent` by value, returns `agent.New(&cfg)`
+  - Bearer path will be wired in issue #108 when `managed_identity` flag is added
+
+**File:** `internal/api/runtime.go`
+- Thread `infra.NewAgent` through when constructing the inner `Infrastructure` in `NewRuntime`
+
+**File:** `internal/api/domain.go`
+- Update `classifications.New()` call: pass `runtime.NewAgent`, `runtime.Agent.Model.Name`, `runtime.Agent.Provider.Name` instead of `runtime.Agent`
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/workflow/runtime.go` | Replace `Agent` config with `NewAgent` factory + metadata strings |
+| `internal/workflow/classify.go` | `agent.New(&rt.Agent)` → `rt.NewAgent(gctx)` |
+| `internal/workflow/enhance.go` | `agent.New(&rt.Agent)` → `rt.NewAgent(gctx)` |
+| `internal/workflow/finalize.go` | `agent.New(&rt.Agent)` → `rt.NewAgent(ctx)` |
+| `internal/classifications/repository.go` | Updated `New()` signature + metadata access |
+| `internal/infrastructure/infrastructure.go` | Add `NewAgent` factory field |
+| `internal/api/runtime.go` | Thread `NewAgent` |
+| `internal/api/domain.go` | Pass factory + metadata to `classifications.New` |
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./cmd/server/` succeeds
+- [ ] All workflow nodes use `rt.NewAgent(ctx)` — no direct `agent.New` calls in workflow package
+- [ ] Nil credential preserves existing api_key behavior (no functional change)
+- [ ] `workflow.Runtime` has no `AgentConfig` dependency — only factory + metadata strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.97.107
+- Add agent factory closure to `workflow.Runtime` for auth-mode-aware agent creation, replacing direct `agent.New` calls in workflow nodes with `rt.NewAgent(ctx)` built at the infrastructure layer (#107)
+
 ## v0.4.0-dev.97.106
 - Add token-based database authentication with `NewWithCredential` constructor, pgx `BeforeConnect` hook for Entra token injection, configurable `TokenLifetime` (default 45m), and `TokenScope` constant (#106)
 

--- a/internal/api/domain.go
+++ b/internal/api/domain.go
@@ -30,7 +30,9 @@ func NewDomain(runtime *Runtime) *Domain {
 
 	classificationsSystem := classifications.New(
 		runtime.Database.Connection(),
-		runtime.Agent,
+		runtime.NewAgent,
+		runtime.Agent.Model.Name,
+		runtime.Agent.Provider.Name,
 		runtime.Logger,
 		runtime.Pagination,
 		runtime.Storage,

--- a/internal/api/runtime.go
+++ b/internal/api/runtime.go
@@ -22,6 +22,7 @@ func NewRuntime(cfg *config.Config, infra *infrastructure.Infrastructure) *Runti
 			Logger:     infra.Logger.With("module", "api"),
 			Database:   infra.Database,
 			Storage:    infra.Storage,
+			NewAgent:   infra.NewAgent,
 		},
 		Pagination: cfg.API.Pagination,
 	}

--- a/internal/classifications/repository.go
+++ b/internal/classifications/repository.go
@@ -18,7 +18,7 @@ import (
 	"github.com/JaimeStill/herald/pkg/repository"
 	"github.com/JaimeStill/herald/pkg/storage"
 
-	gaconfig "github.com/JaimeStill/go-agents/pkg/config"
+	"github.com/JaimeStill/go-agents/pkg/agent"
 )
 
 const streamBufferSize = 32
@@ -34,7 +34,9 @@ type repo struct {
 // It internally constructs the workflow runtime from the provided dependencies.
 func New(
 	db *sql.DB,
-	agent gaconfig.AgentConfig,
+	newAgent func(ctx context.Context) (agent.Agent, error),
+	modelName string,
+	providerName string,
 	logger *slog.Logger,
 	pagination pagination.Config,
 	storage storage.System,
@@ -42,7 +44,9 @@ func New(
 	prompts prompts.System,
 ) System {
 	rt := &workflow.Runtime{
-		Agent:     agent,
+		NewAgent:  newAgent,
+		Model:     modelName,
+		Provider:  providerName,
 		Storage:   storage,
 		Documents: docs,
 		Prompts:   prompts,
@@ -162,8 +166,8 @@ func (r *repo) Classify(ctx context.Context, documentID uuid.UUID) (<-chan workf
 			string(result.State.Confidence),
 			markingsJSON,
 			result.State.Rationale,
-			r.rt.Agent.Model.Name,
-			r.rt.Agent.Provider.Name,
+			r.rt.Model,
+			r.rt.Provider,
 		}
 
 		c, err := repository.WithTx(ctx, r.db, func(tx *sql.Tx) (Classification, error) {

--- a/internal/infrastructure/infrastructure.go
+++ b/internal/infrastructure/infrastructure.go
@@ -3,6 +3,7 @@
 package infrastructure
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -28,6 +29,7 @@ type Infrastructure struct {
 	Storage    storage.System
 	Agent      gaconfig.AgentConfig
 	Credential azcore.TokenCredential
+	NewAgent   func(ctx context.Context) (agent.Agent, error)
 }
 
 // New creates an Infrastructure from the application configuration.
@@ -57,6 +59,11 @@ func New(cfg *config.Config) (*Infrastructure, error) {
 		return nil, fmt.Errorf("agent validation failed: %w", err)
 	}
 
+	agentCfg := cfg.Agent
+	newAgent := func(ctx context.Context) (agent.Agent, error) {
+		return agent.New(&agentCfg)
+	}
+
 	return &Infrastructure{
 		Lifecycle:  lc,
 		Logger:     logger,
@@ -64,6 +71,7 @@ func New(cfg *config.Config) (*Infrastructure, error) {
 		Storage:    store,
 		Agent:      cfg.Agent,
 		Credential: cred,
+		NewAgent:   newAgent,
 	}, nil
 }
 

--- a/internal/workflow/classify.go
+++ b/internal/workflow/classify.go
@@ -9,8 +9,6 @@ import (
 	"github.com/JaimeStill/document-context/pkg/encoding"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/JaimeStill/go-agents/pkg/agent"
-
 	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
 
 	"github.com/JaimeStill/herald/internal/prompts"
@@ -79,7 +77,7 @@ func classifyPages(ctx context.Context, rt *Runtime, cs *ClassificationState) er
 				return gctx.Err()
 			}
 
-			a, err := agent.New(&rt.Agent)
+			a, err := rt.NewAgent(gctx)
 			if err != nil {
 				return fmt.Errorf("page %d: create agent: %w", i+1, err)
 			}

--- a/internal/workflow/enhance.go
+++ b/internal/workflow/enhance.go
@@ -11,8 +11,6 @@ import (
 	"github.com/JaimeStill/document-context/pkg/image"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/JaimeStill/go-agents/pkg/agent"
-
 	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
 
 	"github.com/JaimeStill/herald/internal/prompts"
@@ -106,7 +104,7 @@ func enhancePages(ctx context.Context, rt *Runtime, cs *ClassificationState, tem
 			}
 			defer pdfDoc.Close()
 
-			a, err := agent.New(&rt.Agent)
+			a, err := rt.NewAgent(gctx)
 			if err != nil {
 				return fmt.Errorf("page %d: create agent: %w", cs.Pages[i].PageNumber, err)
 			}

--- a/internal/workflow/finalize.go
+++ b/internal/workflow/finalize.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/JaimeStill/go-agents/pkg/agent"
-
 	"github.com/JaimeStill/go-agents-orchestration/pkg/state"
 
 	"github.com/JaimeStill/herald/internal/prompts"
@@ -45,7 +43,7 @@ func FinalizeNode(rt *Runtime) state.StateNode {
 }
 
 func synthesize(ctx context.Context, rt *Runtime, cs *ClassificationState) error {
-	a, err := agent.New(&rt.Agent)
+	a, err := rt.NewAgent(ctx)
 	if err != nil {
 		return fmt.Errorf("%w: create agent: %w", ErrFinalizeFailed, err)
 	}

--- a/internal/workflow/runtime.go
+++ b/internal/workflow/runtime.go
@@ -1,19 +1,22 @@
 package workflow
 
 import (
+	"context"
 	"log/slog"
+
+	"github.com/JaimeStill/go-agents/pkg/agent"
 
 	"github.com/JaimeStill/herald/internal/documents"
 	"github.com/JaimeStill/herald/internal/prompts"
 	"github.com/JaimeStill/herald/pkg/storage"
-
-	gaconfig "github.com/JaimeStill/go-agents/pkg/config"
 )
 
 // Runtime bundles the dependencies that workflow nodes require.
 // It is constructed by higher-level composition code from Infrastructure and Domain systems.
 type Runtime struct {
-	Agent     gaconfig.AgentConfig
+	NewAgent  func(ctx context.Context) (agent.Agent, error)
+	Model     string
+	Provider  string
 	Storage   storage.System
 	Documents documents.System
 	Prompts   prompts.System

--- a/tests/infrastructure/infrastructure_test.go
+++ b/tests/infrastructure/infrastructure_test.go
@@ -66,6 +66,30 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewAgentFactory(t *testing.T) {
+	infra, err := infrastructure.New(validConfig())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if infra.NewAgent == nil {
+		t.Fatal("NewAgent factory is nil")
+	}
+
+	a, err := infra.NewAgent(t.Context())
+	if err != nil {
+		t.Fatalf("NewAgent() error = %v", err)
+	}
+
+	if a.Model().Name != "llama3.1:8b" {
+		t.Errorf("model name = %q, want %q", a.Model().Name, "llama3.1:8b")
+	}
+
+	if a.Provider().Name() != "ollama" {
+		t.Errorf("provider name = %q, want %q", a.Provider().Name(), "ollama")
+	}
+}
+
 func TestNewDatabaseConnection(t *testing.T) {
 	infra, err := infrastructure.New(validConfig())
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replace direct `agent.New(&rt.Agent)` calls in workflow nodes with a `NewAgent` factory closure on `workflow.Runtime`
- Factory is built at the infrastructure layer during cold start, encapsulating auth strategy resolution
- Workflow nodes call `rt.NewAgent(ctx)` without any auth awareness
- Extract `Model` and `Provider` string fields onto `Runtime` for classification DB record metadata
- Remove `workflow` package's dependency on `gaconfig.AgentConfig`

Closes #107

## Changes

- **`internal/workflow/runtime.go`** — replace `Agent gaconfig.AgentConfig` with `NewAgent` factory + `Model`/`Provider` strings
- **`internal/workflow/classify.go`, `enhance.go`, `finalize.go`** — `rt.NewAgent(ctx)` replaces `agent.New(&rt.Agent)`
- **`internal/classifications/repository.go`** — updated `New()` signature, metadata access via `rt.Model`/`rt.Provider`
- **`internal/infrastructure/infrastructure.go`** — build `NewAgent` factory closure capturing config by value
- **`internal/api/runtime.go`** — thread `NewAgent` through
- **`internal/api/domain.go`** — pass factory + metadata to `classifications.New()`
- **`tests/infrastructure/infrastructure_test.go`** — added `TestNewAgentFactory`