### PR TITLE
Wire token injection into API layer and add header user menu

### DIFF
--- a/.claude/context/guides/.archive/120-wire-token-injection-api-user-menu.md
+++ b/.claude/context/guides/.archive/120-wire-token-injection-api-user-menu.md
@@ -1,0 +1,263 @@
+# 120 — Wire Token Injection into API Layer and Add Header User Menu
+
+## Problem Context
+
+The MSAL auth service (#119) can acquire tokens and verify authentication state, but the API transport layer (`api.ts`) sends unauthenticated requests. This sub-issue connects `Auth.getToken()` to `request()` and `stream()` so all API calls carry bearer tokens when auth is enabled, handles 401 retry with silent token refresh, and displays the authenticated user in the app header.
+
+## Architecture Approach
+
+Token injection is a cross-cutting concern handled at the transport layer. A module-private `authHeaders()` helper centralizes token acquisition for both `request()` and `stream()`. The 401 retry uses a single force-refresh attempt — if that fails, the session is invalid and a full re-login is appropriate. The user menu uses plain DOM hydration because the header is server-rendered HTML (a Lit element would be over-engineering for a static name + button).
+
+## Implementation
+
+### Step 1: Add token injection and 401 retry to `api.ts`
+
+**File: `app/client/core/api.ts`**
+
+Add import at the top of the file (after no existing imports — this is the first):
+
+```ts
+import { Auth } from "./auth";
+```
+
+Add `authHeaders()` helper after the `ExecutionEvent` interface (before the `request` function):
+
+```ts
+async function authHeaders(): Promise<Record<string, string>> {
+  if (!Auth.isEnabled()) return {};
+  const token = await Auth.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+```
+
+Replace the `request()` function with:
+
+```ts
+export async function request<T>(
+  path: string,
+  init?: RequestInit,
+  parse: (res: Response) => Promise<T> = (res) => res.json(),
+): Promise<Result<T>> {
+  try {
+    const headers = { ...init?.headers, ...(await authHeaders()) };
+    const opts: RequestInit = { ...init, headers };
+    let res = await fetch(`${BASE}${path}`, opts);
+
+    if (res.status === 401 && Auth.isEnabled()) {
+      const token = await Auth.getToken(true);
+      if (token) {
+        opts.headers = { ...opts.headers, Authorization: `Bearer ${token}` };
+        res = await fetch(`${BASE}${path}`, opts);
+      }
+      if (res.status === 401) {
+        await Auth.login();
+        return { ok: false, error: "Authentication required" };
+      }
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { ok: false, error: text || res.statusText };
+    }
+    if (res.status === 204) {
+      return { ok: true, data: undefined as T };
+    }
+    return { ok: true, data: await parse(res) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+```
+
+Replace the `stream()` function with:
+
+```ts
+export function stream(
+  path: string,
+  options: StreamOptions,
+  init?: RequestInit,
+): AbortController {
+  const controller = new AbortController();
+  const signal = options.signal ?? controller.signal;
+
+  (async () => {
+    try {
+      const headers = { ...init?.headers, ...(await authHeaders()) };
+      let opts: RequestInit = { ...init, headers, signal };
+      let res = await fetch(`${BASE}${path}`, opts);
+
+      if (res.status === 401 && Auth.isEnabled()) {
+        const token = await Auth.getToken(true);
+        if (token) {
+          opts = {
+            ...opts,
+            headers: { ...opts.headers, Authorization: `Bearer ${token}` },
+          };
+          res = await fetch(`${BASE}${path}`, opts);
+        }
+        if (res.status === 401) {
+          await Auth.login();
+          return;
+        }
+      }
+
+      if (!res.ok) {
+        const text = await res.text();
+        options.onError?.(text || res.statusText);
+        return;
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) {
+        options.onError?.("No response body");
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let currentEvent = "message";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith("data: ")) {
+            const data = line.slice(6).trim();
+            options.onEvent(currentEvent, data);
+            currentEvent = "message";
+          }
+        }
+      }
+
+      options.onComplete?.();
+    } catch (err: unknown) {
+      if ((err as Error).name !== "AbortError") {
+        options.onError?.((err as Error).message);
+      }
+    }
+  })();
+
+  return controller;
+}
+```
+
+The key structural change to `stream()` is wrapping the body in an async IIFE so `authHeaders()` can be awaited before the initial fetch. The 401 retry pattern mirrors `request()`.
+
+### Step 2: Hydrate user menu in `app.ts`
+
+**File: `app/client/app.ts`**
+
+Add user menu hydration after `router.start()`, inside the existing async IIFE:
+
+```ts
+(async () => {
+  await Auth.init();
+
+  if (Auth.isEnabled() && !Auth.isAuthenticated()) {
+    await Auth.login();
+    return;
+  }
+
+  const router = new Router("app-content", routes);
+  router.start();
+
+  if (Auth.isEnabled()) {
+    const account = Auth.getAccount();
+    const menu = document.getElementById("user-menu");
+    if (account && menu) {
+      const name = document.createElement("span");
+      name.className = "user-name";
+      name.textContent = account.name ?? account.username;
+
+      const logout = document.createElement("button");
+      logout.className = "user-logout";
+      logout.textContent = "Logout";
+      logout.addEventListener("click", () => Auth.logout());
+
+      menu.append(name, logout);
+    }
+  }
+})();
+```
+
+No new imports needed — `Auth` is already imported.
+
+### Step 3: Style `#user-menu` in `app.css`
+
+**File: `app/client/design/app/app.css`**
+
+Add inside the `@layer app` block, after the `#app-content` rule:
+
+```css
+  #user-menu {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  #user-menu .user-name {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-1);
+  }
+
+  #user-menu .user-logout {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-1);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      color: var(--blue);
+    }
+  }
+```
+
+Logout button matches the nav link style: no border, no background, color transition on hover. Both elements use `--font-mono` per the design convention for interactive elements.
+
+## Remediation
+
+### R1: Configurable OAuth scope
+
+The original design hardcoded the scope name as `access_as_user` in `auth.ts`. The Entra app registration used `access` instead, causing `AADSTS65005` (scope not found). Fix: added `Scope` field to `pkg/auth/Config`, `app.ClientAuthConfig`, and `AuthConfig` in `auth.ts`. The server stores just the scope claim name (e.g., `access`); the client composes the full `api://<client_id>/<scope>` format. Default derived in `deriveDefaults()` is `access_as_user` when not configured.
+
+**Files:** `pkg/auth/config.go`, `internal/config/config.go`, `app/app.go`, `cmd/server/modules.go`, `app/client/core/auth.ts`, `config.auth.json`
+
+### R2: OIDC verifier audience and issuer mismatch
+
+The auth middleware's OIDC verifier expected `aud` = raw client ID GUID, but Entra access tokens for custom scopes use `aud` = `api://<client_id>`. Additionally, Entra access tokens use the v1 issuer format (`https://sts.windows.net/<tenant>/`) even from the v2.0 endpoint, but OIDC discovery returns the v2.0 issuer. Fix: set verifier audience to `"api://" + cfg.ClientID` and `SkipIssuerCheck: true`. Signature and expiry are still validated.
+
+**File:** `pkg/middleware/auth.go`
+
+### R3: Header nav centering with three flex children
+
+Adding `#user-menu` as a third child of `.app-header` (with `justify-content: space-between`) pushed nav to the center. Fix: replaced `space-between` with `gap`, added `margin-left: auto` on nav to push it right. Added `border-left` divider and `padding-left` on `#user-menu` for visual separation.
+
+**File:** `app/client/design/app/app.css`
+
+### R4: PDF iframe unauthorized when auth enabled
+
+The `hd-blob-viewer` iframe loaded PDFs via direct URL (`/api/storage/view/:key`), which can't carry a bearer token. Fix: when auth is enabled, the review view fetches the PDF through `StorageService.download()` (which goes through the authenticated `request()` path), creates a `blob:` URL, and passes that to `hd-blob-viewer`. Falls back to direct URL when auth is disabled. Blob URLs are revoked on document change and disconnect.
+
+**File:** `app/client/ui/views/review-view.ts`
+
+## Validation Criteria
+
+- [ ] `bun run build` succeeds
+- [ ] `request()` attaches `Authorization: Bearer <token>` when auth is enabled
+- [ ] `stream()` attaches `Authorization: Bearer <token>` when auth is enabled
+- [ ] When auth is disabled (no config script), no token acquisition occurs
+- [ ] 401 responses trigger one silent token refresh retry, then redirect to login
+- [ ] App header displays authenticated user's name when logged in
+- [ ] Logout button calls `Auth.logout()` and redirects to Entra
+- [ ] `#user-menu` remains empty when auth is disabled

--- a/.claude/context/sessions/120-wire-token-injection-api-user-menu.md
+++ b/.claude/context/sessions/120-wire-token-injection-api-user-menu.md
@@ -1,0 +1,46 @@
+# 120 — Wire Token Injection into API Layer and Add Header User Menu
+
+## Summary
+
+Connected the MSAL auth service to the API transport layer so all `request()` and `stream()` calls carry bearer tokens when auth is enabled. Added 401 retry with silent token refresh. Added user display name and logout button to the app header via plain DOM hydration. During live validation with Azure Entra, discovered and fixed four issues: hardcoded scope name, OIDC audience/issuer mismatch, header layout with three flex children, and PDF iframe unauthorized.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Token injection location | Module-private `authHeaders()` in `api.ts` | Cross-cutting concern belongs at the transport layer, not in each service |
+| 401 retry strategy | Single force-refresh, then login redirect | If force-refresh fails, the session is truly invalid |
+| User menu rendering | Plain DOM hydration in `app.ts` | Header is server-rendered HTML; a Lit element for static name + button is over-engineering |
+| OAuth scope configurability | `Scope` field on auth config, client composes full format | Deployments may use different scope names; server stores bare name, client composes `api://<client_id>/<scope>` |
+| OIDC verifier audience | `api://<client_id>` with `SkipIssuerCheck` | Entra access tokens use app URI as audience and v1 issuer format, both mismatching OIDC discovery |
+| PDF viewer with auth | Fetch blob via authenticated `download()`, use `blob:` URL | Iframes can't carry Authorization headers; blob URLs work transparently |
+| Header layout | `margin-left: auto` on nav, `border-left` divider on user-menu | Clean `Brand ... [Nav] | [User Menu]` layout without wrapper elements |
+
+## Files Modified
+
+- `app/client/core/api.ts` — token injection, 401 retry for `request()` and `stream()`
+- `app/client/core/auth.ts` — configurable scope from injected config
+- `app/client/app.ts` — user menu hydration (name + logout button)
+- `app/client/design/app/app.css` — header layout fix, user-menu styles with divider
+- `app/client/ui/views/review-view.ts` — authenticated blob fetch for PDF viewer
+- `app/app.go` — `Scope` field on `ClientAuthConfig`
+- `cmd/server/modules.go` — pass scope through to client auth config
+- `pkg/auth/config.go` — `Scope` field on `Config` and `Env`, merge/env/derive support
+- `internal/config/config.go` — `HERALD_AUTH_SCOPE` env var mapping
+- `pkg/middleware/auth.go` — verifier audience `api://` prefix, `SkipIssuerCheck`
+- `config.auth.json` — auth overlay with scope
+- `README.md` — Entra dev setup docs, auth dev server command
+- `tests/config/auth_test.go` — 6 new scope tests (default, explicit, env, merge)
+
+## Patterns Established
+
+- **Configurable OAuth scope**: bare scope name in server config, client composes full `api://<client_id>/<scope>` URI. Default derived in `deriveDefaults()`.
+- **Authenticated blob viewing**: when auth is enabled, fetch blobs through the API transport layer and use `blob:` URLs for iframes. Revoke on teardown.
+- **OIDC access token validation**: Entra access tokens need `api://` audience prefix and `SkipIssuerCheck` due to v1/v2 issuer mismatch.
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go test ./tests/...` — all pass (6 new scope tests)
+- `bun run build` — succeeds
+- Live validation with Azure Entra: login flow, token injection, 401 retry, user menu display, PDF viewing, logout — all working

--- a/.claude/plans/federated-yawning-biscuit.md
+++ b/.claude/plans/federated-yawning-biscuit.md
@@ -1,0 +1,181 @@
+# 120 — Wire Token Injection into API Layer and Add Header User Menu
+
+## Context
+
+Sub-issue 3 of Objective #99 (Web Client MSAL.js Integration). The auth service from #119 provides `Auth.getToken()`, `Auth.isEnabled()`, and `Auth.getAccount()`. This task connects it to the API transport layer so all requests carry bearer tokens, handles 401 retry with silent token refresh, and displays the authenticated user in the app header.
+
+## Files Modified
+
+1. **`app/client/core/api.ts`** — Token injection + 401 retry
+2. **`app/client/app.ts`** — User menu hydration
+3. **`app/client/design/app/app.css`** — `#user-menu` styles
+
+## Implementation
+
+### 1. `app/client/core/api.ts` — Token injection and 401 retry
+
+**Helper: `authHeaders()`** — async function that returns `{ Authorization: Bearer <token> }` when auth is enabled, empty object otherwise. Called by both `request()` and `stream()`.
+
+```ts
+async function authHeaders(): Promise<HeadersInit> {
+  if (!Auth.isEnabled()) return {};
+  const token = await Auth.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+```
+
+**`request()` changes:**
+- Before fetch, call `authHeaders()` and merge into `init.headers`
+- After non-ok response: if status is 401, call `Auth.getToken(true)` (force refresh), rebuild headers, retry fetch once. If retry also 401, call `Auth.login()`.
+- Extract the fetch + response handling into a helper to avoid duplicating the parse logic.
+
+```ts
+export async function request<T>(
+  path: string,
+  init?: RequestInit,
+  parse: (res: Response) => Promise<T> = (res) => res.json(),
+): Promise<Result<T>> {
+  try {
+    const headers = { ...init?.headers, ...(await authHeaders()) };
+    const opts: RequestInit = { ...init, headers };
+    let res = await fetch(`${BASE}${path}`, opts);
+
+    if (res.status === 401 && Auth.isEnabled()) {
+      const token = await Auth.getToken(true);
+      if (token) {
+        opts.headers = { ...opts.headers, Authorization: `Bearer ${token}` };
+        res = await fetch(`${BASE}${path}`, opts);
+      }
+      if (res.status === 401) {
+        await Auth.login();
+        return { ok: false, error: "Authentication required" };
+      }
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { ok: false, error: text || res.statusText };
+    }
+    if (res.status === 204) {
+      return { ok: true, data: undefined as T };
+    }
+    return { ok: true, data: await parse(res) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+```
+
+**`stream()` changes:**
+- Before fetch, merge `authHeaders()` into init. Same 401 pattern but adapted for streaming: check initial response status, force-refresh + retry once, then login redirect.
+
+```ts
+export function stream(
+  path: string,
+  options: StreamOptions,
+  init?: RequestInit,
+): AbortController {
+  const controller = new AbortController();
+  const signal = options.signal ?? controller.signal;
+
+  (async () => {
+    try {
+      const headers = { ...init?.headers, ...(await authHeaders()) };
+      let opts: RequestInit = { ...init, headers, signal };
+      let res = await fetch(`${BASE}${path}`, opts);
+
+      if (res.status === 401 && Auth.isEnabled()) {
+        const token = await Auth.getToken(true);
+        if (token) {
+          opts = { ...opts, headers: { ...opts.headers, Authorization: `Bearer ${token}` } };
+          res = await fetch(`${BASE}${path}`, opts);
+        }
+        if (res.status === 401) {
+          await Auth.login();
+          return;
+        }
+      }
+
+      if (!res.ok) { ... } // existing error handling
+      // ... existing stream reading logic
+    } catch (err: unknown) {
+      if ((err as Error).name !== "AbortError") {
+        options.onError?.((err as Error).message);
+      }
+    }
+  })();
+
+  return controller;
+}
+```
+
+Import `Auth` at the top of `api.ts`:
+```ts
+import { Auth } from "./auth";
+```
+
+### 2. `app/client/app.ts` — User menu hydration
+
+After `router.start()`, hydrate `#user-menu` with the account display name and a logout button using plain DOM manipulation:
+
+```ts
+if (Auth.isEnabled()) {
+  const account = Auth.getAccount();
+  const menu = document.getElementById("user-menu");
+  if (account && menu) {
+    const name = document.createElement("span");
+    name.className = "user-name";
+    name.textContent = account.name ?? account.username;
+
+    const logout = document.createElement("button");
+    logout.className = "user-logout";
+    logout.textContent = "Logout";
+    logout.addEventListener("click", () => Auth.logout());
+
+    menu.append(name, logout);
+  }
+}
+```
+
+### 3. `app/client/design/app/app.css` — `#user-menu` styles
+
+```css
+#user-menu {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+#user-menu .user-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+#user-menu .user-logout {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-1);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+
+  &:hover {
+    color: var(--blue);
+  }
+}
+```
+
+Logout button styled to match nav link style (no border, no background, color transition on hover).
+
+## Validation
+
+- [ ] `bun run build` succeeds
+- [ ] `request()` attaches `Authorization: Bearer <token>` when auth is enabled
+- [ ] `stream()` attaches `Authorization: Bearer <token>` when auth is enabled
+- [ ] When auth is disabled (no config script), no token acquisition occurs
+- [ ] 401 responses trigger one silent token refresh retry, then redirect to login
+- [ ] App header displays authenticated user's name when logged in
+- [ ] Logout button calls `Auth.logout()`
+- [ ] `#user-menu` remains empty when auth is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0-dev.99.120
+- Wire bearer token injection into `request()` and `stream()` with 401 retry and silent token refresh; add configurable OAuth `Scope` field to auth config; fix OIDC verifier audience/issuer mismatch for Entra access tokens; add user menu with display name and logout to app header; fetch PDFs via authenticated blob download for iframe viewing; document Entra app registration setup in README (#120)
+
 ## v0.4.0-dev.99.119
 - Add MSAL auth service with login gate; create `Auth` singleton in `core/auth.ts` wrapping `@azure/msal-browser` for MSAL initialization, redirect login, and token acquisition; convert app bootstrap to async IIFE gating on authentication; add configurable `CacheLocation` typed enum to `pkg/auth` threaded through `ClientAuthConfig` (#119)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ cd app && bun run watch
 
 # Terminal 2 — hot reload the Go server
 air
+
+# Terminal 2 — hot reload the Go server with Azure Entra auth
+HERALD_ENV=auth air
 ```
 
 The web client is available at `http://localhost:8080/app`.
@@ -56,6 +59,8 @@ To stop:
 ```bash
 docker compose -f docker-compose.yml -f compose/app.yml down
 ```
+
+The web client is available at `http://localhost:8080/app`.
 
 ## Tasks
 
@@ -84,3 +89,39 @@ Config loading follows a layered overlay pattern:
 4. `HERALD_*` environment variables — final overrides
 
 All environment variables use the `HERALD_` prefix (e.g., `HERALD_SERVER_PORT`, `HERALD_DB_HOST`).
+
+### Entra
+
+Azure Entra authentication is opt-in. To enable it locally, create a `config.auth.json` overlay and run with `HERALD_ENV=auth`.
+
+**App registration setup:**
+
+1. Register an app in Azure Entra ID (portal → App registrations → New registration)
+   - Name: `herald`
+   - Supported account types: Single tenant
+   - Redirect URI: **SPA** platform → `http://localhost:8080/app/`
+
+2. Expose an API (left sidebar)
+   - Set Application ID URI: `api://<client-id>` (default)
+   - Add a scope (e.g., `access`) — Admin and users can consent
+
+3. API permissions (left sidebar)
+   - Add your app's scope as a delegated permission (e.g., `api://<client-id>/access`)
+   - Grant admin consent
+
+4. Note the **Directory (tenant) ID** and **Application (client) ID** from the Overview page
+
+**Create `config.auth.json`:**
+
+```json
+{
+  "auth": {
+    "auth_mode": "azure",
+    "tenant_id": "<tenant-id>",
+    "client_id": "<client-id>",
+    "scope": "<scope-name>"
+  }
+}
+```
+
+The `scope` field is the bare scope name (e.g., `access`). The client composes the full `api://<client-id>/<scope>` format at runtime. When omitted, defaults to `access_as_user`.

--- a/app/app.go
+++ b/app/app.go
@@ -34,6 +34,7 @@ type ClientAuthConfig struct {
 	ClientID      string             `json:"client_id"`
 	RedirectURI   string             `json:"redirect_uri"`
 	Authority     string             `json:"authority"`
+	Scope         string             `json:"scope"`
 	CacheLocation auth.CacheLocation `json:"cache_location"`
 }
 

--- a/app/client/app.ts
+++ b/app/client/app.ts
@@ -18,4 +18,21 @@ import "@design/index.css";
 
   const router = new Router("app-content", routes);
   router.start();
+
+  if (Auth.isEnabled()) {
+    const account = Auth.getAccount();
+    const menu = document.getElementById("user-menu");
+    if (account && menu) {
+      const name = document.createElement("span");
+      name.className = "user-name";
+      name.textContent = account.name ?? account.username;
+
+      const logout = document.createElement("button");
+      logout.className = "user-logout";
+      logout.textContent = "Logout";
+      logout.addEventListener("click", () => Auth.logout());
+
+      menu.append(name, logout);
+    }
+  }
 })();

--- a/app/client/core/api.ts
+++ b/app/client/core/api.ts
@@ -1,3 +1,5 @@
+import { Auth } from "./auth";
+
 const BASE = "/api";
 
 /**
@@ -13,6 +15,12 @@ export interface ExecutionEvent {
   data: Record<string, unknown>;
 }
 
+async function authHeaders(): Promise<Record<string, string>> {
+  if (!Auth.isEnabled()) return {};
+  const token = await Auth.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 /**
  * Generic fetch wrapper. Prepends `/api` to the path.
  *
@@ -26,7 +34,22 @@ export async function request<T>(
   parse: (res: Response) => Promise<T> = (res) => res.json(),
 ): Promise<Result<T>> {
   try {
-    const res = await fetch(`${BASE}${path}`, init);
+    const headers = { ...init?.headers, ...(await authHeaders()) };
+    const opts: RequestInit = { ...init, headers };
+    let res = await fetch(`${BASE}${path}`, opts);
+
+    if (res.status === 401 && Auth.isEnabled()) {
+      const token = await Auth.getToken(true);
+      if (token) {
+        opts.headers = { ...opts.headers, Authorization: `Bearer ${token}` };
+        res = await fetch(`${BASE}${path}`, opts);
+      }
+      if (res.status === 401) {
+        await Auth.login();
+        return { ok: false, error: "Authentication required" };
+      }
+    }
+
     if (!res.ok) {
       const text = await res.text();
       return { ok: false, error: text || res.statusText };
@@ -53,13 +76,6 @@ export interface StreamOptions {
   signal?: AbortSignal;
 }
 
-/**
- * SSE client that returns an {@link AbortController} for cancellation.
- *
- * Parses `event:` and `data:` line pairs from the response stream.
- * Accepts optional `init` for non-GET requests (e.g., POST for classification).
- * Calls `onComplete` when the reader reports done; ignores `AbortError`.
- */
 export function stream(
   path: string,
   options: StreamOptions,
@@ -68,8 +84,27 @@ export function stream(
   const controller = new AbortController();
   const signal = options.signal ?? controller.signal;
 
-  fetch(`${BASE}${path}`, { ...init, signal })
-    .then(async (res) => {
+  (async () => {
+    try {
+      const headers = { ...init?.headers, ...(await authHeaders()) };
+      let opts: RequestInit = { ...init, headers, signal };
+      let res = await fetch(`${BASE}${path}`, opts);
+
+      if (res.status === 401 && Auth.isEnabled()) {
+        const token = await Auth.getToken(true);
+        if (token) {
+          opts = {
+            ...opts,
+            headers: { ...opts.headers, Authorization: `Bearer ${token}` },
+          };
+          res = await fetch(`${BASE}${path}`, opts);
+        }
+        if (res.status === 401) {
+          await Auth.login();
+          return;
+        }
+      }
+
       if (!res.ok) {
         const text = await res.text();
         options.onError?.(text || res.statusText);
@@ -106,12 +141,12 @@ export function stream(
       }
 
       options.onComplete?.();
-    })
-    .catch((err: Error) => {
-      if (err.name !== "AbortError") {
-        options.onError?.(err.message);
+    } catch (err: unknown) {
+      if ((err as Error).name !== "AbortError") {
+        options.onError?.((err as Error).message);
       }
-    });
+    }
+  })();
 
   return controller;
 }

--- a/app/client/core/auth.ts
+++ b/app/client/core/auth.ts
@@ -17,6 +17,7 @@ interface AuthConfig {
   client_id: string;
   redirect_uri: string;
   authority: string;
+  scope: string;
   cache_location?: string;
 }
 
@@ -28,7 +29,7 @@ function readConfig(): AuthConfig | null {
 }
 
 function scope(): string {
-  return `api://${config!.client_id}/access_as_user`;
+  return `api://${config!.client_id}/${config!.scope}`;
 }
 
 /**

--- a/app/client/design/app/app.css
+++ b/app/client/design/app/app.css
@@ -11,7 +11,7 @@
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: var(--space-4);
     padding: var(--space-3) var(--space-6);
     background: var(--bg-1);
     border-bottom: 1px solid var(--divider);
@@ -31,6 +31,7 @@
   .app-header nav {
     display: flex;
     gap: var(--space-4);
+    margin-left: auto;
 
     & a {
       color: var(--color-1);
@@ -53,6 +54,34 @@
     & > * {
       flex: 1;
       min-height: 0;
+    }
+  }
+
+  #user-menu {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding-left: var(--space-4);
+    border-left: 1px solid var(--divider);
+  }
+
+  #user-menu .user-name {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-1);
+  }
+
+  #user-menu .user-logout {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-1);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      color: var(--red);
     }
   }
 }

--- a/app/client/ui/views/review-view.ts
+++ b/app/client/ui/views/review-view.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
+import { Auth } from "@core";
 import { navigate } from "@core/router";
 import type { Document } from "@domains/documents";
 import { DocumentService } from "@domains/documents";
@@ -16,14 +17,26 @@ export class ReviewView extends LitElement {
 
   @property() documentId?: string;
   @state() private document?: Document;
+  @state() private blobUrl?: string;
   @state() private error?: string;
 
   async willUpdate(changed: Map<string, unknown>) {
     if (changed.has("documentId") && this.documentId) {
       this.document = undefined;
       this.error = undefined;
+      if (this.blobUrl) {
+        URL.revokeObjectURL(this.blobUrl);
+        this.blobUrl = undefined;
+      }
 
       await this.loadDocument(this.documentId);
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.blobUrl) {
+      URL.revokeObjectURL(this.blobUrl);
     }
   }
 
@@ -32,8 +45,21 @@ export class ReviewView extends LitElement {
 
     if (result.ok) {
       this.document = result.data;
+      await this.loadBlob(result.data.storage_key);
     } else {
       this.error = result.error;
+    }
+  }
+
+  private async loadBlob(storageKey: string) {
+    if (!Auth.isEnabled()) {
+      this.blobUrl = StorageService.view(storageKey);
+      return;
+    }
+
+    const result = await StorageService.download(storageKey);
+    if (result.ok) {
+      this.blobUrl = URL.createObjectURL(result.data);
     }
   }
 
@@ -67,7 +93,7 @@ export class ReviewView extends LitElement {
       <div class="panel pdf-panel">
         <hd-blob-viewer
           .title=${this.document.filename}
-          .src=${StorageService.view(this.document.storage_key)}
+          .src=${this.blobUrl}
         ></hd-blob-viewer>
       </div>
       <div class="panel classification-panel">

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -29,6 +29,7 @@ func NewModules(infra *infrastructure.Infrastructure, cfg *config.Config) (*Modu
 			TenantID:      cfg.Auth.TenantID,
 			ClientID:      cfg.Auth.ClientID,
 			Authority:     cfg.Auth.Authority,
+			Scope:         cfg.Auth.Scope,
 			CacheLocation: cfg.Auth.CacheLocation,
 		}
 	}

--- a/config.auth.json
+++ b/config.auth.json
@@ -1,0 +1,8 @@
+{
+  "auth": {
+    "auth_mode": "azure",
+    "tenant_id": "64819121-d17e-4216-a81e-fa8528635fb8",
+    "client_id": "52e63088-b087-4d03-8b61-0152660e963d",
+    "scope": "access"
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ var authEnv = &auth.Env{
 	ClientID:        "HERALD_AUTH_CLIENT_ID",
 	ClientSecret:    "HERALD_AUTH_CLIENT_SECRET",
 	Authority:       "HERALD_AUTH_AUTHORITY",
+	Scope:           "HERALD_AUTH_SCOPE",
 	CacheLocation:   "HERALD_AUTH_CACHE_LOCATION",
 }
 

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	ClientID        string        `json:"client_id"`
 	ClientSecret    string        `json:"client_secret"`
 	Authority       string        `json:"authority"`
+	Scope           string        `json:"scope"`
 	CacheLocation   CacheLocation `json:"cache_location"`
 }
 
@@ -61,6 +62,7 @@ type Env struct {
 	ClientID        string
 	ClientSecret    string
 	Authority       string
+	Scope           string
 	CacheLocation   string
 }
 
@@ -96,6 +98,9 @@ func (c *Config) Merge(overlay *Config) {
 	}
 	if overlay.Authority != "" {
 		c.Authority = overlay.Authority
+	}
+	if overlay.Scope != "" {
+		c.Scope = overlay.Scope
 	}
 	if overlay.CacheLocation != "" {
 		c.CacheLocation = overlay.CacheLocation
@@ -177,6 +182,11 @@ func (c *Config) loadEnv(env *Env) {
 			c.Authority = v
 		}
 	}
+	if env.Scope != "" {
+		if v := os.Getenv(env.Scope); v != "" {
+			c.Scope = v
+		}
+	}
 	if env.CacheLocation != "" {
 		if v := os.Getenv(env.CacheLocation); v != "" {
 			c.CacheLocation = CacheLocation(v)
@@ -187,6 +197,9 @@ func (c *Config) loadEnv(env *Env) {
 func (c *Config) deriveDefaults() {
 	if c.Authority == "" && c.TenantID != "" {
 		c.Authority = DefaultAuthorityBase + c.TenantID + DefaultAuthorityPath
+	}
+	if c.Scope == "" {
+		c.Scope = "access_as_user"
 	}
 }
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -38,7 +38,8 @@ func Auth(cfg *auth.Config, logger *slog.Logger) func(http.Handler) http.Handler
 			}
 
 			verifier = provider.Verifier(&oidc.Config{
-				ClientID: cfg.ClientID,
+				ClientID:        "api://" + cfg.ClientID,
+				SkipIssuerCheck: true,
 			})
 		}
 

--- a/tests/config/auth_test.go
+++ b/tests/config/auth_test.go
@@ -145,6 +145,76 @@ func TestAuthConfigCacheLocationMergeEmptyPreserves(t *testing.T) {
 	}
 }
 
+func TestAuthConfigScopeDefault(t *testing.T) {
+	cfg := &auth.Config{ClientID: "client-456"}
+	if err := cfg.Finalize(nil); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.Scope != "access_as_user" {
+		t.Errorf("scope: got %q, want %q", cfg.Scope, "access_as_user")
+	}
+}
+
+func TestAuthConfigScopeDefaultNoClientID(t *testing.T) {
+	cfg := &auth.Config{}
+	if err := cfg.Finalize(nil); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.Scope != "access_as_user" {
+		t.Errorf("scope: got %q, want %q", cfg.Scope, "access_as_user")
+	}
+}
+
+func TestAuthConfigScopeExplicit(t *testing.T) {
+	cfg := &auth.Config{Scope: "access", ClientID: "client-456"}
+	if err := cfg.Finalize(nil); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.Scope != "access" {
+		t.Errorf("scope: got %q, want %q", cfg.Scope, "access")
+	}
+}
+
+func TestAuthConfigScopeEnvOverride(t *testing.T) {
+	t.Setenv("HERALD_AUTH_SCOPE", "custom_scope")
+
+	env := &auth.Env{Scope: "HERALD_AUTH_SCOPE"}
+
+	cfg := &auth.Config{}
+	if err := cfg.Finalize(env); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	if cfg.Scope != "custom_scope" {
+		t.Errorf("scope: got %q, want %q", cfg.Scope, "custom_scope")
+	}
+}
+
+func TestAuthConfigScopeMerge(t *testing.T) {
+	base := &auth.Config{Scope: "access_as_user"}
+	overlay := &auth.Config{Scope: "access"}
+
+	base.Merge(overlay)
+
+	if base.Scope != "access" {
+		t.Errorf("scope: got %q, want %q", base.Scope, "access")
+	}
+}
+
+func TestAuthConfigScopeMergeEmptyPreserves(t *testing.T) {
+	base := &auth.Config{Scope: "access"}
+	overlay := &auth.Config{}
+
+	base.Merge(overlay)
+
+	if base.Scope != "access" {
+		t.Errorf("scope should be preserved: got %q", base.Scope)
+	}
+}
+
 func TestAuthConfigEnvOverrides(t *testing.T) {
 	t.Setenv("HERALD_AUTH_MODE", "azure")
 	t.Setenv("HERALD_AUTH_MANAGED_IDENTITY", "true")


### PR DESCRIPTION
## Summary

Connect the MSAL auth service to the API transport layer so all requests carry bearer tokens when auth is enabled. Add 401 retry with silent token refresh, user display in the app header, and authenticated PDF viewing.

Closes #120

## Changes

- Add `authHeaders()` helper and bearer token injection to `request()` and `stream()` in `api.ts`
- Add 401 retry: force-refresh token once, then redirect to login
- Hydrate `#user-menu` in app header with account display name and logout button
- Add configurable `Scope` field to `pkg/auth.Config` (bare scope name, client composes `api://<client_id>/<scope>`)
- Fix OIDC verifier: set audience to `api://<client_id>` and `SkipIssuerCheck` for Entra access token compatibility
- Fetch PDFs via authenticated `StorageService.download()` with `blob:` URL for iframe viewing
- Fix header layout: `margin-left: auto` on nav, `border-left` divider on user-menu
- Add Entra app registration setup docs and `HERALD_ENV=auth air` dev command to README
- Add `config.auth.json` overlay for local Entra testing
- Add 6 new scope tests (default, explicit, env override, merge)