### PR TITLE
Wire auth middleware into API module and populate validated_by from JWT

### DIFF
--- a/.claude/context/guides/.archive/114-wire-auth-middleware.md
+++ b/.claude/context/guides/.archive/114-wire-auth-middleware.md
@@ -1,0 +1,54 @@
+# 114 + 115 — Wire Auth Middleware and Populate validated_by
+
+## Problem Context
+
+Objective #98 (API Authentication Middleware) has three sub-issues. #113 (complete) added the `pkg/auth` package and `pkg/middleware` auth middleware. This session wires the middleware into the API module (#114) and uses the authenticated identity in classifications handlers (#115) to complete the objective.
+
+## Architecture Approach
+
+The auth middleware already accepts `*auth.Config` directly and handles `ModeNone` pass-through internally. No mapping layer or `APIConfig.Auth` field is needed — the middleware reads from the existing `Config.Auth`. The classifications handlers conditionally override `ValidatedBy`/`UpdatedBy` from the JWT context, preserving backward compatibility when auth is disabled.
+
+## Implementation
+
+### Step 1: Register auth middleware in API module
+
+**File:** `internal/api/api.go`
+
+Add `middleware.Auth` between CORS and Logger in `NewModule()`:
+
+```go
+m.Use(middleware.CORS(&cfg.API.CORS))
+m.Use(middleware.Auth(&cfg.Auth, runtime.Infrastructure.Logger))
+m.Use(middleware.Logger(runtime.Infrastructure.Logger))
+```
+
+### Step 2: Override validated_by from authenticated user
+
+**File:** `internal/classifications/handler.go`
+
+Add `"github.com/JaimeStill/herald/pkg/auth"` to imports.
+
+In the `Validate` handler, after JSON decode and before `h.sys.Validate()`:
+
+```go
+if user := auth.UserFromContext(r.Context()); user != nil {
+    cmd.ValidatedBy = user.Name
+}
+```
+
+In the `Update` handler, after JSON decode and before `h.sys.Update()`:
+
+```go
+if user := auth.UserFromContext(r.Context()); user != nil {
+    cmd.UpdatedBy = user.Name
+}
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go build ./cmd/server/` succeeds
+- [ ] Auth middleware registered between CORS and Logger in `api.NewModule()`
+- [ ] `auth_mode: "none"` (default) — middleware is pass-through, no behavioral change
+- [ ] Validate/Update handlers override identity from JWT when user is in context
+- [ ] Validate/Update handlers preserve request body value when no user in context

