### PR TITLE
Add MSAL auth service with login gate

### DIFF
--- a/.claude/context/guides/.archive/119-msal-auth-service.md
+++ b/.claude/context/guides/.archive/119-msal-auth-service.md
@@ -1,0 +1,329 @@
+# 119 — Add MSAL Auth Service with Login Gate
+
+## Problem Context
+
+Sub-issue 2 of Objective #99 (Web Client MSAL.js Integration). With auth config injected into the HTML template (#118), the client needs an `Auth` service wrapping `@azure/msal-browser` that handles MSAL initialization, login redirect, and token acquisition. The app bootstrap must gate on authentication before starting the router when auth is enabled.
+
+## Architecture Approach
+
+The Auth service is framework infrastructure in `core/`, not a domain service. It follows the PascalCase singleton pattern with module-scoped `let` state for the MSAL instance. When the `<script id="herald-config">` element is absent (auth disabled), all methods are safe no-ops. The cache location is configurable via the server-side auth config, flowing from `pkg/auth/config.go` through `ClientAuthConfig` to the client.
+
+## Implementation
+
+### Step 1: Add `CacheLocation` to `pkg/auth/config.go`
+
+Add the `CacheLocation` type, constants, field on `Config` and `Env`, and wire into `loadDefaults`, `loadEnv`, `Merge`, and `validate`:
+
+**Add `CacheLocation` type and constants** (alongside existing `Mode` type):
+
+```go
+type CacheLocation string
+
+const (
+	LocalStorage  CacheLocation = "localStorage"
+	SessionStorage CacheLocation = "sessionStorage"
+)
+```
+
+**In the `Config` struct** (add after `Authority`):
+
+```go
+type Config struct {
+	Mode            Mode          `json:"auth_mode"`
+	ManagedIdentity bool          `json:"managed_identity"`
+	TenantID        string        `json:"tenant_id"`
+	ClientID        string        `json:"client_id"`
+	ClientSecret    string        `json:"client_secret"`
+	Authority       string        `json:"authority"`
+	CacheLocation   CacheLocation `json:"cache_location"`
+}
+```
+
+**In the `Env` struct** (add after `Authority`):
+
+```go
+type Env struct {
+	Mode            string
+	ManagedIdentity string
+	TenantID        string
+	ClientID        string
+	ClientSecret    string
+	Authority       string
+	CacheLocation   string
+}
+```
+
+**In `loadDefaults()`** (add after mode default):
+
+```go
+func (c *Config) loadDefaults() {
+	if c.Mode == "" {
+		c.Mode = ModeNone
+	}
+	if c.CacheLocation == "" {
+		c.CacheLocation = LocalStorage
+	}
+}
+```
+
+**In `loadEnv()`** (add after Authority block):
+
+```go
+	if env.CacheLocation != "" {
+		if v := os.Getenv(env.CacheLocation); v != "" {
+			c.CacheLocation = CacheLocation(v)
+		}
+	}
+```
+
+**In `Merge()`** (add after Authority block):
+
+```go
+	if overlay.CacheLocation != "" {
+		c.CacheLocation = overlay.CacheLocation
+	}
+```
+
+**Replace `validate()`** with both checks:
+
+```go
+func (c *Config) validate() error {
+	switch c.Mode {
+	case ModeNone, ModeAzure:
+	default:
+		return fmt.Errorf(
+			"invalid auth_mode %q: must be %q or %q",
+			c.Mode, ModeNone, ModeAzure,
+		)
+	}
+	switch c.CacheLocation {
+	case LocalStorage, SessionStorage:
+	default:
+		return fmt.Errorf(
+			"invalid cache_location %q: must be %q or %q",
+			c.CacheLocation, LocalStorage, SessionStorage,
+		)
+	}
+
+	return nil
+}
+```
+
+### Step 2: Add env var mapping in `internal/config/config.go`
+
+Add `CacheLocation` to the `authEnv` var:
+
+```go
+var authEnv = &auth.Env{
+	Mode:            "HERALD_AUTH_MODE",
+	ManagedIdentity: "HERALD_AUTH_MANAGED_IDENTITY",
+	TenantID:        "HERALD_AUTH_TENANT_ID",
+	ClientID:        "HERALD_AUTH_CLIENT_ID",
+	ClientSecret:    "HERALD_AUTH_CLIENT_SECRET",
+	Authority:       "HERALD_AUTH_AUTHORITY",
+	CacheLocation:   "HERALD_AUTH_CACHE_LOCATION",
+}
+```
+
+### Step 3: Add `CacheLocation` to `ClientAuthConfig` in `app/app.go`
+
+```go
+type ClientAuthConfig struct {
+	TenantID      string `json:"tenant_id"`
+	ClientID      string `json:"client_id"`
+	RedirectURI   string `json:"redirect_uri"`
+	Authority     string `json:"authority"`
+	CacheLocation string `json:"cache_location"`
+}
+```
+
+### Step 4: Pass `CacheLocation` through in `cmd/server/modules.go`
+
+Update the `ClientAuthConfig` construction:
+
+```go
+	authCfg = &app.ClientAuthConfig{
+		TenantID:      cfg.Auth.TenantID,
+		ClientID:      cfg.Auth.ClientID,
+		Authority:     cfg.Auth.Authority,
+		CacheLocation: cfg.Auth.CacheLocation,
+	}
+```
+
+### Step 5: Add `@azure/msal-browser` dependency
+
+In `app/package.json`, add to dependencies:
+
+```json
+"dependencies": {
+  "@azure/msal-browser": "^5.4.0",
+  "lit": "^3.3.2"
+}
+```
+
+Run `bun install` from the `app/` directory.
+
+### Step 6: Create `app/client/core/auth.ts`
+
+New file — the Auth service:
+
+```typescript
+import {
+  type AccountInfo,
+  type AuthenticationResult,
+  type Configuration,
+  InteractionRequiredAuthError,
+  PublicClientApplication,
+} from "@azure/msal-browser";
+
+interface AuthConfig {
+  tenant_id: string;
+  client_id: string;
+  redirect_uri: string;
+  authority: string;
+  cache_location?: string;
+}
+
+let msalInstance: PublicClientApplication | null = null;
+let config: AuthConfig | null = null;
+
+function readConfig(): AuthConfig | null {
+  const el = document.getElementById("herald-config");
+  if (!el?.textContent) return null;
+
+  return JSON.parse(el.textContent) as AuthConfig;
+}
+
+function scope(): string {
+  return `api://${config!.client_id}/access_as_user`;
+}
+
+export const Auth = {
+  isEnabled(): boolean {
+    return config !== null;
+  },
+
+  isAuthenticated(): boolean {
+    if (!msalInstance) return false;
+    return msalInstance.getActiveAccount() !== null;
+  },
+
+  getAccount(): AccountInfo | null {
+    return msalInstance?.getActiveAccount() ?? null;
+  },
+
+  async init(): Promise<void> {
+    config = readConfig();
+    if (!config) return;
+
+    const msalConfig: Configuration = {
+      auth: {
+        clientId: config.client_id,
+        authority: config.authority,
+        redirectUri: config.redirect_uri,
+      },
+      cache: {
+        cacheLocation: config.cache_location ?? "localStorage",
+      },
+    };
+
+    msalInstance = new PublicClientApplication(msalConfig);
+    await msalInstance.initialize();
+
+    const response: AuthenticationResult | null =
+      await msalInstance.handleRedirectPromise();
+
+    if (response?.account) {
+      msalInstance.setActiveAccount(response.account);
+    } else {
+      const accounts = msalInstance.getAllAccounts();
+      if (accounts.length === 1) {
+        msalInstance.setActiveAccount(accounts[0]);
+      }
+    }
+  },
+
+  async getToken(forceRefresh?: boolean): Promise<string | null> {
+    const account = msalInstance?.getActiveAccount();
+    if (!msalInstance || !account) return null;
+
+    try {
+      const result = await msalInstance.acquireTokenSilent({
+        scopes: [scope()],
+        account,
+        forceRefresh: forceRefresh ?? false,
+      });
+      return result.accessToken;
+    } catch (e) {
+      if (e instanceof InteractionRequiredAuthError) {
+        await this.login();
+      }
+      return null;
+    }
+  },
+
+  async login(): Promise<void> {
+    if (!msalInstance) return;
+    await msalInstance.loginRedirect({ scopes: [scope()] });
+  },
+
+  async logout(): Promise<void> {
+    if (!msalInstance) return;
+    await msalInstance.logoutRedirect();
+  },
+};
+```
+
+### Step 7: Re-export Auth from `app/client/core/index.ts`
+
+Add `Auth` export at the top of the barrel:
+
+```typescript
+export { Auth } from "./auth";
+
+export { request, stream, toQueryString } from "./api";
+
+export type {
+  ExecutionEvent,
+  PageRequest,
+  PageResult,
+  Result,
+  StreamOptions,
+} from "./api";
+```
+
+### Step 8: Convert `app/client/app.ts` to async bootstrap
+
+Replace the entire file:
+
+```typescript
+import { Auth, Router } from "@core";
+import "@ui/elements";
+import "@ui/modules";
+import "@ui/views";
+
+import { routes } from "./routes";
+
+import "@design/index.css";
+
+(async () => {
+  await Auth.init();
+
+  if (Auth.isEnabled() && !Auth.isAuthenticated()) {
+    await Auth.login();
+    return;
+  }
+
+  const router = new Router("app-content", routes);
+  router.start();
+})();
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `bun install` completes in `app/` with `@azure/msal-browser` resolved
+- [ ] `bun run build` produces `dist/app.js` and `dist/app.css` without errors
+- [ ] With auth disabled (default): app loads normally, router starts, existing functionality works
+- [ ] `Auth.isEnabled()` returns `false` when no config script is present
+- [ ] All Auth methods are safe no-ops when auth is disabled

