### PR TITLE
Inject auth config into web app HTML template

### DIFF
--- a/.claude/context/guides/.archive/118-inject-auth-config-web-template.md
+++ b/.claude/context/guides/.archive/118-inject-auth-config-web-template.md
@@ -1,0 +1,195 @@
+# 118 — Inject auth config into web app HTML template
+
+## Problem Context
+
+Sub-issue 1 of Objective #99 (Web Client MSAL.js Integration). The Lit SPA needs MSAL configuration (tenant ID, client ID, redirect URI, authority) available synchronously at page load before any JS executes. The Go server has all auth config in `pkg/auth.Config`, but `app.NewModule` currently receives only a `basePath` string and the `ViewData.Data` field is always empty.
+
+## Architecture Approach
+
+Define a browser-safe `ClientAuthConfig` struct in the `app` package containing only fields safe for client exposure (no `ClientSecret`). The Go template uses `{{ if .Data }}` to conditionally render a `<script id="herald-config" type="application/json">` tag. When auth mode is `none`, `Data` is nil and the block is skipped. JSON is wrapped in `template.JS` to prevent `html/template` from escaping it inside the `<script>` tag. A new `PageHandlerWithData` method on `TemplateSet` populates `ViewData.Data` without modifying the existing `PageHandler`.
+
+## Implementation
+
+### Step 1: Add `PageHandlerWithData` to `pkg/web/views.go`
+
+Add this method after the existing `PageHandler`:
+
+```go
+func (ts *TemplateSet) PageHandlerWithData(layout string, view ViewDef, data any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		d := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+			Data:     data,
+		}
+		if err := ts.Render(w, layout, view.Template, d); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+```
+
+### Step 2: Update `app/app.go` — Add `ClientAuthConfig` and update `NewModule`
+
+Add the `ClientAuthConfig` struct and update the module constructor:
+
+```go
+package app
+
+import (
+	"embed"
+	"encoding/json"
+	"html/template"
+	"net/http"
+
+	"github.com/JaimeStill/herald/pkg/module"
+	"github.com/JaimeStill/herald/pkg/web"
+)
+
+// ClientAuthConfig holds the browser-safe subset of auth configuration
+// needed by the web client for MSAL.js initialization.
+type ClientAuthConfig struct {
+	TenantID    string `json:"tenant_id"`
+	ClientID    string `json:"client_id"`
+	RedirectURI string `json:"redirect_uri"`
+	Authority   string `json:"authority"`
+}
+```
+
+Update `NewModule` to accept auth config:
+
+```go
+func NewModule(basePath string, authCfg *ClientAuthConfig) (*module.Module, error) {
+	ts, err := web.NewTemplateSet(
+		layoutFS,
+		viewFS,
+		"server/layouts/*.html",
+		"server/views",
+		basePath,
+		views,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var data any
+	if authCfg != nil {
+		authCfg.RedirectURI = basePath + "/"
+		b, err := json.Marshal(authCfg)
+		if err != nil {
+			return nil, err
+		}
+		data = template.JS(b)
+	}
+
+	router := buildRouter(ts, data)
+	return module.New(basePath, router), nil
+}
+```
+
+Update `buildRouter` to accept and pass data:
+
+```go
+func buildRouter(ts *web.TemplateSet, data any) http.Handler {
+	r := web.NewRouter()
+
+	r.Handle("GET /dist/", web.DistServer(distFS, "dist", "/dist/"))
+
+	if data != nil {
+		r.SetFallback(ts.PageHandlerWithData("app.html", views[0], data))
+	} else {
+		r.SetFallback(ts.PageHandler("app.html", views[0]))
+	}
+
+	return r
+}
+```
+
+### Step 3: Update `app/server/layouts/app.html`
+
+Add conditional config script in `<head>` and user-menu placeholder in `<header>`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <base href="{{ .BasePath }}/" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ .Title }} - Herald</title>
+    <link rel="stylesheet" href="dist/{{ .Bundle }}.css" />
+    {{ if .Data }}<script id="herald-config" type="application/json">{{ .Data }}</script>{{ end }}
+  </head>
+
+  <body>
+    <header class="app-header">
+      <a href="" class="brand">Herald</a>
+      <nav>
+        <a href="prompts">Prompts</a>
+      </nav>
+      {{ if .Data }}<div id="user-menu"></div>{{ end }}
+    </header>
+    <main id="app-content">{{ block "content" . }}{{ end }}</main>
+
+    <script type="module" src="dist/{{ .Bundle }}.js"></script>
+  </body>
+</html>
+```
+
+### Step 4: Update `cmd/server/modules.go`
+
+Pass auth config subset from `cfg.Auth` to `app.NewModule`:
+
+```go
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/JaimeStill/herald/app"
+	"github.com/JaimeStill/herald/internal/api"
+	"github.com/JaimeStill/herald/internal/config"
+	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/auth"
+	"github.com/JaimeStill/herald/pkg/module"
+)
+```
+
+Update `NewModules`:
+
+```go
+func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modules, error) {
+	apiModule, err := api.NewModule(cfg, infra)
+	if err != nil {
+		return nil, err
+	}
+
+	var authCfg *app.ClientAuthConfig
+	if cfg.Auth.Mode == auth.ModeAzure {
+		authCfg = &app.ClientAuthConfig{
+			TenantID:  cfg.Auth.TenantID,
+			ClientID:  cfg.Auth.ClientID,
+			Authority: cfg.Auth.Authority,
+		}
+	}
+
+	appModule, err := app.NewModule("/app", authCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Modules{
+		API: apiModule,
+		App: appModule,
+	}, nil
+}
+```
+
+## Validation Criteria
+
+- [ ] `app.NewModule` accepts auth config (browser-safe subset only, no `ClientSecret`)
+- [ ] `cmd/server/modules.go` passes auth config from `cfg.Auth` to app module
+- [ ] `app.html` conditionally renders `<script id="herald-config" type="application/json">` with tenant_id, client_id, redirect_uri, authority when auth mode is azure
+- [ ] When auth mode is `none`, no config script tag is rendered
+- [ ] `<div id="user-menu"></div>` placeholder conditionally added to header when auth is enabled
+- [ ] `go vet ./...` passes

--- a/.claude/context/sessions/118-inject-auth-config-web-template.md
+++ b/.claude/context/sessions/118-inject-auth-config-web-template.md
@@ -1,0 +1,35 @@
+# 118 — Inject auth config into web app HTML template
+
+## Summary
+
+Added browser-safe auth config injection from the Go server into the HTML template for MSAL.js initialization. When auth mode is `azure`, a `<script id="herald-config" type="application/json">` tag and `<div id="user-menu">` placeholder are conditionally rendered. When auth mode is `none`, neither element appears.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| `template.JS` wrapping | JSON marshaled to `template.JS` | Prevents `html/template` from HTML-escaping JSON inside `<script>` tag |
+| `PageHandlerWithData` | New method on `TemplateSet` | Preserves existing `PageHandler` behavior; explicit about persistent data |
+| `ClientAuthConfig` location | `app` package | Browser-safe subset is an app concern; avoids coupling `pkg/auth` to template rendering |
+| `RedirectURI` derivation | Set from `basePath + "/"` in `NewModule` | Server knows the base path; client prepends `window.location.origin` |
+| Conditional user-menu | Rendered only when auth enabled | No user to display in `none` mode; keeps DOM clean |
+
+## Files Modified
+
+- `app/app.go` — Added `ClientAuthConfig` struct, updated `NewModule` signature and `buildRouter`
+- `pkg/web/views.go` — Added `PageHandlerWithData` method
+- `app/server/layouts/app.html` — Conditional config script tag and user-menu div
+- `cmd/server/modules.go` — Constructs `ClientAuthConfig` from `cfg.Auth` when mode is azure
+- `tests/app/app_test.go` — Updated existing tests for new signature, added `TestAuthConfigInjection` and `TestNoAuthConfigWhenNil`
+
+## Patterns Established
+
+- **Browser-safe config subset**: Define a dedicated struct in the consuming package with only client-safe fields, construct from full config at the composition root
+- **Conditional template data**: Use `ViewData.Data` with `{{ if .Data }}` for optional template blocks; `template.JS` for safe JSON embedding in `<script>` tags
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go build ./cmd/server/` — compiles
+- `go test ./tests/...` — 20/20 packages pass
+- New tests: `TestAuthConfigInjection` (verifies all JSON fields + user-menu), `TestNoAuthConfigWhenNil` (verifies absence)

--- a/.claude/plans/goofy-juggling-kazoo.md
+++ b/.claude/plans/goofy-juggling-kazoo.md
@@ -1,0 +1,58 @@
+# Plan: #118 — Inject auth config into web app HTML template
+
+## Context
+
+The Lit SPA needs MSAL configuration at page load to initialize `@azure/msal-browser` (sub-issue #119). The Go server has all auth config in `pkg/auth.Config`, but `app.NewModule` currently receives only a `basePath` string and `ViewData.Data` is always empty. This task injects a browser-safe subset of auth config into the HTML template via a `<script type="application/json">` tag, conditionally rendered only when auth mode is azure.
+
+## Approach
+
+Four files, each with a small targeted change:
+
+### 1. `app/app.go` — Define `ClientAuthConfig`, update `NewModule` signature
+
+- Add `ClientAuthConfig` struct with browser-safe fields only: `TenantID`, `ClientID`, `RedirectURI`, `Authority` (JSON-tagged as snake_case)
+- Change `NewModule(basePath string)` → `NewModule(basePath string, authCfg *ClientAuthConfig)`
+- When `authCfg` is non-nil: set `RedirectURI = basePath + "/"`, marshal to JSON, wrap in `template.JS` (prevents html/template from HTML-escaping the JSON inside `<script>`)
+- Pass the `template.JS` value to `buildRouter` → `PageHandlerWithData`
+- When `authCfg` is nil (auth mode "none"): pass `nil` as data — template skips the config block
+
+### 2. `pkg/web/views.go` — Add `PageHandlerWithData` method
+
+- New method: `PageHandlerWithData(layout string, view ViewDef, data any) http.HandlerFunc`
+- Identical to `PageHandler` but sets `ViewData.Data = data`
+- Existing `PageHandler` unchanged — no impact on other consumers
+
+### 3. `app/server/layouts/app.html` — Conditional config script + user-menu placeholder
+
+- Inside `<head>`, before the closing `</head>`: `{{ if .Data }}<script id="herald-config" type="application/json">{{ .Data }}</script>{{ end }}`
+- In `<header>`, after `<nav>`: `{{ if .Data }}<div id="user-menu"></div>{{ end }}` — only rendered when auth is enabled (no user to display otherwise)
+
+### 4. `cmd/server/modules.go` — Pass auth config from `cfg.Auth`
+
+- Import `auth` package, construct `*app.ClientAuthConfig` when `cfg.Auth.Mode == auth.ModeAzure`
+- Pass `nil` when mode is `"none"`
+- Pass the config to `app.NewModule(basePath, authCfg)`
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| `template.JS` for JSON | Wrap marshaled JSON in `template.JS` | `html/template` applies JS escaping inside `<script>` tags — `template.JS` marks it as safe |
+| `PageHandlerWithData` | New method, not modify existing | No impact on existing `PageHandler` callers; explicit about intent |
+| `RedirectURI` from `basePath` | Set in `NewModule` as `basePath + "/"` | Server knows the base path; client (in #119) prepends `window.location.origin` |
+| `ClientAuthConfig` in `app` pkg | Not in `pkg/auth` | Browser-safe subset is an app concern; avoids coupling `pkg/auth` to template rendering |
+
+## Files Modified
+
+- `app/app.go`
+- `pkg/web/views.go`
+- `app/server/layouts/app.html`
+- `cmd/server/modules.go`
+
+## Validation
+
+- `go vet ./...` passes
+- `go build ./cmd/server/` compiles
+- With auth mode `none` (default): no `<script id="herald-config">` in rendered HTML
+- With auth mode `azure` + tenant/client config: `<script id="herald-config">` contains valid JSON with `tenant_id`, `client_id`, `redirect_uri`, `authority`
+- `<div id="user-menu"></div>` present in header regardless of auth mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.99.118
+- Inject browser-safe auth config into web app HTML template for MSAL.js initialization; add `ClientAuthConfig` struct, `PageHandlerWithData` method, and conditional `<script id="herald-config">` rendering when auth mode is azure (#118)
+
 ## v0.4.0-dev.98.114
 - Wire auth middleware into API module between CORS and Logger; populate `validated_by` from authenticated JWT user identity in classifications Validate and Update handlers with backward-compatible fallback to request body when auth is disabled (#114, #115)
 

--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,8 @@ package app
 
 import (
 	"embed"
+	"encoding/json"
+	"html/template"
 	"net/http"
 
 	"github.com/JaimeStill/herald/pkg/module"
@@ -23,10 +25,20 @@ var views = []web.ViewDef{
 	{Route: "/{path...}", Template: "shell.html", Title: "Herald", Bundle: "app"},
 }
 
+// ClientAuthConfig holds the browser-safe subset of auth configuration
+// injected into the HTML template for MSAL.js initialization. ClientSecret
+// is deliberately excluded — only fields safe for client exposure are included.
+type ClientAuthConfig struct {
+	TenantID    string `json:"tenant_id"`
+	ClientID    string `json:"client_id"`
+	RedirectURI string `json:"redirect_uri"`
+	Authority   string `json:"authority"`
+}
+
 // NewModule creates the web app module configured for the given base path.
 // All routes under the base path serve the SPA shell template, with /dist/
 // serving embedded static assets (JS, CSS).
-func NewModule(basePath string) (*module.Module, error) {
+func NewModule(basePath string, authCfg *ClientAuthConfig) (*module.Module, error) {
 	ts, err := web.NewTemplateSet(
 		layoutFS,
 		viewFS,
@@ -38,16 +50,30 @@ func NewModule(basePath string) (*module.Module, error) {
 	if err != nil {
 		return nil, err
 	}
+	var data any
+	if authCfg != nil {
+		authCfg.RedirectURI = basePath + "/"
+		b, err := json.Marshal(authCfg)
+		if err != nil {
+			return nil, err
+		}
+		data = template.JS(b)
+	}
 
-	router := buildRouter(ts)
+	router := buildRouter(ts, data)
 	return module.New(basePath, router), nil
 }
 
-func buildRouter(ts *web.TemplateSet) http.Handler {
+func buildRouter(ts *web.TemplateSet, data any) http.Handler {
 	r := web.NewRouter()
 
 	r.Handle("GET /dist/", web.DistServer(distFS, "dist", "/dist/"))
-	r.SetFallback(ts.PageHandler("app.html", views[0]))
+
+	if data != nil {
+		r.SetFallback(ts.PageHandlerWithData("app.html", views[0], data))
+	} else {
+		r.SetFallback(ts.PageHandler("app.html", views[0]))
+	}
 
 	return r
 }

--- a/app/server/layouts/app.html
+++ b/app/server/layouts/app.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ .Title }} - Herald</title>
     <link rel="stylesheet" href="dist/{{ .Bundle }}.css" />
+    {{ if .Data }}
+    <script id="herald-config" type="application/json">
+      {{ .Data }}
+    </script>
+    {{ end }}
   </head>
 
   <body>
@@ -14,6 +19,9 @@
       <nav>
         <a href="prompts">Prompts</a>
       </nav>
+      {{ if .Data }}
+      <div id="user-menu"></div>
+      {{ end }}
     </header>
     <main id="app-content">{{ block "content" . }}{{ end }}</main>
 

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/JaimeStill/herald/internal/api"
 	"github.com/JaimeStill/herald/internal/config"
 	"github.com/JaimeStill/herald/internal/infrastructure"
+	"github.com/JaimeStill/herald/pkg/auth"
 	"github.com/JaimeStill/herald/pkg/module"
 )
 
@@ -22,7 +23,16 @@ func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modu
 		return nil, err
 	}
 
-	appModule, err := app.NewModule("/app")
+	var authCfg *app.ClientAuthConfig
+	if cfg.Auth.Mode == auth.ModeAzure {
+		authCfg = &app.ClientAuthConfig{
+			TenantID:  cfg.Auth.TenantID,
+			ClientID:  cfg.Auth.ClientID,
+			Authority: cfg.Auth.Authority,
+		}
+	}
+
+	appModule, err := app.NewModule("/app", authCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/web/views.go
+++ b/pkg/web/views.go
@@ -97,6 +97,26 @@ func (ts *TemplateSet) PageHandler(layout string, view ViewDef) http.HandlerFunc
 	}
 }
 
+// PageHandlerWithData returns an HTTP handler that renders the given view
+// with persistent data populated in ViewData.Data for every request.
+func (ts *TemplateSet) PageHandlerWithData(
+	layout string,
+	view ViewDef,
+	data any,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		d := ViewData{
+			Title:    view.Title,
+			Bundle:   view.Bundle,
+			BasePath: ts.basePath,
+			Data:     data,
+		}
+		if err := ts.Render(w, layout, view.Template, d); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
 // Render executes the named layout template with the given view data.
 func (ts *TemplateSet) Render(w http.ResponseWriter, layoutName, viewPath string, data ViewData) error {
 	t, ok := ts.views[viewPath]

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewModule(t *testing.T) {
-	m, err := app.NewModule("/app")
+	m, err := app.NewModule("/app", nil)
 	if err != nil {
 		t.Fatalf("NewModule: %v", err)
 	}
@@ -20,7 +20,7 @@ func TestNewModule(t *testing.T) {
 }
 
 func TestShellTemplate(t *testing.T) {
-	m, err := app.NewModule("/app")
+	m, err := app.NewModule("/app", nil)
 	if err != nil {
 		t.Fatalf("NewModule: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestShellTemplate(t *testing.T) {
 }
 
 func TestDistAssetServing(t *testing.T) {
-	m, err := app.NewModule("/app")
+	m, err := app.NewModule("/app", nil)
 	if err != nil {
 		t.Fatalf("NewModule: %v", err)
 	}
@@ -79,8 +79,72 @@ func TestDistAssetServing(t *testing.T) {
 	}
 }
 
+func TestAuthConfigInjection(t *testing.T) {
+	authCfg := &app.ClientAuthConfig{
+		TenantID:  "test-tenant-id",
+		ClientID:  "test-client-id",
+		Authority: "https://login.microsoftonline.com/test-tenant-id/v2.0",
+	}
+
+	m, err := app.NewModule("/app", authCfg)
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/app/", nil)
+	m.Serve(rec, req)
+
+	body := rec.Body.String()
+
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"config script tag", `<script id="herald-config" type="application/json">`},
+		{"tenant_id", `"tenant_id":"test-tenant-id"`},
+		{"client_id", `"client_id":"test-client-id"`},
+		{"redirect_uri", `"redirect_uri":"/app/"`},
+		{"authority", `"authority":"https://login.microsoftonline.com/test-tenant-id/v2.0"`},
+		{"user-menu", `id="user-menu"`},
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(body, check.content) {
+			t.Errorf("auth config missing %s: want %q in body", check.name, check.content)
+		}
+	}
+}
+
+func TestNoAuthConfigWhenNil(t *testing.T) {
+	m, err := app.NewModule("/app", nil)
+	if err != nil {
+		t.Fatalf("NewModule: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/app/", nil)
+	m.Serve(rec, req)
+
+	body := rec.Body.String()
+
+	absent := []struct {
+		name    string
+		content string
+	}{
+		{"config script tag", `herald-config`},
+		{"user-menu", `user-menu`},
+	}
+
+	for _, check := range absent {
+		if strings.Contains(body, check.content) {
+			t.Errorf("should not contain %s when auth is nil: found %q in body", check.name, check.content)
+		}
+	}
+}
+
 func TestSPAFallback(t *testing.T) {
-	m, err := app.NewModule("/app")
+	m, err := app.NewModule("/app", nil)
 	if err != nil {
 		t.Fatalf("NewModule: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `ClientAuthConfig` struct to the `app` package with browser-safe fields only (no `ClientSecret`)
- Add `PageHandlerWithData` method to `TemplateSet` for populating `ViewData.Data` on every request
- Conditionally render `<script id="herald-config" type="application/json">` and `<div id="user-menu">` when auth mode is azure
- Pass auth config subset from `cfg.Auth` to `app.NewModule` at the composition root
- Add `TestAuthConfigInjection` and `TestNoAuthConfigWhenNil` test cases

Closes #118

## Changes

- `app/app.go` — `ClientAuthConfig` struct, updated `NewModule(basePath, authCfg)` signature, JSON marshaling with `template.JS`
- `pkg/web/views.go` — `PageHandlerWithData` method
- `app/server/layouts/app.html` — Conditional config script tag and user-menu placeholder
- `cmd/server/modules.go` — Construct `ClientAuthConfig` from `cfg.Auth` when mode is azure
- `tests/app/app_test.go` — Updated existing tests, added auth config injection tests