### PR TITLE
Scroll container utility and document-upload queue overflow fix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,6 +88,15 @@ All version references across the project (ARM parameter files, config defaults,
 - **Parameters**: More than two → use a struct.
 - **Interfaces**: Define where consumed, not where implemented. Keep minimal.
 
+## Web Client Conventions
+
+See `.claude/skills/web-development/` for full conventions. Key points that are easy to miss:
+
+- **Cascade layers**: `tokens, reset, base, theme, app`. The `base` layer (`design/core/base.css`) holds cross-cutting primitives like the universal `scrollbar-gutter: stable` rule.
+- **Scroll containers**: Never declare `overflow-y: auto` (or `overflow-x: auto`) directly in a component's CSS. Import `@styles/scroll.module.css` and apply `.scroll-y` / `.scroll-x` in the template. The utility bundles `overflow`, `scrollbar-gutter: stable`, and axis padding — layout still lives in the component's own CSS (`flex: 1; min-height: 0;`, `max-height: ...`, etc.).
+- **Flex sizing for scroll**: A scroll container still needs `flex: 1; min-height: 0;` from its parent flex column; the utility does not fix missing flex constraints.
+- **Shared styles**: `@styles/*` for reusable modules (`badge`, `buttons`, `cards`, `inputs`, `labels`, `scroll`). Component `*.module.css` provides layout-specific overrides.
+
 ## Gotchas
 
 - **Middleware order**: First-registered middleware runs outermost (CORS before Logger)

--- a/.claude/context/guides/.archive/133-document-upload-scroll-container.md
+++ b/.claude/context/guides/.archive/133-document-upload-scroll-container.md
@@ -1,0 +1,271 @@
+# 133 - Scroll container for document-upload module
+
+## Problem Context
+
+When many files are queued in the `hd-document-upload` module, the queue container grows without bounds and overflows the viewport because no scroll container is declared. The sibling `document-grid` and `prompt-list` modules already handle this cleanly.
+
+The module sits inside `documents-view.module.css`'s `.view` flex column (`flex: 1; min-height: 0;`). Its own `:host` currently has no flex sizing, so it expands to intrinsic content height — pushing `<hd-document-grid>` out of view and letting the queue list grow past the viewport instead of scrolling internally.
+
+## Architecture Approach
+
+Mirror the overflow pattern used by `prompt-list.module.css` and `document-grid.module.css`, with one refinement: the File Queue header (title, file count, Clear/Upload actions) stays pinned — only the entries scroll.
+
+- Host becomes a flex-growing, min-height-0 column so the module participates correctly in its parent flex layout.
+- The fixed-height sibling (`.drop-zone`) is pinned above the queue with explicit `flex-shrink: 0;`.
+- `.queue` remains a flex column that claims vertical space (`flex: 1; min-height: 0;`), but is no longer the scroll container.
+- `.queue-header` is pinned inside `.queue` with `flex-shrink: 0;`.
+- A new `.queue-list` wrapper around the mapped entries becomes the internal scroll container.
+
+Requires a small markup change in `document-upload.ts` (wrap the entries in `.queue-list`) plus the CSS updates.
+
+## Implementation
+
+### Step 1: Update `app/client/ui/modules/document-upload.module.css`
+
+Show only the modified rules; other declarations in each rule stay as-is.
+
+**`:host`** — add `flex: 1; min-height: 0;`:
+
+```css
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+}
+```
+
+**`.drop-zone`** — add `flex-shrink: 0;` to keep it pinned above the queue:
+
+```css
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-8);
+  border: 2px dashed var(--divider);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  &:hover {
+    border-color: var(--color-2);
+    background: var(--bg-1);
+  }
+}
+```
+
+**`.queue`** — add `flex: 1; min-height: 0;` so it claims vertical space, but do **not** set `overflow-y`:
+
+```css
+.queue {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--bg-1);
+  flex: 1;
+  min-height: 0;
+}
+```
+
+**`.queue-header`** — add `flex-shrink: 0;` so it stays pinned when the list scrolls:
+
+```css
+.queue-header {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--divider);
+  flex-shrink: 0;
+}
+```
+
+**New `.queue-list` rule** — the actual scroll container for queue entries. Place it directly below the `.queue-header` rule:
+
+```css
+.queue-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+```
+
+### Step 2: Wrap queue entries in `.queue-list` in `app/client/ui/modules/document-upload.ts`
+
+Update `renderQueue()` so the mapped entries live inside a dedicated scroll wrapper (around line 258). Existing:
+
+```ts
+  private renderQueue() {
+    if (this.queue.length < 1) return nothing;
+
+    return html`
+      <div class="queue">
+        <div class="queue-header">
+          <span class="queue-title">File Queue</span>
+          <span class="queue-count">
+            ${this.queue.length} file${this.queue.length > 1 ? "s" : ""}
+          </span>
+          ${this.renderQueueActions()}
+        </div>
+        ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+      </div>
+    `;
+  }
+```
+
+Replace the body with:
+
+```ts
+  private renderQueue() {
+    if (this.queue.length < 1) return nothing;
+
+    return html`
+      <div class="queue">
+        <div class="queue-header">
+          <span class="queue-title">File Queue</span>
+          <span class="queue-count">
+            ${this.queue.length} file${this.queue.length > 1 ? "s" : ""}
+          </span>
+          ${this.renderQueueActions()}
+        </div>
+        <div class="queue-list">
+          ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+        </div>
+      </div>
+    `;
+  }
+```
+
+## Remediation
+
+### R1: Scrollbar Gutter Design System Primitive
+
+**Context.** With the new `.queue-list` scroll container introduced above, the app now has seven scroll containers (one added here, six pre-existing). Each reserves its own scrollbar behavior ad-hoc via `overflow-y: auto`, with no shared gutter reservation or visual separation between content and scrollbar. This remediation extracts a reusable primitive so scroll behavior is consistent across every module and so future scroll containers inherit the pattern by convention.
+
+**Shadow DOM constraint.** Components are Lit elements; styles in `design/index.css` do not pierce shadow roots. The design system therefore needs two tiers: a light-DOM rule for document-level scroll contexts and a component-adoptable CSS module for shadow roots.
+
+**Pattern overview.**
+
+- **Light DOM** — new `base` layer between `reset` and `theme` with a universal `scrollbar-gutter: stable` rule. `scrollbar-gutter` is a no-op on elements whose `overflow` is not `auto`/`scroll`/`hidden`, so the `*` selector is safe.
+- **Shadow DOM** — new `scroll.module.css` exposing `.scroll-y` and `.scroll-x` utilities that components import via the `@styles/` alias (same pattern as `buttons.module.css`, `inputs.module.css`). Each utility bundles `overflow-*: auto`, `scrollbar-gutter: stable`, and a `padding-*` axis to keep the scrollbar visually separated from content.
+
+The refactor swaps every per-component `overflow-y: auto` declaration for the `.scroll-y` utility class applied in the template.
+
+### R1 Step 1: Add `app/client/design/core/base.css`
+
+New file:
+
+```css
+@layer base {
+  * {
+    scrollbar-gutter: stable;
+  }
+}
+```
+
+### R1 Step 2: Register the `base` layer in `app/client/design/index.css`
+
+Insert `base` into the layer order (between `reset` and `theme`) and add the import:
+
+```css
+@layer tokens, reset, base, theme, app;
+
+@import url(./core/tokens.css);
+@import url(./core/reset.css);
+@import url(./core/base.css);
+@import url(./core/theme.css);
+
+@import url(./app/app.css);
+```
+
+### R1 Step 3: Add `app/client/design/styles/scroll.module.css`
+
+New file. `padding-inline-end` / `padding-block-end` reserves visible space so the scrollbar does not abut content:
+
+```css
+.scroll-y {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding-inline-end: var(--space-2);
+}
+
+.scroll-x {
+  overflow-x: auto;
+  scrollbar-gutter: stable;
+  padding-block-end: var(--space-2);
+}
+```
+
+### R1 Step 4: Migrate existing scroll containers to `.scroll-y`
+
+For every scroll container, do the following three things:
+
+1. In the `.module.css`, **remove** the `overflow-y: auto` declaration from the rule. Leave any surrounding layout declarations (`flex: 1; min-height: 0;`, `max-height: ...`, etc.) in place.
+2. In the component `.ts` file, add the scroll styles import and include it in `static styles`:
+
+   ```ts
+   import scrollStyles from "@styles/scroll.module.css";
+   // ...
+   static styles = [/* existing */, scrollStyles, styles];
+   ```
+
+3. In the component template, add `scroll-y` to the scroll container's `class` attribute.
+
+**Touchpoints:**
+
+| Component | File (module.css → ts) | Selector losing `overflow-y: auto` | Template element to add `scroll-y` to |
+|-----------|------------------------|------------------------------------|---------------------------------------|
+| document-grid | `ui/modules/document-grid.*` | `.grid` | `<div class="grid">` → `<div class="grid scroll-y">` |
+| prompt-list | `ui/modules/prompt-list.*` | `.list` | `<div class="list">` → `<div class="list scroll-y">` |
+| classification-panel | `ui/modules/classification-panel.*` | `.panel-body` | All three `.panel-body` usages (lines ~165, ~215, ~257) |
+| prompt-form | `ui/modules/prompt-form.*` | `.form-body` | `<form class="form-body">` → `<form class="form-body scroll-y">` |
+| prompt-form (inner) | `ui/modules/prompt-form.*` | `.defaults-content` (keep `max-height: 20rem;`) | `<div class="defaults-content">` → `<div class="defaults-content scroll-y">` |
+| review-view | `ui/views/review-view.*` | `.classification-panel` | `<div class="panel classification-panel">` → `<div class="panel classification-panel scroll-y">` |
+| document-upload | `ui/modules/document-upload.*` (from Step 1 above) | `.queue-list` | `<div class="queue-list">` → `<div class="queue-list scroll-y">` |
+
+For `document-upload`, remove the `overflow-y: auto;` from the `.queue-list` rule added in Step 1 above so it matches the refactored pattern — the utility class now owns that declaration.
+
+### R1 Step 5: Ensure `document-upload.ts` imports `scrollStyles`
+
+Update the import block and `static styles` in `app/client/ui/modules/document-upload.ts`:
+
+```ts
+import badgeStyles from "@styles/badge.module.css";
+import buttonStyles from "@styles/buttons.module.css";
+import scrollStyles from "@styles/scroll.module.css";
+import styles from "./document-upload.module.css";
+```
+
+```ts
+static styles = [buttonStyles, badgeStyles, scrollStyles, styles];
+```
+
+## Validation Criteria
+
+- [ ] CSS updates applied to `:host`, `.drop-zone`, `.queue`, `.queue-header`, and new `.queue-list`
+- [ ] `renderQueue()` wraps entries in `<div class="queue-list scroll-y">`
+- [ ] `design/core/base.css` exists and is imported in `design/index.css` under the `base` layer
+- [ ] `design/styles/scroll.module.css` exists with `.scroll-y` and `.scroll-x` utilities
+- [ ] All seven scroll containers listed in R1 Step 4 have their local `overflow-y: auto` removed and the `scroll-y` class applied, with `scrollStyles` imported into each component's `static styles`
+- [ ] `mise run dev` starts cleanly
+- [ ] Navigate to `/documents`, click **Upload**, drop ≥ 20 PDFs — only the entries scroll; the "File Queue" title, count, and Clear/Upload buttons stay pinned at the top of the queue
+- [ ] Scrollbar has visible breathing room from the rightmost content in every scroll container (queue list, document grid, prompt list, classification panel, prompt form body and defaults, review-view classification panel)
+- [ ] No horizontal layout shift occurs when a container's content grows past the fold (scrollbar-gutter reserved consistently)
+- [ ] Drop zone remains visible above the queue regardless of entry count
+- [ ] Drag-and-drop works over the drop zone with both empty and populated queues
+- [ ] During upload, progress rows and completion badges render correctly without layout shift
+- [ ] Closing the upload panel leaves the document grid rendering normally
+- [ ] `mise run vet` passes

--- a/.claude/context/sessions/133-document-upload-scroll-container.md
+++ b/.claude/context/sessions/133-document-upload-scroll-container.md
@@ -1,0 +1,54 @@
+# 133 - Scroll container for document-upload module
+
+## Summary
+
+Fixed the unbounded growth of the `hd-document-upload` queue (it overflowed the viewport when many files were queued) by adding scroll semantics to the queue and pinning the queue header. Scope expanded mid-session to extract a reusable scroll primitive into the design system — a universal `scrollbar-gutter: stable` rule plus `.scroll-y` / `.scroll-x` utilities — and to migrate all seven of the app's scroll containers to the utility. Skill and project docs updated so future scroll containers default to the utility.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Queue scroll structure | Wrap mapped entries in a new `.queue-list` child of `.queue` | Keeps the `.queue-header` (title, count, Clear/Upload buttons) pinned while only the entries scroll — more useful than scrolling the whole queue. |
+| `scrollbar-gutter` placement | New `base` layer between `reset` and `theme` with `* { scrollbar-gutter: stable; }` | `scrollbar-gutter` is a no-op on non-scrolling elements, so the universal selector is safe. Own layer keeps cross-cutting primitives separate from reset-layer normalizations. |
+| Shadow-DOM reach | New `design/styles/scroll.module.css` imported per component | Light-DOM rules don't pierce shadow DOM. A shared CSS module reuses the existing `@styles/*` pattern (no base-class refactor, no build-time magic). |
+| Utility class vs attribute | `.scroll-y` / `.scroll-x` classes | Matches existing `@styles/*` convention (`.btn`, `.input`, `.badge`, `.label`, `.card`). |
+| Visual scrollbar spacing | Utility bundles `padding-inline-end: var(--space-2)` (or `padding-block-end` for `.scroll-x`) | CSS can't detect "is-scrolling" via a selector, so padding is baked into the utility. Non-scrolling elements don't use the utility, so there's no accidental padding elsewhere. |
+| Scope of design-system work | Folded into #133 as Remediation 1 | The new scroll container introduced here benefits immediately, and the primitive lands in a natural place rather than waiting on a follow-up issue. |
+| `@design/index.css` TS error | Folded in as Remediation 2 (three-line fix in `css.d.ts`) | Pre-existed on `main`, but the fix is trivial and we were touching the design-system entry point anyway. Keeps `tsc --noEmit` clean going forward. |
+
+## Files Modified
+
+**New files:**
+- `app/client/design/core/base.css`
+- `app/client/design/styles/scroll.module.css`
+
+**Design system:**
+- `app/client/design/index.css` — register `base` layer and import
+- `app/client/css.d.ts` — add `declare module "*.css"` for side-effect imports
+
+**Component migrations (remove local `overflow-y: auto`, import `scrollStyles`, apply `.scroll-y`):**
+- `app/client/ui/modules/document-upload.{module.css,ts}` (new `.queue-list` scroll container + host/drop-zone flex sizing)
+- `app/client/ui/modules/document-grid.{module.css,ts}`
+- `app/client/ui/modules/prompt-list.{module.css,ts}`
+- `app/client/ui/modules/prompt-form.{module.css,ts}` (both `.form-body` and inner `.defaults-content`)
+- `app/client/ui/modules/classification-panel.{module.css,ts}` (all three `.panel-body` template usages)
+- `app/client/ui/views/review-view.{module.css,ts}`
+
+**Documentation context:**
+- `.claude/CLAUDE.md` — new "Web Client Conventions" section
+- `.claude/skills/web-development/SKILL.md` — CSS one-liner, Prefer/Avoid lists
+- `.claude/skills/web-development/references/css.md` — five-layer stack, new `base` layer subsection, `scroll.module.css` in shared-styles table, rewritten scroll-container view pattern
+
+## Patterns Established
+
+- **Scroll containers use the `.scroll-y` / `.scroll-x` utility.** Never declare `overflow-y: auto` directly in a component's CSS. Layout (`flex: 1; min-height: 0;`, `max-height: ...`) lives in the component CSS; scroll behavior (`overflow`, `scrollbar-gutter`, axis padding) lives in the utility. The utility is imported alongside the existing `@styles/*` pattern.
+- **The `base` layer** is the home for cross-cutting primitives (universal `scrollbar-gutter`, future similar rules) that aren't resets but apply broadly. Sits between `reset` and `theme` in the cascade.
+- **Scroll header pinning** — when a scroll container has a fixed header (title, actions, counts), wrap entries in a dedicated scroll child rather than making the whole container scroll. See `document-upload`'s `.queue` / `.queue-list` split for the reference pattern.
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `mise run test` — 20/20 Go packages pass
+- `bun run build` — Bun CSS-modules plugin picks up `scroll.module.css` cleanly, `dist/app.js` + `dist/app.css` build
+- `bunx tsc --noEmit` — clean after R2 fix (was erroring on `@design/index.css` side-effect import, pre-existing on main)
+- Manual UI verification — queue scrolls internally with ≥ 20 files, header pinned, drop zone fixed above, all six other scroll containers (document grid, prompt list, classification panel, prompt form body + defaults, review-view classification panel) verified visually with scrollbar breathing room

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -69,7 +69,7 @@ Stateless API wrappers that mirror Go domain handlers. Each domain has a PascalC
 
 ### CSS — [references/css.md](references/css.md)
 
-Four cascade layers (`tokens, reset, theme, app`), design tokens as CSS custom properties using `light-dark()` (penetrate shadow DOM naturally), component styles via `*.module.css` → `CSSStyleSheet`, shared styles via `@styles/*` alias, global CSS via side-effect import, and app-shell scroll architecture (body never scrolls, views own scroll regions).
+Five cascade layers (`tokens, reset, base, theme, app`), design tokens as CSS custom properties using `light-dark()` (penetrate shadow DOM naturally), component styles via `*.module.css` → `CSSStyleSheet`, shared styles via `@styles/*` alias (including `.scroll-y` / `.scroll-x` utilities — the default for every scroll container), global CSS via side-effect import, and app-shell scroll architecture (body never scrolls, views own scroll regions).
 
 ### API — [references/api.md](references/api.md)
 
@@ -237,6 +237,7 @@ declare global {
 - Pure elements importing stateful infrastructure — services, context, or router utilities. Elements can import immutable domain infrastructure (types, constants, formatters) but never anything that holds or mutates state.
 - Using `height: 100%` in flex containers — use `flex: 1` with `min-height: 0`
 - Forgetting `min-height: 0` on flex children that need scroll boundaries
+- Declaring `overflow-y: auto` (or `overflow-x: auto`) directly in a component's CSS — use the `.scroll-y` / `.scroll-x` utility from `@styles/scroll.module.css` so the scrollbar gutter and spacing stay consistent across the app
 - Using inline `style` attributes — use CSS classes and custom properties
 - Accessing `this.id` or `this.title` on components — conflicts with `HTMLElement` built-ins
 - Importing `*.module.css` with `?inline` suffix — Herald uses the naming convention, not query params
@@ -256,3 +257,4 @@ declare global {
 - Domain types and constants in pure elements — immutable domain knowledge is fine, stateful behavior is not
 - Monospace font (`--font-mono`) on interactive elements (buttons, inputs, selects)
 - `light-dark()` for color tokens instead of duplicated `@media (prefers-color-scheme)` blocks
+- `.scroll-y` / `.scroll-x` from `@styles/scroll.module.css` as the default for every scroll container — layout lives in the component CSS (`flex: 1; min-height: 0;`), scroll behavior lives in the utility

--- a/.claude/skills/web-development/references/css.md
+++ b/.claude/skills/web-development/references/css.md
@@ -2,20 +2,27 @@
 
 ## Cascade Layers
 
-Herald uses four layers with explicit precedence. Tokens are lowest priority (easily overridden), app is highest.
+Herald uses five layers with explicit precedence. Tokens are lowest priority (easily overridden), app is highest.
 
 ```css
 /* design/index.css */
-@layer tokens, reset, theme, app;
+@layer tokens, reset, base, theme, app;
 
 @import url(./core/tokens.css);
 @import url(./core/reset.css);
+@import url(./core/base.css);
 @import url(./core/theme.css);
 
 @import url(./app/app.css);
 ```
 
 `app.css` is in the `app` layer (highest priority) and handles the application shell layout.
+
+### The `base` layer
+
+`design/core/base.css` holds cross-cutting primitives that aren't resets but need to apply broadly — currently a universal `scrollbar-gutter: stable` rule. Because `scrollbar-gutter` is a no-op on elements whose `overflow` is not `auto`/`scroll`/`hidden`, a `*` selector is safe and ensures every scroll container in the light DOM reserves scrollbar space consistently (no layout shift when content crosses the scroll threshold).
+
+Light-DOM rules don't pierce shadow DOM, so components get the same guarantee through `scroll.module.css` (see Shared Component Styles below).
 
 ## Design Tokens
 
@@ -97,6 +104,7 @@ Reusable CSS modules in `app/client/design/styles/` imported via `@styles/*`. Co
 | `cards.module.css` | `.card` | Flex column container with gap, padding, border, radius, transition |
 | `inputs.module.css` | `.input` | Text inputs, selects, and textareas with focus/disabled states |
 | `labels.module.css` | `.label` | Uppercase monospace section labels (form field labels, section headers) |
+| `scroll.module.css` | `.scroll-y`, `.scroll-x` | Scroll container utilities — bundle `overflow-*: auto`, `scrollbar-gutter: stable`, and padding on the scroll axis so the scrollbar has breathing room from content |
 
 Usage pattern:
 
@@ -149,19 +157,46 @@ body {
 }
 ```
 
-View pattern for scrollable content — the critical pieces are `flex: 1`, `min-height: 0`, and `overflow-y: auto` on the scrollable child:
+### Scroll containers use the `.scroll-y` / `.scroll-x` utility
+
+Never declare `overflow-y: auto` (or `overflow-x: auto`) directly on a scroll container. Import `scroll.module.css` and apply `.scroll-y` in the template instead. The utility bundles three concerns that belong together:
+
+- `overflow-*: auto` — the scroll behavior.
+- `scrollbar-gutter: stable` — reserves the scrollbar track so content doesn't shift horizontally when the scrollbar appears/disappears.
+- `padding-*` on the scroll axis — keeps the scrollbar visually separated from content.
+
+Component CSS still owns the layout (`flex: 1; min-height: 0;`, `max-height: ...`, grid layout, etc.). The utility only provides scroll behavior, which keeps the component rule focused on layout intent and the utility focused on scroll ergonomics.
+
+**Component CSS** — layout only, no `overflow`:
 
 ```css
 :host {
   display: flex;
   flex-direction: column;
-}
-
-.scrollable {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+}
+
+.list {
+  flex: 1;
+  min-height: 0;
+  /* no overflow-y — .scroll-y provides it */
 }
 ```
 
-Without `min-height: 0` on flex children, content overflows instead of scrolling. This is the most common CSS bug in the application.
+**Component TypeScript** — import the shared module and attach the class:
+
+```ts
+import scrollStyles from "@styles/scroll.module.css";
+import styles from "./my-list.module.css";
+
+static styles = [scrollStyles, styles];
+
+render() {
+  return html`<div class="list scroll-y">...</div>`;
+}
+```
+
+Use `.scroll-x` for horizontal scroll containers; the two utilities don't compose on the same element (a container should scroll on one axis).
+
+Without `min-height: 0` on flex children, content overflows instead of scrolling even with `.scroll-y` applied. This is still the most common CSS bug in the application — the utility doesn't obviate the flex-sizing requirement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.5.0-dev.132.133
+
+### Web Client
+
+- Fix `hd-document-upload` queue overflowing the viewport with many queued files — host/drop-zone flex sized so the module participates in the view's flex column, new `.queue-list` wrapper scrolls the entries while the File Queue header (title, count, Clear/Upload) stays pinned (#133)
+
+### Design System
+
+- Add `design/core/base.css` in a new `base` cascade layer (between `reset` and `theme`) with `* { scrollbar-gutter: stable; }` for universal light-DOM scrollbar-track reservation (#133)
+- Add `design/styles/scroll.module.css` with `.scroll-y` / `.scroll-x` utilities — bundle `overflow-*: auto`, `scrollbar-gutter: stable`, and axis padding so scroll containers share consistent ergonomics across shadow DOM (#133)
+- Migrate all scroll containers (`document-grid`, `prompt-list`, `classification-panel`, `prompt-form` body and defaults, `review-view` classification panel, `document-upload` queue list) to the `.scroll-y` utility (#133)
+- Add `declare module "*.css"` to `client/css.d.ts` so side-effect imports of non-module CSS (e.g. `@design/index.css`) type-check under `tsc --noEmit` (#133)
+
 ## v0.5.0-dev.132.136
 
 ### Dependencies

--- a/app/client/css.d.ts
+++ b/app/client/css.d.ts
@@ -3,3 +3,5 @@ declare module "*.module.css" {
   const sheet: CSSStyleSheet;
   export default sheet;
 }
+
+declare module "*.css";

--- a/app/client/design/core/base.css
+++ b/app/client/design/core/base.css
@@ -1,0 +1,5 @@
+@layer base {
+  * {
+    scrollbar-gutter: stable;
+  }
+}

--- a/app/client/design/index.css
+++ b/app/client/design/index.css
@@ -1,7 +1,8 @@
-@layer tokens, reset, theme, app;
+@layer tokens, reset, base, theme, app;
 
 @import url(./core/tokens.css);
 @import url(./core/reset.css);
+@import url(./core/base.css);
 @import url(./core/theme.css);
 
 @import url(./app/app.css);

--- a/app/client/design/styles/scroll.module.css
+++ b/app/client/design/styles/scroll.module.css
@@ -1,0 +1,11 @@
+.scroll-y {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding-inline-end: var(--space-2);
+}
+
+.scroll-x {
+  overflow-x: auto;
+  scrollbar-gutter: stable;
+  padding-block-end: var(--space-2);
+}

--- a/app/client/ui/modules/classification-panel.module.css
+++ b/app/client/ui/modules/classification-panel.module.css
@@ -25,7 +25,6 @@
   padding-inline: var(--space-2);
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
 }
 
 .section {

--- a/app/client/ui/modules/classification-panel.ts
+++ b/app/client/ui/modules/classification-panel.ts
@@ -10,6 +10,7 @@ import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
 import labelStyles from "@styles/labels.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./classification-panel.module.css";
 
 type PanelMode = "view" | "validate" | "update";
@@ -22,7 +23,14 @@ type PanelMode = "view" | "validate" | "update";
  */
 @customElement("hd-classification-panel")
 export class ClassificationPanel extends LitElement {
-  static styles = [badgeStyles, buttonStyles, inputStyles, labelStyles, styles];
+  static styles = [
+    badgeStyles,
+    buttonStyles,
+    inputStyles,
+    labelStyles,
+    scrollStyles,
+    styles,
+  ];
 
   @property() documentId = "";
 
@@ -162,7 +170,7 @@ export class ClassificationPanel extends LitElement {
     const c = this.classification!;
 
     return html`
-      <div class="panel-body">
+      <div class="panel-body scroll-y">
         <div class="section">
           <span class="label">Classification</span>
           <div class="classification-value">
@@ -212,7 +220,7 @@ export class ClassificationPanel extends LitElement {
 
   private renderValidateMode() {
     return html`
-      <form class="panel-body" @submit=${this.handleValidate}>
+      <form class="panel-body scroll-y" @submit=${this.handleValidate}>
         <p>Confirm that the classification is correct.</p>
 
         <div class="field">
@@ -254,7 +262,7 @@ export class ClassificationPanel extends LitElement {
     const c = this.classification!;
 
     return html`
-      <form class="panel-body" @submit=${this.handleUpdate}>
+      <form class="panel-body scroll-y" @submit=${this.handleUpdate}>
         <p>Manually update the classification result.</p>
 
         <div class="field">

--- a/app/client/ui/modules/document-grid.module.css
+++ b/app/client/ui/modules/document-grid.module.css
@@ -27,7 +27,6 @@
   justify-items: stretch;
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
   padding-bottom: var(--space-2);
 }
 

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -10,6 +10,7 @@ import type { Document, SearchRequest } from "@domains/documents";
 
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./document-grid.module.css";
 
 interface ClassifyProgress {
@@ -24,7 +25,7 @@ interface ClassifyProgress {
  */
 @customElement("hd-document-grid")
 export class DocumentGrid extends LitElement {
-  static styles = [buttonStyles, inputStyles, styles];
+  static styles = [buttonStyles, inputStyles, scrollStyles, styles];
 
   @state() private documents: PageResult<Document> | null = null;
   @state() private page = 1;
@@ -261,7 +262,7 @@ export class DocumentGrid extends LitElement {
     }
 
     return html`
-      <div class="grid">
+      <div class="grid scroll-y">
         ${this.documents.data.map((doc) => {
           const progress = this.classifying.get(doc.id);
           return html`

--- a/app/client/ui/modules/document-upload.module.css
+++ b/app/client/ui/modules/document-upload.module.css
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
 }
 
 .drop-zone {
@@ -14,6 +16,7 @@
   border: 2px dashed var(--divider);
   border-radius: var(--radius-md);
   cursor: pointer;
+  flex-shrink: 0;
   transition:
     border-color 0.15s,
     background 0.15s;
@@ -47,6 +50,8 @@
   border-radius: var(--radius-md);
   padding: var(--space-3);
   background: var(--bg-1);
+  flex: 1;
+  min-height: 0;
 }
 
 .queue-header {
@@ -55,6 +60,15 @@
   align-items: center;
   padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--divider);
+  flex-shrink: 0;
+}
+
+.queue-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  min-height: 0;
 }
 
 .queue-title {

--- a/app/client/ui/modules/document-upload.ts
+++ b/app/client/ui/modules/document-upload.ts
@@ -7,6 +7,7 @@ import type { UploadEntry } from "@domains/documents";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./document-upload.module.css";
 
 /**
@@ -17,7 +18,7 @@ import styles from "./document-upload.module.css";
  */
 @customElement("hd-document-upload")
 export class DocumentUpload extends LitElement {
-  static styles = [buttonStyles, badgeStyles, styles];
+  static styles = [buttonStyles, badgeStyles, scrollStyles, styles];
 
   @state() private queue: UploadEntry[] = [];
   @state() private uploading = false;
@@ -267,7 +268,9 @@ export class DocumentUpload extends LitElement {
           </span>
           ${this.renderQueueActions()}
         </div>
-        ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+        <div class="queue-list scroll-y">
+          ${this.queue.map((entry, i) => this.renderQueueEntry(entry, i))}
+        </div>
       </div>
     `;
   }

--- a/app/client/ui/modules/prompt-form.module.css
+++ b/app/client/ui/modules/prompt-form.module.css
@@ -31,7 +31,6 @@
   padding-inline: var(--space-2);
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
 }
 
 .field {
@@ -71,7 +70,6 @@
   flex-direction: column;
   gap: var(--space-4);
   max-height: 20rem;
-  overflow-y: auto;
 }
 
 .defaults-content h4 {

--- a/app/client/ui/modules/prompt-form.ts
+++ b/app/client/ui/modules/prompt-form.ts
@@ -7,6 +7,7 @@ import type { Prompt } from "@domains/prompts";
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
 import labelStyles from "@styles/labels.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./prompt-form.module.css";
 
 /**
@@ -17,7 +18,13 @@ import styles from "./prompt-form.module.css";
  */
 @customElement("hd-prompt-form")
 export class PromptForm extends LitElement {
-  static styles = [buttonStyles, inputStyles, labelStyles, styles];
+  static styles = [
+    buttonStyles,
+    inputStyles,
+    labelStyles,
+    scrollStyles,
+    styles,
+  ];
 
   @property({ type: Object }) prompt: Prompt | null = null;
 
@@ -112,7 +119,7 @@ export class PromptForm extends LitElement {
     return html`
       <details class="defaults">
         <summary>Default Prompt</summary>
-        <div class="defaults-content">
+        <div class="defaults-content scroll-y">
           ${this.spec
             ? html`
                 <h4>Specification</h4>
@@ -147,7 +154,7 @@ export class PromptForm extends LitElement {
         complete prompt. Override the default instructions below to customize
         behavior.
       </div>
-      <form class="form-body" @submit=${this.handleSubmit}>
+      <form class="form-body scroll-y" @submit=${this.handleSubmit}>
         <div class="field">
           <label class="label" for="name">Name</label>
           <input

--- a/app/client/ui/modules/prompt-list.module.css
+++ b/app/client/ui/modules/prompt-list.module.css
@@ -29,7 +29,6 @@
   gap: var(--space-3);
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
   padding-bottom: var(--space-2);
 }
 

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -7,6 +7,7 @@ import type { Prompt, SearchRequest } from "@domains/prompts";
 
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./prompt-list.module.css";
 
 /**
@@ -16,7 +17,7 @@ import styles from "./prompt-list.module.css";
  */
 @customElement("hd-prompt-list")
 export class PromptList extends LitElement {
-  static styles = [buttonStyles, inputStyles, styles];
+  static styles = [buttonStyles, inputStyles, scrollStyles, styles];
 
   @property({ type: Object }) selected: Prompt | null = null;
 
@@ -193,7 +194,7 @@ export class PromptList extends LitElement {
     }
 
     return html`
-      <div class="list">
+      <div class="list scroll-y">
         ${this.prompts.data.map(
           (prompt) => html`
             <hd-prompt-card

--- a/app/client/ui/views/review-view.module.css
+++ b/app/client/ui/views/review-view.module.css
@@ -21,7 +21,6 @@
   padding: var(--space-4);
   border: 1px solid var(--divider);
   border-radius: var(--radius-md);
-  overflow-y: auto;
 }
 
 .loading,

--- a/app/client/ui/views/review-view.ts
+++ b/app/client/ui/views/review-view.ts
@@ -8,12 +8,13 @@ import { DocumentService } from "@domains/documents";
 import { StorageService } from "@domains/storage";
 
 import buttonStyles from "@styles/buttons.module.css";
+import scrollStyles from "@styles/scroll.module.css";
 import styles from "./review-view.module.css";
 
 /** Route-level view for reviewing a document's classification result. */
 @customElement("hd-review-view")
 export class ReviewView extends LitElement {
-  static styles = [buttonStyles, styles];
+  static styles = [buttonStyles, scrollStyles, styles];
 
   @property() documentId?: string;
   @state() private document?: Document;
@@ -96,7 +97,7 @@ export class ReviewView extends LitElement {
           .src=${this.blobUrl}
         ></hd-blob-viewer>
       </div>
-      <div class="panel classification-panel">
+      <div class="panel classification-panel scroll-y">
         <hd-classification-panel
           .documentId=${this.documentId ?? ""}
           @validate=${this.handleClassificationChange}


### PR DESCRIPTION
## Summary

- Fix `hd-document-upload` queue overflowing the viewport when many files are queued — host/drop-zone flex sizing restores participation in the view's flex column, and a new `.queue-list` wrapper scrolls the entries while the File Queue header (title, count, Clear/Upload buttons) stays pinned.
- Extract a reusable scroll-container primitive into the design system: universal `scrollbar-gutter: stable` in a new `base` cascade layer, plus `.scroll-y` / `.scroll-x` utilities in `design/styles/scroll.module.css` that bundle `overflow`, `scrollbar-gutter`, and axis padding.
- Migrate all existing scroll containers to the utility so scroll ergonomics stay consistent app-wide.

Closes #133

## Changes

**Design system**
- `design/core/base.css` (new) — universal `scrollbar-gutter: stable`, registered as the `base` layer between `reset` and `theme`.
- `design/styles/scroll.module.css` (new) — `.scroll-y` / `.scroll-x` utility classes.
- `client/css.d.ts` — add `declare module "*.css"` so side-effect imports of non-module CSS type-check under `tsc --noEmit` (fixes a pre-existing error on `main`).

**Document upload (the reported bug)**
- `:host` claims vertical space in the parent flex column; `.drop-zone` is pinned; `.queue` holds `.queue-header` (pinned) and a new `.queue-list` scroll child.

**Migrated scroll containers**
- `document-grid`, `prompt-list`, `classification-panel` (all three panel-body usages), `prompt-form` (body + inner defaults), `review-view` classification panel, `document-upload` queue list. Local `overflow-y: auto` removed; `.scroll-y` applied via template; `scrollStyles` added to each component's `static styles`.

**Context updates**
- `.claude/CLAUDE.md` — new "Web Client Conventions" section.
- `.claude/skills/web-development/SKILL.md` and `references/css.md` — five-layer stack, `base` layer description, `scroll.module.css` in shared-styles table, rewritten scroll-container view pattern, Avoid/Prefer list updates.

## Test plan

- [x] `mise run test` — all 20 Go packages pass
- [x] `mise run vet` — clean
- [x] `bun run build` — CSS-modules plugin emits `scroll.module.css`, `dist/app.{js,css}` build cleanly
- [x] `bunx tsc --noEmit` — clean (was erroring on `@design/index.css` pre-existing, now fixed)
- [x] Manual: document-upload queue with ≥ 20 files scrolls internally, header pinned, drop zone fixed above
- [x] Manual: document grid, prompt list, classification panel, prompt form (body + defaults), review-view classification panel — scrollbar has breathing room, no layout shift when content crosses scroll threshold