--- a/.claude/context/sessions/119-msal-auth-service.md
+++ b/.claude/context/sessions/119-msal-auth-service.md
@@ -1,0 +1,41 @@
+# 119 — Add MSAL Auth Service with Login Gate
+
+## Summary
+
+Added the `Auth` service wrapping `@azure/msal-browser` v5.4.0 for Azure Entra ID authentication in the Lit SPA. The service reads server-injected config from the DOM, initializes MSAL, handles redirect login flow, and provides token acquisition. When auth is disabled (no config present), all methods are safe no-ops. The app bootstrap was converted to an async IIFE that gates on authentication before starting the router.
+
+A configurable `CacheLocation` typed string enum was added to `pkg/auth` and threaded through `ClientAuthConfig` to the client, allowing operators to choose between `localStorage` (default) and `sessionStorage` for MSAL token caching via config or the `HERALD_AUTH_CACHE_LOCATION` env var.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Cache location | Configurable via `CacheLocation` type | Operator flexibility — `localStorage` default, `sessionStorage` option via config/env var |
+| Auth service location | `core/auth.ts` (not `domains/`) | Framework infrastructure, not a domain service |
+| Bootstrap pattern | Async IIFE | Explicit bootstrap boundary, gates on auth before router start |
+| MSAL version | v5.4.0 (resolved from `^5.4.0`) | Latest stable, API compatible with guide's v4 assumptions |
+| Scope convention | `api://<client_id>/access_as_user` | Derived from config, no separate field needed |
+
+## Files Modified
+
+- `pkg/auth/config.go` — Added `CacheLocation` type, constants, field on Config/Env, wired into loadDefaults/loadEnv/Merge/validate
+- `internal/config/config.go` — Added `HERALD_AUTH_CACHE_LOCATION` env var mapping
+- `app/app.go` — Added `CacheLocation` field to `ClientAuthConfig`
+- `cmd/server/modules.go` — Pass `CacheLocation` through to `ClientAuthConfig`
+- `app/package.json` — Added `@azure/msal-browser` dependency
+- `app/client/core/auth.ts` — New Auth service (PascalCase singleton)
+- `app/client/core/index.ts` — Re-exported Auth
+- `app/client/app.ts` — Async IIFE bootstrap with auth gate
+- `tests/config/auth_test.go` — Added CacheLocation tests (defaults, validation, env override, merge)
+- `tests/app/app_test.go` — Added cache_location to auth config injection test
+
+## Patterns Established
+
+- **Typed string enums for config values**: `CacheLocation` follows the `Mode` pattern — typed string, named constants, validated in `validate()`. Future config enums should follow this pattern.
+- **TypeScript module-scoped `let` narrowing**: When using module-scoped `let` variables in object literal methods, TypeScript narrows based on initialization. Methods defined after the reassigning method see the full union type; explicit null guards needed otherwise.
+
+## Validation Results
+
+- `go test ./tests/...` — all 20 packages pass
+- `go vet ./...` — clean
+- `bun run build` — produces `dist/app.js` and `dist/app.css` without errors

