### PR TITLE
Configurable page size and editable page input for list views

### DIFF
--- a/.claude/context/guides/.archive/134-page-size-select.md
+++ b/.claude/context/guides/.archive/134-page-size-select.md
@@ -1,0 +1,313 @@
+# 134 - Configurable page size selector for list views
+
+## Problem Context
+
+Both `document-grid` and `prompt-list` hardcode `page_size: 12` in their fetch requests. During IL6 usage it became clear users want to see more results at once without paginating repeatedly. Both `SearchRequest` types already accept an optional `page_size`, so this is a pure client-side change.
+
+## Architecture Approach
+
+Extend the existing `<hd-pagination>` element rather than adding a sibling element. Pagination and per-page size are one conceptual footer unit — always rendered together, sharing the same divider and spacing. Merging keeps the module templates simple (one element, one footer), avoids a new CSS wrapper in both modules, and keeps the existing `border-top` on `pagination-controls.module.css` in place.
+
+The element gains `size` / `sizeOptions` properties and a `page-size-change` event in addition to its existing `page-change`. Each module promotes the hardcoded `12` to a `pageSize` `@state()` field, binds it to the element, and on change resets `page = 1` and refetches.
+
+The static "Page X of N" indicator also becomes an editable `<input type="number">` so users can jump directly to a specific page. The input commits on `change` (blur / Enter), not `input`, so refetches don't fire per keystroke. Values are `Math.trunc`'d then clamped to `[1, totalPages]`; invalid or out-of-range entries are silently corrected and the DOM value is rebound to `this.page`. Browser-native spinner arrows and mouse-wheel stepping are left as-is (no overrides). The input is disabled when `totalPages <= 1`.
+
+## Implementation
+
+### Step 1 — Extend `app/client/ui/elements/pagination-controls.ts`
+
+Replace the existing file with the full implementation below. Changes from today's file: add `inputStyles`, add `size` / `sizeOptions` `@property()` fields, add `handleSizeChange` + `handlePageInput` + `handlePageFocus` methods, and restructure `render()` so the footer has a left `.page-size` label and a right `.page-controls` group with an editable page-number input replacing the static indicator.
+
+```typescript
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import styles from "./pagination-controls.module.css";
+
+@customElement("hd-pagination")
+export class PaginationControls extends LitElement {
+  static styles = [buttonStyles, inputStyles, styles];
+
+  @property({ type: Number }) page = 1;
+
+  @property({ type: Number, attribute: "total-pages" })
+  totalPages = 1;
+
+  @property({ type: Number }) size = 12;
+
+  @property({ type: Array, attribute: "size-options" })
+  sizeOptions: number[] = [12, 24, 48, 96];
+
+  private handlePrev() {
+    if (this.page > 1) {
+      this.dispatchEvent(
+        new CustomEvent("page-change", {
+          detail: { page: this.page - 1 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  private handleNext() {
+    if (this.page < this.totalPages) {
+      this.dispatchEvent(
+        new CustomEvent("page-change", {
+          detail: { page: this.page + 1 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  private handleSizeChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    this.dispatchEvent(
+      new CustomEvent("page-size-change", {
+        detail: { size: Number(target.value) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handlePageInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const raw = target.valueAsNumber;
+
+    if (!Number.isFinite(raw)) {
+      target.value = String(this.page);
+      return;
+    }
+
+    const clamped = Math.min(
+      Math.max(Math.trunc(raw), 1),
+      this.totalPages,
+    );
+
+    if (clamped === this.page) {
+      target.value = String(this.page);
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("page-change", {
+        detail: { page: clamped },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handlePageFocus(e: FocusEvent) {
+    (e.target as HTMLInputElement).select();
+  }
+
+  render() {
+    return html`
+      <div class="pagination">
+        <label class="page-size">
+          <span class="label">Per page:</span>
+          <select
+            class="input"
+            .value=${String(this.size)}
+            @change=${this.handleSizeChange}
+          >
+            ${this.sizeOptions.map(
+              (n) => html`<option value=${n}>${n}</option>`,
+            )}
+          </select>
+        </label>
+        <div class="page-controls">
+          <button
+            class="btn"
+            ?disabled=${this.page <= 1}
+            @click=${this.handlePrev}
+          >
+            Prev
+          </button>
+          <span class="page-indicator">
+            Page
+            <input
+              class="input page-input"
+              type="number"
+              min="1"
+              max=${this.totalPages}
+              step="1"
+              .value=${String(this.page)}
+              ?disabled=${this.totalPages <= 1}
+              aria-label="Page number"
+              @change=${this.handlePageInput}
+              @focus=${this.handlePageFocus}
+            />
+            of ${this.totalPages}
+          </span>
+          <button
+            class="btn"
+            ?disabled=${this.page >= this.totalPages}
+            @click=${this.handleNext}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-pagination": PaginationControls;
+  }
+}
+```
+
+### Step 2 — Update `app/client/ui/elements/pagination-controls.module.css`
+
+Replace the file with the following. Changes: `.pagination` flips from `justify-content: center` to `justify-content: space-between`; new rules add `.page-size`, `.page-controls`, `.label`, and `.page-input`. `.page-indicator` becomes a flex row so its "Page" / `<input>` / "of N" children align on the input's baseline without vertical jitter.
+
+```css
+:host {
+  display: block;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--divider);
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.label {
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+.page-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+.page-input {
+  width: auto;
+  padding: var(--space-2) var(--space-1);
+  text-align: center;
+}
+```
+
+### Step 3 — Wire `app/client/ui/modules/document-grid.ts`
+
+Three incremental changes.
+
+**3a.** Add `pageSize` alongside the existing `@state()` fields (the block around line 30):
+
+```typescript
+@state() private pageSize = 12;
+```
+
+**3b.** In `fetchDocuments()`, replace the hardcoded page size:
+
+```typescript
+const req: SearchRequest = {
+  page: this.page,
+  page_size: this.pageSize,
+  sort: this.sort,
+};
+```
+
+**3c.** Add the handler next to `handlePageChange`:
+
+```typescript
+private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+  this.pageSize = e.detail.size;
+  this.page = 1;
+  this.fetchDocuments();
+}
+```
+
+**3d.** Extend the existing `<hd-pagination>` render with two new bindings:
+
+```typescript
+<hd-pagination
+  .page=${this.documents?.page ?? 1}
+  .totalPages=${this.documents?.total_pages ?? 1}
+  .size=${this.pageSize}
+  @page-change=${this.handlePageChange}
+  @page-size-change=${this.handlePageSizeChange}
+></hd-pagination>
+```
+
+### Step 4 — Wire `app/client/ui/modules/prompt-list.ts`
+
+Mirror Step 3 against `fetchPrompts()` and the prompt-list's `<hd-pagination>` render.
+
+**4a.** Add `@state() private pageSize = 12;` alongside the existing `@state()` fields.
+
+**4b.** In `fetchPrompts()`:
+
+```typescript
+const req: SearchRequest = {
+  page: this.page,
+  page_size: this.pageSize,
+  sort: this.sort,
+};
+```
+
+**4c.** Add the handler next to `handlePageChange`:
+
+```typescript
+private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+  this.pageSize = e.detail.size;
+  this.page = 1;
+  this.fetchPrompts();
+}
+```
+
+**4d.** Extend the existing `<hd-pagination>` render:
+
+```typescript
+<hd-pagination
+  .page=${this.prompts?.page ?? 1}
+  .totalPages=${this.prompts?.total_pages ?? 1}
+  .size=${this.pageSize}
+  @page-change=${this.handlePageChange}
+  @page-size-change=${this.handlePageSizeChange}
+></hd-pagination>
+```
+
+## Validation Criteria
+
+- [ ] `<hd-pagination>` footer renders "Per page: [12 ▼]" on the left and "Prev / Page [n] of N / Next" on the right, divider spanning the full row.
+- [ ] Options list is `[12, 24, 48, 96]`, current selection matches the module's `pageSize`.
+- [ ] Changing the selector refetches the list (`document-grid` and `prompt-list`) and resets `page` to 1.
+- [ ] `SearchRequest.page_size` on the network shows the chosen value (check devtools / server logs).
+- [ ] Page input: typing a valid page and blurring / pressing Enter navigates to that page.
+- [ ] Page input: typing `0`, a negative, or a value above `totalPages` snaps to the nearest valid value; a decimal truncates (`2.9` → `2`); non-numeric / empty reverts to the current page without navigating.
+- [ ] Page input: focusing the input auto-selects its contents so typing immediately overwrites.
+- [ ] Page input: spinner arrows and mouse-wheel stepping work and are constrained by `min` / `max`.
+- [ ] Page input: when `totalPages <= 1`, the input is disabled and shows `1`.
+- [ ] Existing search / status / sort / stage filters still work and do not disturb `pageSize`.
+- [ ] Bulk-select / classify / delete interactions on `document-grid` still behave as before.
+- [ ] `mise run vet` passes with no new warnings.
+- [ ] `mise run test` passes.

--- a/.claude/context/sessions/134-page-size-select.md
+++ b/.claude/context/sessions/134-page-size-select.md
@@ -1,0 +1,35 @@
+# 134 - Configurable page size selector for list views
+
+## Summary
+
+Extended `<hd-pagination>` with a per-page size selector (12 / 24 / 48 / 96) and an editable page-number input that replaces the static "Page X of N" indicator. Both `document-grid` and `prompt-list` promoted their hardcoded `page_size: 12` to a `pageSize` `@state()` field and now refetch with `page = 1` when the selector changes.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| New element vs. extend `hd-pagination` | Extend | Pagination and per-page size are one conceptual footer unit — always rendered together, share the same divider. Avoids a new module-level wrapper in both callers and keeps the `border-top` in one place. |
+| State field naming | `pageSize` (camelCase) | Matches existing `selectedIds` / `deleteDocument` pattern. `page_size` snake_case stays on the wire in `SearchRequest`. |
+| Page-input commit timing | `@change` (blur / Enter) | `@input` would refetch on every keystroke. |
+| Invalid input handling | Silent clamp + rebind | `Math.trunc` then clamp to `[1, totalPages]`; non-numeric or empty reverts to `this.page`; DOM `value` is written directly so the input clears the bad text even when `this.page` didn't change. |
+| Browser-native behaviors | Keep spinners and wheel-to-change | Match user expectations for `type="number"`. |
+| Page input sizing | `width: auto; padding: var(--space-2) var(--space-1);` | Auto width scales with digit count (1 → 4 digits) without truncation risk; reduced horizontal padding prevents a narrow input from consuming excess width. Height stays consistent with other form inputs across the UI (taller than buttons, by choice). |
+
+## Files Modified
+
+- `app/client/ui/elements/pagination-controls.ts` — added `size` / `sizeOptions` properties, `handleSizeChange` / `handlePageInput` / `handlePageFocus`, restructured template into `.page-size` + `.page-controls`, updated class JSDoc
+- `app/client/ui/elements/pagination-controls.module.css` — `justify-content: space-between`, new `.page-size` / `.page-controls` / `.label` / `.page-input` rules, `.page-indicator` promoted to flex row
+- `app/client/ui/modules/document-grid.ts` — added `pageSize` state, wired `.size` + `@page-size-change` on `<hd-pagination>`, added `handlePageSizeChange` (resets page to 1 + refetches)
+- `app/client/ui/modules/prompt-list.ts` — same wiring as document-grid
+
+## Patterns Established
+
+- **Editable numeric fields** — pattern for `<input type="number">` bound to Lit state: bind `.value=${String(this.x)}`, commit on `@change` with `valueAsNumber` guard, trunc-then-clamp, silent rebind on invalid/no-op (write `target.value` directly to clear stale DOM text), disable at degenerate bounds (e.g., `totalPages <= 1`), `aria-label` since surrounding text isn't programmatically associated.
+- **Multi-concern footer elements** — when two pieces of UI always render together as a conceptual unit (pagination + page size), extend a single element rather than introducing a sibling. Keeps caller templates one element wide and divider/spacing concerns in one place.
+
+## Validation Results
+
+- `mise run test` — all 21 Go test packages pass.
+- `mise run vet` — clean.
+- `mise run web:build` — `dist/app.js` + `dist/app.css` built without TS errors.
+- Manual verification on `/app/documents` (3-page, 24-entry list): per-page selector cycles [12, 24, 48, 96], list refetches and resets to page 1 each time; page input accepts direct page numbers, clamps out-of-range values, reverts on non-numeric; spinner arrows and mouse-wheel stepping work within `min`/`max`; auto-select on focus behaves correctly. Screenshot captured showing the "Per page: 12 / Prev / Page [1] / of 3 / Next" footer layout with the divider spanning the full row.

--- a/.claude/plans/greedy-yawning-graham.md
+++ b/.claude/plans/greedy-yawning-graham.md
@@ -1,0 +1,203 @@
+# Issue #134 — Configurable page size selector for list views
+
+## Context
+
+During the IL6 deployment it became clear that users want to see more list results at a time without paginating repeatedly. Both `document-grid` and `prompt-list` currently hardcode `page_size: 12` in their fetch requests. This task makes the page size user-controlled.
+
+No server changes — both `SearchRequest` types (`app/client/domains/documents/document.ts:27`, `app/client/domains/prompts/prompt.ts:40`) already accept an optional `page_size`.
+
+## Approach
+
+Extend the existing `<hd-pagination>` element rather than introducing a sibling element. Pagination and per-page size are one conceptual footer unit — always rendered together, emit related events, share the same divider and spacing. Merging keeps the module templates simple (one element, one footer), avoids a new CSS wrapper in both modules, and avoids relocating the existing `border-top` on `pagination-controls.module.css`.
+
+The element gains:
+- `@property() size` — current page size (default `12`)
+- `@property() sizeOptions` — the selectable values (default `[12, 24, 48, 96]`)
+- Emits `page-size-change` with `detail: { size: number }` (in addition to its existing `page-change`)
+
+Each module:
+- Promotes the hardcoded `12` to `@state() private pageSize = 12` (camelCase follows the existing `selectedIds` / `deleteDocument` pattern; `page_size` snake_case stays on the wire).
+- Binds `.size` and handles `page-size-change` — reset `page = 1` and refetch.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `app/client/ui/elements/pagination-controls.ts` | Add `size` / `sizeOptions` props, page-size handler, render size selector in footer |
+| `app/client/ui/elements/pagination-controls.module.css` | Split into `.page-size` (left) + `.page-controls` (right) via `justify-content: space-between` |
+| `app/client/ui/modules/document-grid.ts` | Add `pageSize` state, use in `fetchDocuments`, bind to element, handle change |
+| `app/client/ui/modules/prompt-list.ts` | Same as document-grid |
+
+Module CSS files are unchanged — the element owns its footer layout.
+
+## Implementation
+
+### Step 1 — Extend `app/client/ui/elements/pagination-controls.ts`
+
+Add `inputStyles` to the styles array, add two new `@property()` fields, add the change handler, and restructure `render()` so the size selector sits on the left and the prev/indicator/next group on the right:
+
+```typescript
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
+import styles from "./pagination-controls.module.css";
+
+@customElement("hd-pagination")
+export class PaginationControls extends LitElement {
+  static styles = [buttonStyles, inputStyles, styles];
+
+  @property({ type: Number }) page = 1;
+  @property({ type: Number, attribute: "total-pages" }) totalPages = 1;
+  @property({ type: Number }) size = 12;
+  @property({ type: Array, attribute: "size-options" })
+  sizeOptions: number[] = [12, 24, 48, 96];
+
+  private handlePrev() {
+    if (this.page > 1) {
+      this.dispatchEvent(
+        new CustomEvent("page-change", {
+          detail: { page: this.page - 1 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  private handleNext() {
+    if (this.page < this.totalPages) {
+      this.dispatchEvent(
+        new CustomEvent("page-change", {
+          detail: { page: this.page + 1 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  private handleSizeChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    this.dispatchEvent(
+      new CustomEvent("page-size-change", {
+        detail: { size: Number(target.value) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  render() {
+    return html`
+      <div class="pagination">
+        <label class="page-size">
+          <span class="label">Per page:</span>
+          <select
+            class="input"
+            .value=${String(this.size)}
+            @change=${this.handleSizeChange}
+          >
+            ${this.sizeOptions.map(n => html`<option value=${n}>${n}</option>`)}
+          </select>
+        </label>
+        <div class="page-controls">
+          <button class="btn" ?disabled=${this.page <= 1} @click=${this.handlePrev}>
+            Prev
+          </button>
+          <span class="page-indicator">
+            Page ${this.page} of ${this.totalPages}
+          </span>
+          <button class="btn" ?disabled=${this.page >= this.totalPages} @click=${this.handleNext}>
+            Next
+          </button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-pagination": PaginationControls;
+  }
+}
+```
+
+### Step 2 — Update `app/client/ui/elements/pagination-controls.module.css`
+
+Switch `.pagination` to `space-between` and add selectors for the new `.page-size` / `.page-controls` / `.label` pieces. Keep the existing `border-top` and `padding-top` so the divider still spans the full footer.
+
+```css
+:host {
+  display: block;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--divider);
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.label,
+.page-indicator {
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+```
+
+### Step 3 — Wire `app/client/ui/modules/document-grid.ts`
+
+- Add `@state() private pageSize = 12;` alongside existing `@state()` fields.
+- In `fetchDocuments()`, change `page_size: 12` → `page_size: this.pageSize`.
+- Add a handler next to `handlePageChange`:
+
+  ```typescript
+  private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+    this.pageSize = e.detail.size;
+    this.page = 1;
+    this.fetchDocuments();
+  }
+  ```
+
+- Extend the existing `<hd-pagination>` render with the two new bindings:
+
+  ```typescript
+  <hd-pagination
+    .page=${this.documents?.page ?? 1}
+    .totalPages=${this.documents?.total_pages ?? 1}
+    .size=${this.pageSize}
+    @page-change=${this.handlePageChange}
+    @page-size-change=${this.handlePageSizeChange}
+  ></hd-pagination>
+  ```
+
+### Step 4 — Wire `app/client/ui/modules/prompt-list.ts`
+
+Same shape as Step 3 against `fetchPrompts()` — add `@state() private pageSize = 12`, use `this.pageSize` in the request, add `handlePageSizeChange` that resets `page = 1` and calls `fetchPrompts()`, bind `.size` + `@page-size-change` on `<hd-pagination>`.
+
+## Validation
+
+- `mise run dev` + `bun run watch` — visit `/app/documents` and `/app/prompts`:
+  - Footer shows "Per page: [12 ▼]" on the left and "Prev / Page X of Y / Next" on the right, divider spanning the full row.
+  - Changing the size refetches the list and the page indicator resets to "Page 1 of N".
+  - Existing search / status / sort filters still work and don't disturb `pageSize`.
+  - Bulk-select / classify / delete interactions on `document-grid` still behave as before.
+- `mise run vet` — no type or lint regressions.
+- `mise run test` — existing suites pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.0-dev.132.134
+
+### Web Client
+
+- Extend `hd-pagination` with a per-page size selector (12 / 24 / 48 / 96) on the left of the footer and an editable page-number input replacing the static "Page X of N" indicator — input commits on blur/Enter, `Math.trunc`s and clamps to `[1, totalPages]`, reverts silently on non-numeric/empty values, auto-selects on focus, disables at `totalPages <= 1`; `document-grid` and `prompt-list` promote hardcoded `page_size: 12` to a `pageSize` `@state()` field and refetch with `page = 1` on change (#134)
+
 ## v0.5.0-dev.132.133
 
 ### Web Client

--- a/app/client/ui/elements/pagination-controls.module.css
+++ b/app/client/ui/elements/pagination-controls.module.css
@@ -5,13 +5,39 @@
 .pagination {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: var(--space-3);
   padding-top: var(--space-3);
   border-top: 1px solid var(--divider);
 }
 
-.page-indicator {
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.label {
   font-size: var(--text-sm);
   color: var(--color-1);
+}
+
+.page-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+.page-input {
+  width: auto;
+  padding: var(--space-2) var(--space-1);
+  text-align: center;
 }

--- a/app/client/ui/elements/pagination-controls.ts
+++ b/app/client/ui/elements/pagination-controls.ts
@@ -2,17 +2,27 @@ import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import buttonStyles from "@styles/buttons.module.css";
+import inputStyles from "@styles/inputs.module.css";
 import styles from "./pagination-controls.module.css";
 
-/** Pure element that renders prev/next pagination controls with a page indicator. */
+/**
+ * Pure element that renders the list-view footer: a per-page size selector,
+ * prev/next buttons, and an editable page-number input clamped to the valid range.
+ * Dispatches `page-change` and `page-size-change` custom events.
+ */
 @customElement("hd-pagination")
 export class PaginationControls extends LitElement {
-  static styles = [buttonStyles, styles];
+  static styles = [buttonStyles, inputStyles, styles];
 
   @property({ type: Number }) page = 1;
 
   @property({ type: Number, attribute: "total-pages" })
   totalPages = 1;
+
+  @property({ type: Number }) size = 12;
+
+  @property({ type: Array, attribute: "size-options" })
+  sizeOptions: number[] = [12, 24, 48, 96];
 
   private handlePrev() {
     if (this.page > 1) {
@@ -38,26 +48,93 @@ export class PaginationControls extends LitElement {
     }
   }
 
+  private handleSizeChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    this.dispatchEvent(
+      new CustomEvent("page-size-change", {
+        detail: { size: Number(target.value) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handlePageInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const raw = target.valueAsNumber;
+
+    if (!Number.isFinite(raw)) {
+      target.value = String(this.page);
+      return;
+    }
+
+    const clamped = Math.min(Math.max(Math.trunc(raw), 1), this.totalPages);
+
+    if (clamped === this.page) {
+      target.value = String(this.page);
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("page-change", {
+        detail: { page: clamped },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handlePageFocus(e: FocusEvent) {
+    (e.target as HTMLInputElement).select();
+  }
+
   render() {
     return html`
       <div class="pagination">
-        <button
-          class="btn"
-          ?disabled=${this.page <= 1}
-          @click=${this.handlePrev}
-        >
-          Prev
-        </button>
-        <span class="page-indicator">
-          Page ${this.page} of ${this.totalPages}
-        </span>
-        <button
-          class="btn"
-          ?disabled=${this.page >= this.totalPages}
-          @click=${this.handleNext}
-        >
-          Next
-        </button>
+        <label class="page-size">
+          <span class="label">Per page:</span>
+          <select
+            class="input"
+            .value=${String(this.size)}
+            @change=${this.handleSizeChange}
+          >
+            ${this.sizeOptions.map(
+              (n) => html`<option value=${n}>${n}</option>`,
+            )}
+          </select>
+        </label>
+        <div class="page-controls">
+          <button
+            class="btn"
+            ?disabled=${this.page <= 1}
+            @click=${this.handlePrev}
+          >
+            Prev
+          </button>
+          <span class="page-indicator">
+            Page
+            <input
+              class="input page-input"
+              type="number"
+              min="1"
+              max=${this.totalPages}
+              step="1"
+              .value=${String(this.page)}
+              ?disabled=${this.totalPages <= 1}
+              aria-label="Page number"
+              @change=${this.handlePageInput}
+              @focus=${this.handlePageFocus}
+            />
+            of ${this.totalPages}
+          </span>
+          <button
+            class="btn"
+            ?disabled=${this.page >= this.totalPages}
+            @click=${this.handleNext}
+          >
+            Next
+          </button>
+        </div>
       </div>
     `;
   }

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -29,6 +29,7 @@ export class DocumentGrid extends LitElement {
 
   @state() private documents: PageResult<Document> | null = null;
   @state() private page = 1;
+  @state() private pageSize = 12;
   @state() private search = "";
   @state() private status = "";
   @state() private sort = "-UploadedAt";
@@ -60,7 +61,7 @@ export class DocumentGrid extends LitElement {
   private async fetchDocuments() {
     const req: SearchRequest = {
       page: this.page,
-      page_size: 12,
+      page_size: this.pageSize,
       sort: this.sort,
     };
 
@@ -95,6 +96,12 @@ export class DocumentGrid extends LitElement {
 
   private handlePageChange(e: CustomEvent<{ page: number }>) {
     this.page = e.detail.page;
+    this.fetchDocuments();
+  }
+
+  private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+    this.pageSize = e.detail.size;
+    this.page = 1;
     this.fetchDocuments();
   }
 
@@ -289,7 +296,9 @@ export class DocumentGrid extends LitElement {
       <hd-pagination
         .page=${this.documents?.page ?? 1}
         .totalPages=${this.documents?.total_pages ?? 1}
+        .size=${this.pageSize}
         @page-change=${this.handlePageChange}
+        @page-size-change=${this.handlePageSizeChange}
       ></hd-pagination>
       ${this.deleteDocument
         ? html`

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -23,6 +23,7 @@ export class PromptList extends LitElement {
 
   @state() private prompts: PageResult<Prompt> | null = null;
   @state() private page = 1;
+  @state() private pageSize = 12;
   @state() private search = "";
   @state() private stage = "";
   @state() private sort = "Name";
@@ -48,7 +49,7 @@ export class PromptList extends LitElement {
   private async fetchPrompts() {
     const req: SearchRequest = {
       page: this.page,
-      page_size: 12,
+      page_size: this.pageSize,
       sort: this.sort,
     };
 
@@ -82,6 +83,12 @@ export class PromptList extends LitElement {
 
   private handlePageChange(e: CustomEvent<{ page: number }>) {
     this.page = e.detail.page;
+    this.fetchPrompts();
+  }
+
+  private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+    this.pageSize = e.detail.size;
+    this.page = 1;
     this.fetchPrompts();
   }
 
@@ -218,7 +225,9 @@ export class PromptList extends LitElement {
       <hd-pagination
         .page=${this.prompts?.page ?? 1}
         .totalPages=${this.prompts?.total_pages ?? 1}
+        .size=${this.pageSize}
         @page-change=${this.handlePageChange}
+        @page-size-change=${this.handlePageSizeChange}
       ></hd-pagination>
       ${this.deletePrompt
         ? html`


### PR DESCRIPTION
## Summary

Extends `<hd-pagination>` with a per-page size selector and an editable page-number input so users can browse long document and prompt lists without repeated prev/next clicks. No server changes — both `SearchRequest` types already accept `page_size`.

Closes #134

## Changes

- `hd-pagination` gains `size` + `sizeOptions` properties and `page-size-change` event; footer splits into `.page-size` (left) and `.page-controls` (right) with the divider spanning the full row
- Static "Page X of N" becomes an `<input type="number">` — `Math.trunc`s + clamps to `[1, totalPages]`, commits on `change` (blur/Enter), auto-selects on focus, disables at `totalPages <= 1`, reverts silently on non-numeric/empty values
- `document-grid` and `prompt-list` promote hardcoded `page_size: 12` to `@state() pageSize = 12`, wire `.size` + `@page-size-change`, reset `page = 1` and refetch on change
- Browser-native spinners and mouse-wheel stepping left untouched to match user expectations for `type="number"`

## Test plan

- [x] `mise run test` — all Go test packages pass
- [x] `mise run vet` — clean
- [x] `mise run web:build` — TS builds without errors
- [x] Manual: `/app/documents` — selector cycles [12, 24, 48, 96], list refetches, page resets to 1
- [x] Manual: `/app/prompts` — same behavior
- [x] Manual: page input accepts direct entry, clamps `0` / negatives / values > `totalPages`, truncates decimals, reverts on non-numeric
- [x] Manual: input disabled when `totalPages <= 1`; focus auto-selects contents; spinner arrows and mouse wheel step within bounds