--- a/.claude/context/sessions/114-wire-auth-middleware.md
+++ b/.claude/context/sessions/114-wire-auth-middleware.md
@@ -1,0 +1,30 @@
+# 114 + 115 — Wire Auth Middleware and Populate validated_by
+
+## Summary
+
+Wired the auth middleware into the API module and connected authenticated user identity to the classifications domain. Combined #114 (middleware wiring) and #115 (validated_by population) into a single session since #114 was a one-line change. Together they complete Objective #98 (API Authentication Middleware).
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| No `APIConfig.Auth` field | Pass `Config.Auth` directly to middleware | #113 implemented middleware to accept `*auth.Config` — no mapping layer needed |
+| No `config.json` changes | Top-level `auth` section already sufficient | Adding `api.auth` would duplicate config without purpose |
+| Conditional override pattern | `if user := auth.UserFromContext(ctx)` | Preserves backward compatibility when auth is disabled |
+
+## Files Modified
+
+- `internal/api/api.go` — Added `middleware.Auth` registration between CORS and Logger
+- `internal/classifications/handler.go` — Added `pkg/auth` import, `UserFromContext` override in Validate and Update handlers
+- `tests/middleware/middleware_test.go` — Added 4 auth middleware tests (ModeNone passthrough, no token required, missing bearer, invalid bearer)
+- `tests/classifications/handler_test.go` — Added 4 handler auth context tests (validate/update with and without authenticated user)
+
+## Patterns Established
+
+- **Auth context override pattern**: `if user := auth.UserFromContext(r.Context()); user != nil { cmd.Field = user.Name }` — use in any handler that needs to derive identity from JWT when available, falling back to request body when auth is disabled.
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go build ./cmd/server/` — success
+- 20/20 test packages pass (8 new tests added across middleware and classifications)

--- a/.claude/plans/agile-soaring-reef.md
+++ b/.claude/plans/agile-soaring-reef.md
@@ -1,0 +1,57 @@
+# 114 + 115 — Wire Auth Middleware and Populate validated_by
+
+## Context
+
+Sub-issues 2 and 3 of Objective #98 (API Authentication Middleware). #114 connects the auth middleware to the API module. #115 uses the authenticated identity in classifications handlers. Combined because #114 is a one-line change and both are needed to complete the objective.
+
+## Changes
+
+### Step 1: `internal/api/api.go` — Register auth middleware (#114)
+
+Add `middleware.Auth(&cfg.Auth, logger)` between CORS and Logger:
+
+```go
+m.Use(middleware.CORS(&cfg.API.CORS))
+m.Use(middleware.Auth(&cfg.Auth, runtime.Infrastructure.Logger))
+m.Use(middleware.Logger(runtime.Infrastructure.Logger))
+```
+
+No `APIConfig.Auth` field needed — middleware reads `Config.Auth` directly. No `config.json` changes — top-level `auth` section already provides the config.
+
+### Step 2: `internal/classifications/handler.go` — Override validated_by from JWT (#115)
+
+In the `Validate` handler, after JSON decode and before calling `h.sys.Validate()`:
+
+```go
+if user := auth.UserFromContext(r.Context()); user != nil {
+    cmd.ValidatedBy = user.Name
+}
+```
+
+In the `Update` handler, after JSON decode and before calling `h.sys.Update()`:
+
+```go
+if user := auth.UserFromContext(r.Context()); user != nil {
+    cmd.UpdatedBy = user.Name
+}
+```
+
+Add `"github.com/JaimeStill/herald/pkg/auth"` to imports.
+
+**Behavior:**
+- `auth_mode: "none"` → no user in context → request body value used (existing behavior)
+- `auth_mode: "azure"` → user extracted from JWT → overrides request body value
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/api/api.go` | Add `middleware.Auth` call |
+| `internal/classifications/handler.go` | Import `pkg/auth`, override `ValidatedBy`/`UpdatedBy` from context |
+
+## Verification
+
+- `go vet ./...` passes
+- `go build ./cmd/server/` succeeds
+- Server starts with `auth_mode: "none"` — middleware is pass-through, no behavioral change
+- Validate/Update handlers still accept body values when no user in context

--- a/.claude/skills/web-development/references/build.md
+++ b/.claude/skills/web-development/references/build.md
@@ -89,5 +89,5 @@ Key settings in `tsconfig.json`:
 
 - `target: "es2024"` — modern JavaScript output
 - `experimentalDecorators: true` — required for Lit decorators
-- `useDefineForClassFields: false` — required for Lit reactivity (class fields must use [[Set]] semantics)
+- `useDefineForClassFields: false` — required for Lit reactivity (class fields must use `[Set]` semantics)
 - `moduleResolution: "bundler"` — matches Bun's resolution strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.98.114
