### PR TITLE
Fix Azure Government auth authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.2
+
+### Authentication
+
+- Fix Azure Government auth by composing authority URL from base + tenant ID — `HERALD_AUTH_AUTHORITY` now accepts the base URL (e.g., `https://login.microsoftonline.us`) and derives the full OIDC authority
+- Add `knownAuthorities` to MSAL config to prevent instance discovery against commercial endpoints
+- Add `authAuthority` Bicep parameter for injecting `HERALD_AUTH_AUTHORITY` on non-commercial clouds
+
 ## v0.4.1
 
 ### Deployment

--- a/app/client/core/auth.ts
+++ b/app/client/core/auth.ts
@@ -62,11 +62,14 @@ export const Auth = {
     config = readConfig();
     if (!config) return;
 
+    const authorityHost = new URL(config.authority).hostname;
+
     const msalConfig: Configuration = {
       auth: {
         clientId: config.client_id,
         authority: config.authority,
         redirectUri: config.redirect_uri,
+        knownAuthorities: [authorityHost],
       },
       cache: {
         cacheLocation: config.cache_location ?? "localStorage",

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -107,6 +107,9 @@ param tenantId string = ''
 @description('Entra app registration client ID (required when authEnabled is true)')
 param entraClientId string = ''
 
+@description('Entra authority base URL (override for Azure Government, e.g., https://login.microsoftonline.us)')
+param authAuthority string = ''
+
 // ============================================================================
 // Modules
 // ============================================================================
@@ -298,7 +301,13 @@ var authEnvVars = authEnabled
     ]
   : []
 
-var envVars = concat(baseEnvVars, authEnvVars)
+var authorityEnvVars = authAuthority != ''
+  ? [
+      { name: 'HERALD_AUTH_AUTHORITY', value: authAuthority }
+    ]
+  : []
+
+var envVars = concat(baseEnvVars, authEnvVars, authorityEnvVars)
 
 // ============================================================================
 // Container App (when computeTarget == 'containerapp')

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -30,8 +30,8 @@ const (
 	// ModeAzure enables Azure identity credentials via the azidentity SDK.
 	ModeAzure Mode = "azure"
 
-	// DefaultAuthorityBase is the commercial Azure AD authority URL prefix.
-	DefaultAuthorityBase = "https://login.microsoftonline.com/"
+	// DefaultAuthorityBase is the commercial Azure AD authority URL.
+	DefaultAuthorityBase = "https://login.microsoftonline.com"
 	// DefaultAuthorityPath is the OIDC v2.0 endpoint suffix.
 	DefaultAuthorityPath = "/v2.0"
 )
@@ -192,8 +192,12 @@ func (c *Config) loadEnv(env *Env) {
 }
 
 func (c *Config) deriveDefaults() {
-	if c.Authority == "" && c.TenantID != "" {
-		c.Authority = DefaultAuthorityBase + c.TenantID + DefaultAuthorityPath
+	if c.TenantID != "" {
+		base := DefaultAuthorityBase
+		if c.Authority != "" {
+			base = c.Authority
+		}
+		c.Authority = base + "/" + c.TenantID + DefaultAuthorityPath
 	}
 	if c.Scope == "" {
 		c.Scope = "access_as_user"


### PR DESCRIPTION
## Summary

- Compose OIDC authority from `HERALD_AUTH_AUTHORITY` base URL + tenant ID instead of hardcoding commercial `login.microsoftonline.com`
- Add `knownAuthorities` to MSAL config derived from authority hostname, preventing instance discovery against commercial endpoints
- Add `authAuthority` Bicep parameter for injecting `HERALD_AUTH_AUTHORITY` on non-commercial deployments