--- a/.claude/plans/humming-jumping-treehouse.md
+++ b/.claude/plans/humming-jumping-treehouse.md
@@ -1,0 +1,102 @@
+# 119 — Add MSAL Auth Service with Login Gate
+
+## Context
+
+Sub-issue 2 of Objective #99 (Web Client MSAL.js Integration). With auth config now injected into the HTML template (#118), the client needs an `Auth` service that wraps `@azure/msal-browser`, handles MSAL initialization, login redirect, and token acquisition. The app bootstrap must gate on authentication before starting the router when auth is enabled.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `pkg/auth/config.go` | Add `CacheLocation` field to `Config` |
+| `internal/config/config.go` | Add `CacheLocation` env var to `authEnv` |
+| `app/app.go` | Add `CacheLocation` field to `ClientAuthConfig` |
+| `cmd/server/modules.go` | Pass `CacheLocation` through to `ClientAuthConfig` |
+| `app/package.json` | Add `@azure/msal-browser` dependency |
+| `app/client/core/auth.ts` | **New** — Auth service |
+| `app/client/core/index.ts` | Re-export Auth |
+| `app/client/app.ts` | Async bootstrap with auth gate |
+
+## Implementation
+
+### 1. Server-side: Add `CacheLocation` field
+
+**`pkg/auth/config.go`** — Add `CacheLocation string` field to `Config` (json: `"cache_location"`). Add to `loadDefaults()` (default `"localStorage"`), `loadEnv()` (via new `Env.CacheLocation`), and `Merge()`. Valid values: `"localStorage"`, `"sessionStorage"`.
+
+**`internal/config/config.go`** — Add `CacheLocation: "HERALD_AUTH_CACHE_LOCATION"` to the `authEnv` var.
+
+**`app/app.go`** — Add `CacheLocation string` field to `ClientAuthConfig` (json: `"cache_location"`).
+
+**`cmd/server/modules.go`** — Pass `cfg.Auth.CacheLocation` through when building `ClientAuthConfig`.
+
+### 2. `app/package.json` — Add dependency
+
+Add `@azure/msal-browser` to dependencies. Run `bun install`.
+
+### 3. `app/client/core/auth.ts` — Auth service (new file)
+
+PascalCase singleton object (matches service pattern) in `core/` (framework infra, not domain).
+
+**Internal state** (module-scoped `let`):
+- `msalInstance: PublicClientApplication | null`
+- `config: AuthConfig | null`
+
+**`AuthConfig` interface** (unexported, matches server JSON):
+```typescript
+interface AuthConfig {
+  tenant_id: string;
+  client_id: string;
+  redirect_uri: string;
+  authority: string;
+  cache_location?: string; // "localStorage" | "sessionStorage", defaults to "localStorage"
+}
+```
+
+**`readConfig()` (unexported helper)**:
+- `document.getElementById("herald-config")`
+- If not found → return `null` (auth disabled)
+- `JSON.parse(el.textContent!)` → `AuthConfig`
+
+**Exported `Auth` object methods:**
+
+| Method | Behavior |
+|--------|----------|
+| `isEnabled(): boolean` | `config !== null` |
+| `isAuthenticated(): boolean` | Active account exists (false when disabled) |
+| `getAccount(): AccountInfo \| null` | Active account or null |
+| `async init(): Promise<void>` | readConfig → if null, return. Create MSAL instance (`auth.clientId`, `auth.authority`, `auth.redirectUri`, `cache.cacheLocation: config.cache_location ?? "localStorage"`). `await instance.initialize()`. `await handleRedirectPromise()` → set active account from result or from `getAllAccounts()[0]`. |
+| `async getToken(forceRefresh?): Promise<string \| null>` | If disabled/no account → null. `acquireTokenSilent({ scopes: [scope], account, forceRefresh })`. On interaction-required error → `login()`. |
+| `async login(): Promise<void>` | `loginRedirect({ scopes: [scope] })`. No-op if disabled. |
+| `async logout(): Promise<void>` | `logoutRedirect()`. No-op if disabled. |
+
+**Scope**: `api://${config.client_id}/access_as_user` — derived from config, not a separate field.
+
+**Cache location**: `localStorage` — persists tokens across browser sessions.
+
+### 4. `app/client/core/index.ts` — Re-export
+
+Add `export { Auth } from "./auth"` at top of barrel.
+
+### 5. `app/client/app.ts` — Async bootstrap
+
+Wrap in async IIFE:
+1. `await Auth.init()`
+2. If `Auth.isEnabled() && !Auth.isAuthenticated()` → `await Auth.login(); return`
+3. Create router and start
+
+The `return` after `login()` prevents the router from mounting during redirect. The redirect navigates away, so this is a safety guard.
+
+## Key Decisions
+
+- **Configurable cache location** — `CacheLocation` field on `auth.Config` (default `"localStorage"`), flows through `ClientAuthConfig` to the client. Overridable via `HERALD_AUTH_CACHE_LOCATION` env var or JSON config.
+- **Async IIFE** over top-level await — more explicit bootstrap boundary
+- **`init()` calls `handleRedirectPromise()`** — completes in-flight redirect on second page load, sets active account
+- **No-op when disabled** — all methods are safe when config is absent; no conditional imports needed
+- **Scope derived from `client_id`** — `api://<client_id>/access_as_user` convention, no extra config field
+
+## Verification
+
+- `bun install` succeeds with new dependency
+- `bun run build` produces `dist/app.js` and `dist/app.css` without errors
+- With auth disabled (no config script in DOM): app loads normally, router starts, all existing functionality works
+- `go vet ./...` passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.99.119
+- Add MSAL auth service with login gate; create `Auth` singleton in `core/auth.ts` wrapping `@azure/msal-browser` for MSAL initialization, redirect login, and token acquisition; convert app bootstrap to async IIFE gating on authentication; add configurable `CacheLocation` typed enum to `pkg/auth` threaded through `ClientAuthConfig` (#119)
+
 ## v0.4.0-dev.99.118
 - Inject browser-safe auth config into web app HTML template for MSAL.js initialization; add `ClientAuthConfig` struct, `PageHandlerWithData` method, and conditional `<script id="herald-config">` rendering when auth mode is azure (#118)
 

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/JaimeStill/herald/pkg/auth"
 	"github.com/JaimeStill/herald/pkg/module"
 	"github.com/JaimeStill/herald/pkg/web"
 )
@@ -29,10 +30,11 @@ var views = []web.ViewDef{
 // injected into the HTML template for MSAL.js initialization. ClientSecret
 // is deliberately excluded — only fields safe for client exposure are included.
 type ClientAuthConfig struct {
-	TenantID    string `json:"tenant_id"`
-	ClientID    string `json:"client_id"`
-	RedirectURI string `json:"redirect_uri"`
-	Authority   string `json:"authority"`
+	TenantID      string             `json:"tenant_id"`
+	ClientID      string             `json:"client_id"`
+	RedirectURI   string             `json:"redirect_uri"`
+	Authority     string             `json:"authority"`
+	CacheLocation auth.CacheLocation `json:"cache_location"`
 }
 
 // NewModule creates the web app module configured for the given base path.

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "herald-app",
       "dependencies": {
+        "@azure/msal-browser": "^5.4.0",
         "lit": "^3.3.2",
       },
       "devDependencies": {
@@ -13,6 +14,10 @@
     },
   },
   "packages": {
+    "@azure/msal-browser": ["@azure/msal-browser@5.4.0", "", { "dependencies": { "@azure/msal-common": "16.2.0" } }, "sha512-GvRbLNk26oPOPpnry4Ym8wtXrmdozGm2Sry5EKfui0siwnEuAKWEeMLLyosDo5nVEIIDO1C2t/+HpVzqqCWlfQ=="],
+
+    "@azure/msal-common": ["@azure/msal-common@16.2.0", "", {}, "sha512-ge0nGzTLmEE5lg7tSCbTBrYqMGkpFQeQEtqfcKPuGJn/FPFf8Xz51uDfZsm5xpstNZGMYPhHvnYbL8OeNp/aLw=="],
+
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
     "@lit/reactive-element": ["@lit/reactive-element@2.1.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0" } }, "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A=="],