+- Wire auth middleware into API module between CORS and Logger; populate `validated_by` from authenticated JWT user identity in classifications Validate and Update handlers with backward-compatible fallback to request body when auth is disabled (#114, #115)
+
 ## v0.4.0-dev.98.113
 - Add `pkg/auth/` package with unified auth config, User context helpers, and error sentinels; add JWT validation middleware using `go-oidc` for OIDC discovery and token verification; move auth config from `internal/config/` to `pkg/auth/` following package-owns-config pattern; document dependency criteria in project README (#113)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -20,6 +20,7 @@ func NewModule(cfg *config.Config, infra *infrastructure.Infrastructure) (*modul
 
 	m := module.New(cfg.API.BasePath, mux)
 	m.Use(middleware.CORS(&cfg.API.CORS))
+	m.Use(middleware.Auth(&cfg.Auth, runtime.Infrastructure.Logger))
 	m.Use(middleware.Logger(runtime.Infrastructure.Logger))
 
 	return m, nil

--- a/internal/classifications/handler.go
+++ b/internal/classifications/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/JaimeStill/herald/pkg/auth"
 	"github.com/JaimeStill/herald/pkg/handlers"
 	"github.com/JaimeStill/herald/pkg/pagination"
 	"github.com/JaimeStill/herald/pkg/routes"
@@ -185,6 +186,10 @@ func (h *Handler) Validate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		cmd.ValidatedBy = user.Name
+	}
+
 	c, err := h.sys.Validate(r.Context(), id, cmd)
 	if err != nil {
 		handlers.RespondError(w, h.logger, MapHTTPStatus(err), err)
@@ -207,6 +212,10 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil {
 		handlers.RespondError(w, h.logger, http.StatusBadRequest, err)
 		return
+	}
+
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		cmd.UpdatedBy = user.Name
 	}
 
 	c, err := h.sys.Update(r.Context(), id, cmd)

--- a/tests/classifications/handler_test.go
+++ b/tests/classifications/handler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/JaimeStill/herald/internal/classifications"
 	"github.com/JaimeStill/herald/internal/workflow"
+	"github.com/JaimeStill/herald/pkg/auth"
 	"github.com/JaimeStill/herald/pkg/pagination"
 )
 
@@ -549,6 +550,58 @@ func TestHandlerValidate(t *testing.T) {
 			t.Errorf("status = %d, want 409", rec.Code)
 		}
 	})
+
+	t.Run("authenticated user overrides validated_by", func(t *testing.T) {
+		var capturedCmd classifications.ValidateCommand
+		sys := &mockSystem{
+			validateFn: func(_ context.Context, _ uuid.UUID, cmd classifications.ValidateCommand) (*classifications.Classification, error) {
+				capturedCmd = cmd
+				return &c, nil
+			},
+		}
+		mux := setupMux(newTestHandler(sys))
+
+		body, _ := json.Marshal(classifications.ValidateCommand{ValidatedBy: "body-user"})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/classifications/"+c.ID.String()+"/validate", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		ctx := auth.ContextWithUser(req.Context(), &auth.User{ID: "oid-123", Name: "JWT User", Email: "jwt@example.com"})
+		req = req.WithContext(ctx)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if capturedCmd.ValidatedBy != "JWT User" {
+			t.Errorf("validated_by = %q, want %q", capturedCmd.ValidatedBy, "JWT User")
+		}
+	})
+
+	t.Run("no auth user preserves body validated_by", func(t *testing.T) {
+		var capturedCmd classifications.ValidateCommand
+		sys := &mockSystem{
+			validateFn: func(_ context.Context, _ uuid.UUID, cmd classifications.ValidateCommand) (*classifications.Classification, error) {
+				capturedCmd = cmd
+				return &c, nil
+			},
+		}
+		mux := setupMux(newTestHandler(sys))
+
+		body, _ := json.Marshal(classifications.ValidateCommand{ValidatedBy: "body-user"})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/classifications/"+c.ID.String()+"/validate", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if capturedCmd.ValidatedBy != "body-user" {
+			t.Errorf("validated_by = %q, want %q", capturedCmd.ValidatedBy, "body-user")
+		}
+	})
 }
 
 func TestHandlerUpdate(t *testing.T) {
@@ -644,6 +697,66 @@ func TestHandlerUpdate(t *testing.T) {
 
 		if rec.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409", rec.Code)
+		}
+	})
+
+	t.Run("authenticated user overrides updated_by", func(t *testing.T) {
+		var capturedCmd classifications.UpdateCommand
+		sys := &mockSystem{
+			updateFn: func(_ context.Context, _ uuid.UUID, cmd classifications.UpdateCommand) (*classifications.Classification, error) {
+				capturedCmd = cmd
+				return &c, nil
+			},
+		}
+		mux := setupMux(newTestHandler(sys))
+
+		body, _ := json.Marshal(classifications.UpdateCommand{
+			Classification: "TOP SECRET",
+			Rationale:      "Updated rationale.",
+			UpdatedBy:      "body-user",
+		})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/classifications/"+c.ID.String(), bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		ctx := auth.ContextWithUser(req.Context(), &auth.User{ID: "oid-456", Name: "JWT Reviewer", Email: "reviewer@example.com"})
+		req = req.WithContext(ctx)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if capturedCmd.UpdatedBy != "JWT Reviewer" {
+			t.Errorf("updated_by = %q, want %q", capturedCmd.UpdatedBy, "JWT Reviewer")
+		}
+	})
+
+	t.Run("no auth user preserves body updated_by", func(t *testing.T) {
+		var capturedCmd classifications.UpdateCommand
+		sys := &mockSystem{
+			updateFn: func(_ context.Context, _ uuid.UUID, cmd classifications.UpdateCommand) (*classifications.Classification, error) {
+				capturedCmd = cmd
+				return &c, nil
+			},
+		}
+		mux := setupMux(newTestHandler(sys))
+
+		body, _ := json.Marshal(classifications.UpdateCommand{
+			Classification: "TOP SECRET",
+			Rationale:      "Updated rationale.",
+			UpdatedBy:      "body-user",
+		})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/classifications/"+c.ID.String(), bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if capturedCmd.UpdatedBy != "body-user" {
+			t.Errorf("updated_by = %q, want %q", capturedCmd.UpdatedBy, "body-user")
 		}
 	})
 }