--- a/app/client/app.ts
+++ b/app/client/app.ts
@@ -1,3 +1,4 @@
+import { Auth } from "@core";
 import { Router } from "@core/router";
 import "@ui/elements";
 import "@ui/modules";
@@ -7,5 +8,14 @@ import { routes } from "./routes";
 
 import "@design/index.css";
 
-const router = new Router("app-content", routes);
-router.start();
+(async () => {
+  await Auth.init();
+
+  if (Auth.isEnabled() && !Auth.isAuthenticated()) {
+    await Auth.login();
+    return;
+  }
+
+  const router = new Router("app-content", routes);
+  router.start();
+})();

--- a/app/client/core/auth.ts
+++ b/app/client/core/auth.ts
@@ -1,0 +1,125 @@
+import {
+  InteractionRequiredAuthError,
+  PublicClientApplication,
+} from "@azure/msal-browser";
+
+import type {
+  AccountInfo,
+  AuthenticationResult,
+  Configuration,
+} from "@azure/msal-browser";
+
+let msalInstance: PublicClientApplication | null = null;
+let config: AuthConfig | null = null;
+
+interface AuthConfig {
+  tenant_id: string;
+  client_id: string;
+  redirect_uri: string;
+  authority: string;
+  cache_location?: string;
+}
+
+function readConfig(): AuthConfig | null {
+  const el = document.getElementById("herald-config");
+  if (!el?.textContent) return null;
+
+  return JSON.parse(el.textContent) as AuthConfig;
+}
+
+function scope(): string {
+  return `api://${config!.client_id}/access_as_user`;
+}
+
+/**
+ * Auth service wrapping `@azure/msal-browser` for Azure Entra ID authentication.
+ *
+ * Reads config from the server-injected `<script id="herald-config">` element.
+ * When the element is absent (auth disabled), all methods are safe no-ops.
+ */
+export const Auth = {
+  /** Whether auth is configured (config script present in DOM). */
+  isEnabled(): boolean {
+    return config !== null;
+  },
+
+  /** Whether an active MSAL account exists after initialization. */
+  isAuthenticated(): boolean {
+    return msalInstance?.getActiveAccount() !== null;
+  },
+
+  /** Returns the active MSAL account, or null if not authenticated. */
+  getAccount(): AccountInfo | null {
+    return msalInstance?.getActiveAccount() ?? null;
+  },
+
+  /**
+   * Reads config from the DOM, creates the MSAL instance, and handles
+   * any in-flight redirect. No-op when auth is disabled.
+   */
+  async init(): Promise<void> {
+    config = readConfig();
+    if (!config) return;
+
+    const msalConfig: Configuration = {
+      auth: {
+        clientId: config.client_id,
+        authority: config.authority,
+        redirectUri: config.redirect_uri,
+      },
+      cache: {
+        cacheLocation: config.cache_location ?? "localStorage",
+      },
+    };
+
+    msalInstance = new PublicClientApplication(msalConfig);
+    await msalInstance.initialize();
+
+    const response: AuthenticationResult | null =
+      await msalInstance.handleRedirectPromise();
+
+    if (response?.account) {
+      msalInstance.setActiveAccount(response.account);
+    } else {
+      const accounts = msalInstance.getAllAccounts();
+      if (accounts.length === 1) {
+        msalInstance.setActiveAccount(accounts[0]);
+      }
+    }
+  },
+
+  /**
+   * Acquires an access token silently from the MSAL cache.
+   * On interaction-required errors, redirects to login.
+   */
+  async getToken(forceRefresh?: boolean): Promise<string | null> {
+    const account = msalInstance?.getActiveAccount();
+    if (!msalInstance || !account) return null;
+
+    try {
+      const result = await msalInstance.acquireTokenSilent({
+        scopes: [scope()],
+        account,
+        forceRefresh: forceRefresh ?? false,
+      });
+      return result.accessToken;
+    } catch (e) {
+      if (e instanceof InteractionRequiredAuthError) {
+        await this.login();
+      }
+      return null;
+    }
+  },
+
+  /** Redirects to the Azure Entra login page. No-op when auth is disabled. */
+  async login(): Promise<void> {
+    if (!msalInstance) return;
+    await msalInstance.loginRedirect({ scopes: [scope()] });
+  },
+
+  /** Redirects to the Azure Entra logout page. No-op when auth is disabled. */
+  async logout(): Promise<void> {
+    if (!msalInstance) return;
+    await msalInstance.logoutRedirect();
+  },
+};