--- a/tests/middleware/middleware_test.go
+++ b/tests/middleware/middleware_test.go
@@ -1,12 +1,14 @@
 package middleware_test
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/JaimeStill/herald/pkg/auth"
 	"github.com/JaimeStill/herald/pkg/middleware"
 )
 
@@ -220,6 +222,108 @@ func TestCORSConfigFinalizeEnv(t *testing.T) {
 	}
 	if !cfg.AllowCredentials {
 		t.Error("allow_credentials should be true")
+	}
+}
+
+func TestAuthModeNonePassthrough(t *testing.T) {
+	cfg := &auth.Config{Mode: auth.ModeNone}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var handlerCalled bool
+	handler := middleware.Auth(cfg, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	handler.ServeHTTP(rec, req)
+
+	if !handlerCalled {
+		t.Error("handler should be called when auth mode is none")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthModeNoneNoTokenRequired(t *testing.T) {
+	cfg := &auth.Config{Mode: auth.ModeNone}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler := middleware.Auth(cfg, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if user := auth.UserFromContext(r.Context()); user != nil {
+			t.Error("user should not be in context when auth is disabled")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthModeAzureMissingBearer(t *testing.T) {
+	cfg := &auth.Config{
+		Mode:     auth.ModeAzure,
+		TenantID: "test-tenant",
+		ClientID: "test-client",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var handlerCalled bool
+	handler := middleware.Auth(cfg, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	handler.ServeHTTP(rec, req)
+
+	if handlerCalled {
+		t.Error("handler should not be called without bearer token")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("error response should contain an error message")
+	}
+}
+
+func TestAuthModeAzureInvalidBearer(t *testing.T) {
+	cfg := &auth.Config{
+		Mode:      auth.ModeAzure,
+		TenantID:  "test-tenant",
+		ClientID:  "test-client",
+		Authority: "http://localhost:0/invalid",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var handlerCalled bool
+	handler := middleware.Auth(cfg, logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	handler.ServeHTTP(rec, req)
+
+	if handlerCalled {
+		t.Error("handler should not be called with invalid token")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

Register auth middleware between CORS and Logger in the API module, connecting the `pkg/auth` config and `pkg/middleware/auth` middleware from #113 to the application layer. Add `UserFromContext` override in classifications Validate and Update handlers to populate `validated_by` from the authenticated JWT user identity, with backward-compatible fallback to request body values when auth is disabled.

Closes #114
Closes #115

## Changes

- **`internal/api/api.go`** — Add `middleware.Auth(&cfg.Auth, logger)` between CORS and Logger
- **`internal/classifications/handler.go`** — Import `pkg/auth`, override `ValidatedBy`/`UpdatedBy` from JWT context in Validate and Update handlers
- **`tests/middleware/middleware_test.go`** — Add auth middleware tests (ModeNone passthrough, missing bearer rejection, invalid bearer rejection)
- **`tests/classifications/handler_test.go`** — Add handler auth context tests (validate/update with and without authenticated user)
- **`CHANGELOG.md`** — Add `v0.4.0-dev.98.114` entry