--- a/app/client/core/index.ts
+++ b/app/client/core/index.ts
@@ -7,3 +7,5 @@ export type {
   Result,
   StreamOptions,
 } from "./api";
+
+export { Auth } from "./auth";

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "watch": "bun scripts/watch.ts"
   },
   "dependencies": {
+    "@azure/msal-browser": "^5.4.0",
     "lit": "^3.3.2"
   },
   "devDependencies": {

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -26,9 +26,10 @@ func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modu
 	var authCfg *app.ClientAuthConfig
 	if cfg.Auth.Mode == auth.ModeAzure {
 		authCfg = &app.ClientAuthConfig{
-			TenantID:  cfg.Auth.TenantID,
-			ClientID:  cfg.Auth.ClientID,
-			Authority: cfg.Auth.Authority,
+			TenantID:      cfg.Auth.TenantID,
+			ClientID:      cfg.Auth.ClientID,
+			Authority:     cfg.Auth.Authority,
+			CacheLocation: cfg.Auth.CacheLocation,
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ var authEnv = &auth.Env{
 	ClientID:        "HERALD_AUTH_CLIENT_ID",
 	ClientSecret:    "HERALD_AUTH_CLIENT_SECRET",
 	Authority:       "HERALD_AUTH_AUTHORITY",
+	CacheLocation:   "HERALD_AUTH_CACHE_LOCATION",
 }
 
 var databaseEnv = &database.Env{

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -14,6 +14,16 @@ import (
 // AgentScope is the OAuth scope for acquiring Azure AI Foundry bearer tokens.
 const AgentScope = "https://cognitiveservices.azure.com/.default"
 
+// CacheLocation identifies the browser storage backend for MSAL token caching.
+type CacheLocation string
+
+const (
+	// LocalStorage persists MSAL tokens in the browser's localStorage.
+	LocalStorage CacheLocation = "localStorage"
+	// SessionStorage persists MSAL tokens in the browser's sessionStorage.
+	SessionStorage CacheLocation = "sessionStorage"
+)
+
 // Mode identifies the authentication strategy for Azure service connections.
 type Mode string
 
@@ -34,12 +44,13 @@ const (
 // (JWT validation via the Auth middleware). Mode controls both: ModeNone
 // disables all auth; ModeAzure enables credential creation and JWT validation.
 type Config struct {
-	Mode            Mode   `json:"auth_mode"`
-	ManagedIdentity bool   `json:"managed_identity"`
-	TenantID        string `json:"tenant_id"`
-	ClientID        string `json:"client_id"`
-	ClientSecret    string `json:"client_secret"`
-	Authority       string `json:"authority"`
+	Mode            Mode          `json:"auth_mode"`
+	ManagedIdentity bool          `json:"managed_identity"`
+	TenantID        string        `json:"tenant_id"`
+	ClientID        string        `json:"client_id"`
+	ClientSecret    string        `json:"client_secret"`
+	Authority       string        `json:"authority"`
+	CacheLocation   CacheLocation `json:"cache_location"`
 }
 
 // Env maps Config fields to environment variable names for override injection.
@@ -50,6 +61,7 @@ type Env struct {
 	ClientID        string
 	ClientSecret    string
 	Authority       string
+	CacheLocation   string
 }
 
 // Finalize applies defaults, environment variable overrides, derived defaults,
@@ -84,6 +96,9 @@ func (c *Config) Merge(overlay *Config) {
 	}
 	if overlay.Authority != "" {
 		c.Authority = overlay.Authority
+	}
+	if overlay.CacheLocation != "" {
+		c.CacheLocation = overlay.CacheLocation
 	}
 }
 
@@ -124,6 +139,9 @@ func (c *Config) loadDefaults() {
 	if c.Mode == "" {
 		c.Mode = ModeNone
 	}
+	if c.CacheLocation == "" {
+		c.CacheLocation = LocalStorage
+	}
 }
 
 func (c *Config) loadEnv(env *Env) {
@@ -159,6 +177,11 @@ func (c *Config) loadEnv(env *Env) {
 			c.Authority = v
 		}
 	}
+	if env.CacheLocation != "" {
+		if v := os.Getenv(env.CacheLocation); v != "" {
+			c.CacheLocation = CacheLocation(v)
+		}
+	}
 }
 
 func (c *Config) deriveDefaults() {
@@ -170,11 +193,20 @@ func (c *Config) deriveDefaults() {
 func (c *Config) validate() error {
 	switch c.Mode {
 	case ModeNone, ModeAzure:
-		return nil
 	default:
 		return fmt.Errorf(
 			"invalid auth_mode %q: must be %q or %q",
 			c.Mode, ModeNone, ModeAzure,
 		)
 	}
+	switch c.CacheLocation {
+	case LocalStorage, SessionStorage:
+	default:
+		return fmt.Errorf(
+			"invalid cache_location %q: must be %q or %q",
+			c.CacheLocation, LocalStorage, SessionStorage,
+		)
+	}
+
+	return nil
 }

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -81,9 +81,10 @@ func TestDistAssetServing(t *testing.T) {
 
 func TestAuthConfigInjection(t *testing.T) {
 	authCfg := &app.ClientAuthConfig{
-		TenantID:  "test-tenant-id",
-		ClientID:  "test-client-id",
-		Authority: "https://login.microsoftonline.com/test-tenant-id/v2.0",
+		TenantID:      "test-tenant-id",
+		ClientID:      "test-client-id",
+		Authority:     "https://login.microsoftonline.com/test-tenant-id/v2.0",
+		CacheLocation: "localStorage",
 	}
 
 	m, err := app.NewModule("/app", authCfg)
@@ -106,6 +107,7 @@ func TestAuthConfigInjection(t *testing.T) {
 		{"client_id", `"client_id":"test-client-id"`},
 		{"redirect_uri", `"redirect_uri":"/app/"`},
 		{"authority", `"authority":"https://login.microsoftonline.com/test-tenant-id/v2.0"`},
+		{"cache_location", `"cache_location":"localStorage"`},
 		{"user-menu", `id="user-menu"`},
 	}
 

--- a/tests/config/auth_test.go
+++ b/tests/config/auth_test.go
@@ -20,6 +20,9 @@ func TestAuthConfigDefaults(t *testing.T) {
 	if cfg.ManagedIdentity {
 		t.Error("managed_identity should default to false")
 	}
+	if cfg.CacheLocation != auth.LocalStorage {
+		t.Errorf("cache_location: got %q, want %q", cfg.CacheLocation, auth.LocalStorage)
+	}
 }
 
 func TestAuthConfigNoneCredential(t *testing.T) {
@@ -67,6 +70,78 @@ func TestAuthConfigValidation(t *testing.T) {
 				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestAuthConfigCacheLocationValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		location auth.CacheLocation
+		wantErr  string
+	}{
+		{"localStorage is valid", auth.LocalStorage, ""},
+		{"sessionStorage is valid", auth.SessionStorage, ""},
+		{"invalid cache_location", "bad", "invalid cache_location"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &auth.Config{CacheLocation: tt.location}
+			err := cfg.Finalize(nil)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAuthConfigCacheLocationEnvOverride(t *testing.T) {
+	t.Setenv("HERALD_AUTH_CACHE_LOCATION", "sessionStorage")
+
+	env := &auth.Env{
+		CacheLocation: "HERALD_AUTH_CACHE_LOCATION",
+	}
+
+	cfg := &auth.Config{}
+	if err := cfg.Finalize(env); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.CacheLocation != auth.SessionStorage {
+		t.Errorf("cache_location: got %q, want %q", cfg.CacheLocation, auth.SessionStorage)
+	}
+}
+
+func TestAuthConfigCacheLocationMerge(t *testing.T) {
+	base := &auth.Config{CacheLocation: auth.LocalStorage}
+	overlay := &auth.Config{CacheLocation: auth.SessionStorage}
+
+	base.Merge(overlay)
+
+	if base.CacheLocation != auth.SessionStorage {
+		t.Errorf("cache_location: got %q, want %q", base.CacheLocation, auth.SessionStorage)
+	}
+}
+
+func TestAuthConfigCacheLocationMergeEmptyPreserves(t *testing.T) {
+	base := &auth.Config{CacheLocation: auth.SessionStorage}
+	overlay := &auth.Config{}
+
+	base.Merge(overlay)
+
+	if base.CacheLocation != auth.SessionStorage {
+		t.Errorf("cache_location should be preserved: got %q", base.CacheLocation)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Create `Auth` singleton service in `core/auth.ts` wrapping `@azure/msal-browser` v5.4.0 for Azure Entra ID authentication — MSAL initialization, redirect login flow, and silent token acquisition
- Convert app bootstrap to async IIFE that gates on authentication before starting the router; safe no-op when auth is disabled
- Add configurable `CacheLocation` typed string enum to `pkg/auth` (`localStorage` default, `sessionStorage` option) threaded through `ClientAuthConfig` to the client, overridable via `HERALD_AUTH_CACHE_LOCATION` env var

Closes #119

## Changes

- `pkg/auth/config.go` — Add `CacheLocation` type, constants, Config/Env fields, loadDefaults/loadEnv/Merge/validate
- `internal/config/config.go` — Add `HERALD_AUTH_CACHE_LOCATION` env var mapping
- `app/app.go` — Add `CacheLocation` to `ClientAuthConfig`
- `cmd/server/modules.go` — Pass `CacheLocation` through
- `app/package.json` — Add `@azure/msal-browser` dependency
- `app/client/core/auth.ts` — New Auth service (PascalCase singleton)
- `app/client/core/index.ts` — Re-export Auth
- `app/client/app.ts` — Async IIFE bootstrap with auth gate
- Tests updated for `CacheLocation` (defaults, validation, env override, merge) and auth config injection