### PR TITLE
URL query-parameter state persistence for list views

### DIFF
--- a/.claude/context/guides/.archive/135-url-query-state-persistence.md
+++ b/.claude/context/guides/.archive/135-url-query-state-persistence.md
@@ -1,0 +1,415 @@
+# 135 - URL query-parameter state persistence for list views
+
+## Problem Context
+
+List-view state (pagination, search, filter, sort) on `hd-document-grid` and `hd-prompt-list` lives only in `@state` and is destroyed on view unmount. Clicking into `/review/:id` and returning to `/`, or reloading the page, drops the user back at defaults.
+
+This task adds two-way URL binding: reads on mount, writes on each filter change. Writes must use `history.replaceState` — `pushState` plus the router's `innerHTML = ""` teardown (router.ts:108) would remount the view on every filter change and destroy the state we're preserving.
+
+## Architecture Approach
+
+- Keep filter fields as `@state` (internal state), not `@property`. The codebase reserves `@property` for parent-passed inputs.
+- Retire the router's unused query-attribute splat (router.ts:115-117) and replace it with explicit `queryParams()` / `updateQuery()` helpers views call on demand.
+- `updateQuery` is built on `URLSearchParams` + `history.replaceState`. Do not reuse `toQueryString` — that helper is coupled to API request URL construction.
+- Per-view `DEFAULTS` const centralizes the canonical default values; field initializers, hydration fallbacks, and sync-omission checks all reference it.
+
+## Implementation
+
+### Step 1: Add `queryParams` and `updateQuery` helpers; remove query-attribute splat
+
+**File:** `app/client/core/router/router.ts`
+
+In `mount()`, delete the query-attribute splat at lines 115-117:
+
+```ts
+// REMOVE this block:
+for (const [key, value] of Object.entries(match.query)) {
+  el.setAttribute(key, value);
+}
+```
+
+(Path-param splatting at 111-113 stays — it's in use by `hd-review-view` and `hd-not-found-view`.)
+
+Append two exported functions at the top of the file, near the existing `navigate` export:
+
+```ts
+export function queryParams(): Record<string, string> {
+  const params = new URLSearchParams(location.search);
+  const result: Record<string, string> = {};
+  for (const [key, value] of params) result[key] = value;
+  return result;
+}
+
+export function updateQuery(
+  patch: Record<string, string | number | undefined | null>,
+): void {
+  const url = new URL(location.href);
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined || value === null || value === "") {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  history.replaceState(null, "", url.pathname + url.search);
+}
+```
+
+### Step 2: Re-export the helpers from the router barrel
+
+**File:** `app/client/core/router/index.ts`
+
+Change:
+
+```ts
+export { Router, navigate } from "./router";
+```
+
+to:
+
+```ts
+export { Router, navigate, queryParams, updateQuery } from "./router";
+```
+
+### Step 3: Wire URL state into `hd-document-grid`
+
+**File:** `app/client/ui/modules/document-grid.ts`
+
+Update the router import to include the new helpers:
+
+```ts
+import { navigate, queryParams, updateQuery } from "@core/router";
+```
+
+Add a `DEFAULTS` const immediately below the imports (before the `ClassifyProgress` interface):
+
+```ts
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  status: "",
+  sort: "-UploadedAt",
+} as const;
+```
+
+Replace the `@state` initializers for the filter fields to reference `DEFAULTS`:
+
+```ts
+@state() private page = DEFAULTS.page;
+@state() private pageSize = DEFAULTS.pageSize;
+@state() private search = DEFAULTS.search;
+@state() private status = DEFAULTS.status;
+@state() private sort = DEFAULTS.sort;
+```
+
+Leave `documents`, `classifying`, `selectedIds`, `deleteDocument` unchanged.
+
+Update `connectedCallback` to hydrate before fetching:
+
+```ts
+connectedCallback() {
+  super.connectedCallback();
+  this.hydrateFromQuery();
+  this.fetchDocuments();
+}
+```
+
+Add two new private methods (place them next to `fetchDocuments`):
+
+```ts
+private hydrateFromQuery() {
+  const q = queryParams();
+  if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+  if (q.page_size) this.pageSize = Number(q.page_size) || DEFAULTS.pageSize;
+  if (q.search) this.search = q.search;
+  if (q.status) this.status = q.status;
+  if (q.sort) this.sort = q.sort;
+}
+
+private syncQuery() {
+  updateQuery({
+    page: this.page === DEFAULTS.page ? undefined : this.page,
+    page_size: this.pageSize === DEFAULTS.pageSize ? undefined : this.pageSize,
+    search: this.search || undefined,
+    status: this.status || undefined,
+    sort: this.sort === DEFAULTS.sort ? undefined : this.sort,
+  });
+}
+```
+
+Fold `syncQuery` into `refresh`:
+
+```ts
+async refresh() {
+  this.page = DEFAULTS.page;
+  this.syncQuery();
+  await this.fetchDocuments();
+}
+```
+
+Update the page-level handlers to sync the URL before fetching:
+
+```ts
+private handlePageChange(e: CustomEvent<{ page: number }>) {
+  this.page = e.detail.page;
+  this.syncQuery();
+  this.fetchDocuments();
+}
+
+private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+  this.pageSize = e.detail.size;
+  this.page = DEFAULTS.page;
+  this.syncQuery();
+  this.fetchDocuments();
+}
+```
+
+`handleSearchInput`, `handleStatusFilter`, and `handleSort` already funnel through `refresh()` and need no further changes.
+
+### Step 4: Wire URL state into `hd-prompt-list`
+
+**File:** `app/client/ui/modules/prompt-list.ts`
+
+Add the router import (this module does not currently import from `@core/router`):
+
+```ts
+import { queryParams, updateQuery } from "@core/router";
+```
+
+Add a `DEFAULTS` const below the imports:
+
+```ts
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  stage: "",
+  sort: "Name",
+} as const;
+```
+
+Replace the filter `@state` initializers:
+
+```ts
+@state() private page = DEFAULTS.page;
+@state() private pageSize = DEFAULTS.pageSize;
+@state() private search = DEFAULTS.search;
+@state() private stage = DEFAULTS.stage;
+@state() private sort = DEFAULTS.sort;
+```
+
+Leave `prompts` and `deletePrompt` unchanged. `selected` is already `@property` and stays.
+
+Update `connectedCallback`:
+
+```ts
+connectedCallback() {
+  super.connectedCallback();
+  this.hydrateFromQuery();
+  this.fetchPrompts();
+}
+```
+
+Add the two new private methods next to `fetchPrompts`:
+
+```ts
+private hydrateFromQuery() {
+  const q = queryParams();
+  if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+  if (q.page_size) this.pageSize = Number(q.page_size) || DEFAULTS.pageSize;
+  if (q.search) this.search = q.search;
+  if (q.stage) this.stage = q.stage;
+  if (q.sort) this.sort = q.sort;
+}
+
+private syncQuery() {
+  updateQuery({
+    page: this.page === DEFAULTS.page ? undefined : this.page,
+    page_size: this.pageSize === DEFAULTS.pageSize ? undefined : this.pageSize,
+    search: this.search || undefined,
+    stage: this.stage || undefined,
+    sort: this.sort === DEFAULTS.sort ? undefined : this.sort,
+  });
+}
+```
+
+Fold `syncQuery` into `refresh`:
+
+```ts
+async refresh() {
+  this.page = DEFAULTS.page;
+  this.syncQuery();
+  await this.fetchPrompts();
+}
+```
+
+Update the page-level handlers:
+
+```ts
+private handlePageChange(e: CustomEvent<{ page: number }>) {
+  this.page = e.detail.page;
+  this.syncQuery();
+  this.fetchPrompts();
+}
+
+private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
+  this.pageSize = e.detail.size;
+  this.page = DEFAULTS.page;
+  this.syncQuery();
+  this.fetchPrompts();
+}
+```
+
+`handleSearchInput`, `handleStageFilter`, and `handleSort` already funnel through `refresh()` and need no further changes.
+
+## Remediation
+
+### R1: Pagination controls don't scale into narrow containers
+
+`hd-pagination` was designed against the full-width documents toolbar. When embedded in the narrow prompt-list column (~300px), the labels wrap and the layout breaks. Rather than maintaining two layouts conditionally, simplify the component permanently: drop the textual labels ("Per page:", "Prev", "Page", "of N", "Next") in favor of a compact form that works at any width — `[size-select]  ‹  [page-input]/N  ›`. Nothing is lost functionally, the per-page select remains a dropdown, and a11y is preserved by moving the textual labels to `aria-label` attributes.
+
+#### Markup changes
+
+**File:** `app/client/ui/elements/pagination-controls.ts`
+
+Replace the `render()` method body with the simplified form. `label` element becomes a plain wrapper (no longer pairing a visible caption with the select), and the prev/next buttons use chevron glyphs with accessible labels:
+
+```ts
+render() {
+  return html`
+    <div class="pagination">
+      <label class="page-size">
+        <span class="page-size-label">Page Size</span>
+        <select
+          class="input"
+          .value=${String(this.size)}
+          @change=${this.handleSizeChange}
+        >
+          ${this.sizeOptions.map(
+            (n) => html`<option value=${n}>${n}</option>`,
+          )}
+        </select>
+      </label>
+      <div class="page-controls">
+        <button
+          class="btn btn-page"
+          aria-label="Previous page"
+          ?disabled=${this.page <= 1}
+          @click=${this.handlePrev}
+        >
+          ‹
+        </button>
+        <span class="page-indicator">
+          <input
+            class="input page-input"
+            type="number"
+            min="1"
+            max=${this.totalPages}
+            step="1"
+            .value=${String(this.page)}
+            ?disabled=${this.totalPages <= 1}
+            aria-label="Page number"
+            @change=${this.handlePageInput}
+            @focus=${this.handlePageFocus}
+          />
+          <span aria-hidden="true">/ ${this.totalPages}</span>
+        </span>
+        <button
+          class="btn btn-page"
+          aria-label="Next page"
+          ?disabled=${this.page >= this.totalPages}
+          @click=${this.handleNext}
+        >
+          ›
+        </button>
+      </div>
+    </div>
+  `;
+}
+```
+
+The `<label class="page-size">` pairs the visible caption with the select via native label association. Keeping the `aria-label` off the select (native label is preferred when present).
+
+#### Style changes
+
+**File:** `app/client/ui/elements/pagination-controls.module.css`
+
+Keep `.page-size` (now wrapping the label + select again), add a `.page-size-label` rule, and make the chevron buttons stretch to match the height of their sibling `.input` controls so everything is flush. Chevron glyphs get a larger font-size (`--text-xl`) so they're clearly readable:
+
+```css
+:host {
+  display: block;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--divider);
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-size-label {
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+.page-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
+.page-input {
+  width: auto;
+  padding: var(--space-2) var(--space-1);
+  text-align: center;
+  appearance: textfield;
+}
+
+.page-input::-webkit-inner-spin-button,
+.page-input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.btn-page {
+  align-self: stretch;
+  min-width: auto;
+  padding: 0 var(--space-3);
+  font-size: var(--text-xl);
+  line-height: 1;
+}
+```
+
+`align-self: stretch` on `.btn-page` overrides the flex container's `align-items: center` so the chevron buttons fill the cross-axis height of the flex line — which is determined by the tallest sibling (the page-size select and the page input). No hardcoded heights; the buttons auto-match regardless of theme/density changes.
+
+The `appearance: textfield` on `.page-input` plus the `::-webkit-inner/outer-spin-button` rules remove the native number-input spinner arrows and the reserved space they occupy. `width: auto` is retained intentionally — the input renders at its intrinsic content width, so it grows naturally as page counts scale into 4-5+ digits (relevant for the ~750k-1M document corpus).
+
+## Validation Criteria
+
+- [ ] On `/documents`, changing search / status / sort / page / page_size updates the URL with only non-default values and re-renders the grid.
+- [ ] Browser history length stays constant across filter changes (`replaceState`, not `pushState`).
+- [ ] Navigating `/documents` → `/review/:id` → Back restores filter state exactly.
+- [ ] Hard-reloading `/documents?page=2&status=review&sort=Filename` mounts with those values and fires a single fetch.
+- [ ] Same behaviors verified on `/prompts` with `stage` filter and default sort `"Name"`.
+- [ ] Default state (no filter touched) leaves the URL at `/documents` or `/prompts` with no `?`.
+- [ ] `bun run build` succeeds with no type errors.
+- [ ] `mise run vet` succeeds with no regressions.
+- [ ] Simplified `hd-pagination` renders cleanly in both the wide documents toolbar and the narrow prompt-list column; chevron buttons and `[input]/N` indicator fit without wrapping; per-page select remains functional.

--- a/.claude/context/sessions/135-url-query-state-persistence.md
+++ b/.claude/context/sessions/135-url-query-state-persistence.md
@@ -1,0 +1,49 @@
+# 135 - URL query-parameter state persistence for list views
+
+## Summary
+
+Two-way URL binding for `hd-document-grid` and `hd-prompt-list` filter state. Views hydrate pagination, search, filter, and sort from the URL query string on mount via a new `queryParams()` router helper, and write them back on every change via `updateQuery()` — which uses `history.replaceState` to avoid remounting the active view. Defaults are omitted from the URL so shareable links stay clean. Navigating into `/review/:id` and returning, or reloading the page, now restores the prior grid state exactly.
+
+Paired with a visual simplification of `hd-pagination` (folded in as remediation R1 after the developer observed that the full-width layout did not scale into the narrow prompt-list column): chevron buttons replace textual prev/next, "Page X of N" collapses to `[input] / N`, native number-input spinners are hidden so the page input auto-sizes to its digit count, and prev/next `align-self: stretch` to match the sibling input/select height. The component now renders the same in both the wide documents toolbar and the narrow prompt-list column.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| State decorator for filter fields | Keep as `@state`, not `@property` | `@property` is reserved for parent-passed inputs across the codebase. Filter state is view-internal — converting would blur that boundary. |
+| URL ingress path | Explicit `queryParams()` helper in `connectedCallback` | The router's attribute-splat for query keys was unused by any view. Explicit hydration makes the contract visible and keeps `@state` fields private. |
+| URL egress path | `updateQuery()` built on `URLSearchParams` + `history.replaceState` | `pushState` would stack history entries per keystroke; the router's `innerHTML = ""` teardown would remount the view on any route mutation. `replaceState` avoids both. |
+| Reuse of `toQueryString` | No, build `updateQuery` independently | `toQueryString` is shaped for API request URLs (prepends `?`, flat params object). URL state sync needs merge-and-delete semantics over an existing URL. |
+| Default-value location | Per-view `DEFAULTS` const at module top | Single source of truth for field initializers, hydration fallbacks, and sync-omission checks. App-wide defaults would require server-injected config — out of scope. |
+| Pagination controls layout | Simplify permanently, not dual-mode | User preference after weighing container-query complexity vs. a simpler universal layout. Nothing is lost functionally; a11y preserved via `aria-label` on the chevron buttons. |
+| Page input width | Keep `width: auto` | Intrinsic sizing scales with digit count — important as the corpus grows toward 750k-1M documents. Native spinner buttons hidden via `appearance: textfield` so the reserved space collapses. |
+
+## Files Modified
+
+- `app/client/core/router/router.ts` — add `queryParams` and `updateQuery` exports, remove query-attribute splat in `mount()`, refresh `Router` class docstring
+- `app/client/core/router/index.ts` — re-export the two new helpers
+- `app/client/ui/modules/document-grid.ts` — `DEFAULTS` const, `hydrateFromQuery`/`syncQuery` methods, handler sync points
+- `app/client/ui/modules/prompt-list.ts` — same pattern (filter is `stage`, sort default is `"Name"`)
+- `app/client/ui/elements/pagination-controls.ts` — chevron glyphs + aria-labels, restored "Page Size" label, `[input] / N` indicator
+- `app/client/ui/elements/pagination-controls.module.css` — `.page-size-label`, `.btn-page` with `align-self: stretch` + `--text-xl` glyphs, spinner-removal rules on `.page-input`
+- `.claude/skills/web-development/SKILL.md` — update router one-liner to reflect the new parameter-passing contract
+- `.claude/skills/web-development/references/router.md` — rewrite "Parameter Passing" section to document the path-attribute / query-helper split
+- `CHANGELOG.md` — new `v0.5.0-dev.132.135` section
+
+## Patterns Established
+
+- **Query-state pattern for list views**: `DEFAULTS` const at module top → `hydrateFromQuery()` in `connectedCallback` → `syncQuery()` called before every `fetch*()` in handlers → `refresh()` folds page reset + sync + fetch. Reuse this shape for any future list view with URL-persistent state.
+- **Router helper split**: `navigate` (route change with remount), `queryParams` (read current URL state), `updateQuery` (write URL state without remount). These three cover the full navigation-and-state surface for the app.
+- **Height matching via `align-self: stretch`**: cleaner than hardcoded heights or magic padding numbers — the flex line's cross-axis size is already determined by the tallest sibling, so opting into stretch gives automatic alignment.
+
+## Validation Results
+
+- `bun run build` — clean, `dist/app.js` and `dist/app.css` emitted.
+- `mise run vet` — clean (`go vet ./...` reports nothing).
+- Manual UI verification by the developer (screenshots reviewed mid-session):
+  - Documents view: search / status / sort / page / page_size each write to URL with non-default values only; defaults omitted; browser history length constant across filter changes.
+  - Navigate `/documents` → `/review/:id` → Back: grid state restored.
+  - Hard-reload with query params (`?page=2&status=review`): mounts with those values.
+  - Prompts view: same behavior with `stage` filter and `"Name"` sort default.
+  - Pagination controls render cleanly in both the wide documents toolbar and narrow prompt-list column.
+- **No web client test authorship**: the project has no TypeScript/Lit test harness (no bun test files, no jsdom, no vitest). Adding a framework is out of scope for this task. Per CLAUDE.md, Go tests in `tests/` mirror `internal/`; web client coverage has historically relied on manual visual QA. The changes here — browser-API-heavy router helpers and Lit lifecycle wiring — are exactly the surfaces that a browser-harness framework would be needed to cover. Flagging as a follow-up consideration.

--- a/.claude/plans/cached-swimming-crescent.md
+++ b/.claude/plans/cached-swimming-crescent.md
@@ -1,0 +1,211 @@
+# Plan — Issue #135: URL query-parameter state persistence for list views
+
+## Context
+
+List-view state (pagination, search, filter, sort) on `hd-document-grid` and `hd-prompt-list` lives only in `@state` and is destroyed on view unmount. Clicking into `/review/:id` and returning to `/` drops the user back at defaults. Reload does the same.
+
+This needs a two-way URL binding: reads on mount, writes on change. The egress path (view → URL) must use `history.replaceState` — `pushState` plus the router's `innerHTML = ""` teardown at router.ts:108 would remount the view on every filter change and destroy the very state we're trying to preserve.
+
+## Design choices
+
+### 1. Don't convert `@state` to `@property`
+
+The existing codebase uses `@property` exclusively for **parent-passed inputs** (`document`, `documentId`, `prompt`, `selected`, `page` on `hd-pagination`, etc.). `page`/`search`/`status`/`sort`/`pageSize` on the list modules are **internal filter state** — nothing outside the module writes them. Declaring them `@property` blurs that boundary and overloads the decorator semantics.
+
+Keep them as `@state`. Hydrate from the URL explicitly in `connectedCallback`. This is also minimally invasive — every existing handler, `refresh()`, and `fetchDocuments()` keeps its current shape.
+
+### 2. Retire the router's query-attribute splat
+
+Router.ts:115-117 currently does `el.setAttribute(key, value)` for each query-string entry. No view reads these, and per Design Choice 1 we don't want views reading them as attributes. Remove this block and replace it with an explicit `queryParams()` accessor that views call on demand. Path-param splatting (router.ts:111-113) stays — it's used by `hd-review-view` and `hd-not-found-view`.
+
+### 3. Don't reuse `toQueryString`
+
+`toQueryString` (api.ts:164) builds API request query strings: prepends `?`, takes a flat params object, always emits a complete string. Used by `documents/service.ts`, `prompts/service.ts`, `classifications/service.ts`.
+
+URL state sync has different semantics: **merge-and-replace** on `location.search`, delete keys on empty, operate on an existing URL. Build `updateQuery` directly on `URLSearchParams` + `history.replaceState`. The two helpers stay decoupled — they solve different problems.
+
+### 4. Centralize defaults per view
+
+Hardcoding `page=1`, `pageSize=12`, `sort="-UploadedAt"` in the field declaration, again in the hydration fallback, and a third time in the sync-omission check is brittle. One `DEFAULTS` const at module top, referenced everywhere:
+
+```ts
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  status: "",
+  sort: "-UploadedAt",
+} as const;
+```
+
+`@state` fields initialize from `DEFAULTS.*`, hydration falls back to `DEFAULTS.*`, syncQuery omits when `this.x === DEFAULTS.x`. Scoped per view because filter fields diverge (`status` vs `stage`, different sort defaults). App-wide defaults would require server-injected config — noted as out of scope in this session; the per-view const is the natural seam for that future plumbing.
+
+## Implementation
+
+### 1. Router helpers
+
+**File:** `app/client/core/router/router.ts`
+
+Add two exports:
+
+```ts
+/** Reads the current URL's query string as a flat map. */
+export function queryParams(): Record<string, string> {
+  const params = new URLSearchParams(location.search);
+  const result: Record<string, string> = {};
+  for (const [key, value] of params) result[key] = value;
+  return result;
+}
+
+/**
+ * Merges a patch into the current URL's query string and replaces history.
+ * Keys with undefined/null/"" values are deleted, not retained.
+ * Uses replaceState (not pushState) so filter changes don't stack history
+ * entries and don't trigger a view remount.
+ */
+export function updateQuery(patch: Record<string, string | number | undefined | null>): void {
+  const url = new URL(location.href);
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined || value === null || value === "") {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  history.replaceState(null, "", url.pathname + url.search);
+}
+```
+
+Remove router.ts:115-117 (the query-attribute splat):
+
+```ts
+// DELETE:
+for (const [key, value] of Object.entries(match.query)) {
+  el.setAttribute(key, value);
+}
+```
+
+`RouteMatch.query` stays on the type for now — it's still populated by `match()` and cheap to keep for future use. No production caller reads it after this change.
+
+**File:** `app/client/core/router/index.ts`
+
+Re-export `queryParams` and `updateQuery` alongside `navigate`:
+
+```ts
+export { Router, navigate, queryParams, updateQuery } from "./router";
+```
+
+### 2. `hd-document-grid`
+
+**File:** `app/client/ui/modules/document-grid.ts`
+
+Add at module top:
+
+```ts
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  status: "",
+  sort: "-UploadedAt",
+} as const;
+```
+
+Update `@state` initializers to reference `DEFAULTS.*`:
+
+```ts
+@state() private page = DEFAULTS.page;
+@state() private pageSize = DEFAULTS.pageSize;
+@state() private search = DEFAULTS.search;
+@state() private status = DEFAULTS.status;
+@state() private sort = DEFAULTS.sort;
+```
+
+Hydrate in `connectedCallback`:
+
+```ts
+connectedCallback() {
+  super.connectedCallback();
+  this.hydrateFromQuery();
+  this.fetchDocuments();
+}
+
+private hydrateFromQuery() {
+  const q = queryParams();
+  if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+  if (q.page_size) this.pageSize = Number(q.page_size) || DEFAULTS.pageSize;
+  if (q.search) this.search = q.search;
+  if (q.status) this.status = q.status;
+  if (q.sort) this.sort = q.sort;
+}
+```
+
+Add a `syncQuery` method, call it from each handler before `fetchDocuments`:
+
+```ts
+private syncQuery() {
+  updateQuery({
+    page: this.page === DEFAULTS.page ? undefined : this.page,
+    page_size: this.pageSize === DEFAULTS.pageSize ? undefined : this.pageSize,
+    search: this.search || undefined,
+    status: this.status || undefined,
+    sort: this.sort === DEFAULTS.sort ? undefined : this.sort,
+  });
+}
+```
+
+Handler touch points (insert `this.syncQuery()` before the existing fetch call):
+- `handleSearchInput` — after the debounce timer fires (inside `setTimeout`), call `this.refresh()` which becomes `page = DEFAULTS.page; syncQuery(); fetchDocuments()`.
+- `handleStatusFilter`, `handleSort` — already call `this.refresh()`; folding `syncQuery` into `refresh` keeps it DRY.
+- `handlePageChange`, `handlePageSizeChange` — add `this.syncQuery()` before `fetchDocuments()`.
+
+Consolidate via `refresh`:
+
+```ts
+async refresh() {
+  this.page = DEFAULTS.page;
+  this.syncQuery();
+  await this.fetchDocuments();
+}
+```
+
+### 3. `hd-prompt-list`
+
+**File:** `app/client/ui/modules/prompt-list.ts`
+
+Same pattern. Defaults:
+
+```ts
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  stage: "",
+  sort: "Name",
+} as const;
+```
+
+Filter key is `stage` (not `status`), sort default is `"Name"`. Hydration, sync, and handler touch points mirror document-grid.
+
+## Files Modified
+
+- `app/client/core/router/router.ts` — add `queryParams`, `updateQuery`; remove query-attribute splat
+- `app/client/core/router/index.ts` — re-export new helpers
+- `app/client/ui/modules/document-grid.ts` — `DEFAULTS`, hydrate, sync
+- `app/client/ui/modules/prompt-list.ts` — `DEFAULTS`, hydrate, sync
+
+No changes to `api.ts`, `domains/*`, or `pagination-controls.ts`.
+
+## Verification
+
+Manual E2E (UI-first per CLAUDE.md):
+
+1. `bun run watch` + `mise run dev` in two terminals.
+2. On `/documents`: change each of search, status, sort, page, page size. URL reflects only non-default values; list re-renders; browser history length stays constant across filter changes (replaceState).
+3. Click a document card → `/review/:id` → browser Back. Filter state fully restored.
+4. Hard-reload `/documents?page=2&status=review&sort=Filename`. Mounts with those values, single fetch fires.
+5. Repeat 2-4 on `/prompts` with `stage` filter, default sort `"Name"`.
+6. Default state: no query touched → URL stays `/documents` (no `?`).
+7. `bun run build && mise run vet` — no type/lint regressions.
+
+Tests are AI-owned in Phase 5 of the session.

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -77,7 +77,7 @@ Five cascade layers (`tokens, reset, base, theme, app`), design tokens as CSS cu
 
 ### Router — [references/router.md](references/router.md)
 
-History API router at `app/client/core/router/`. Routes are defined in `app/client/routes.ts` and injected into the `Router` constructor — the router has no knowledge of specific routes. Dynamic `:paramName` segments, catch-all `'*'`, `navigate()` for programmatic routing. Router sets path/query params as HTML attributes on mounted components. Progressive enhancement with View Transitions API.
+History API router at `app/client/core/router/`. Routes are defined in `app/client/routes.ts` and injected into the `Router` constructor — the router has no knowledge of specific routes. Dynamic `:paramName` segments, catch-all `'*'`, `navigate()` for programmatic routing. Path params are set as HTML attributes on mounted components; query params are read via `queryParams()` and written via `updateQuery()` helpers (no attribute splat). Progressive enhancement with View Transitions API.
 
 ### Build — [references/build.md](references/build.md)
 

--- a/.claude/skills/web-development/references/router.md
+++ b/.claude/skills/web-development/references/router.md
@@ -52,16 +52,45 @@ html`<a href="prompts">Prompts</a>`
 
 ## Parameter Passing
 
-The router sets path params and query params as HTML attributes on the mounted component. Components receive them via `@property()`:
+### Path params — HTML attributes
+
+Path params are set as HTML attributes on the mounted component. Components receive them via `@property()`:
 
 ```typescript
 // Route: 'review/:documentId'
-// URL: /app/review/abc-123?tab=markings
+// URL: /app/review/abc-123
 
 @property({ type: String }) documentId?: string;  // "abc-123"
 ```
 
-Query params are also set as attributes on the component.
+### Query params — explicit helpers
+
+Query params are **not** splatted as attributes. Components read them with `queryParams()` (typically in `connectedCallback`) and write them back with `updateQuery()`:
+
+```typescript
+import { queryParams, updateQuery } from '@core/router';
+
+// Read on mount
+connectedCallback() {
+  super.connectedCallback();
+  const q = queryParams();
+  if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+  // ...
+  this.fetchItems();
+}
+
+// Write on change (uses history.replaceState — no remount)
+private syncQuery() {
+  updateQuery({
+    page: this.page === DEFAULTS.page ? undefined : this.page,
+    // undefined/null/"" values are deleted from the URL
+  });
+}
+```
+
+This keeps filter fields as `@state` (internal state) rather than `@property` (parent-passed inputs), preserves the semantic distinction, and gives list views clean, shareable URLs that round-trip through browser back/forward navigation.
+
+Centralize per-view defaults in a top-of-module `DEFAULTS` const so field initializers, hydration fallbacks, and sync-omission checks share one source of truth.
 
 ## Route Types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.5.0-dev.132.135
+
+### Web Client
+
+- Persist list-view pagination, search, filter, and sort state in the URL query string — `document-grid` and `prompt-list` hydrate their `@state` from `queryParams()` on mount, write back via `updateQuery()` on every filter change, and omit default values so shareable URLs stay clean; navigating into `/review/:id` and returning (or reloading the page) now restores the prior grid state (#135)
+- Add `queryParams()` and `updateQuery()` helpers to `@core/router` — `updateQuery` merges a patch into `location.search`, deletes keys on empty/undefined/null values, and uses `history.replaceState` so filter changes don't remount the active view (#135)
+- Retire the router's query-attribute splat on mount — query state now flows through the explicit helpers, keeping filter fields as `@state` (internal) rather than `@property` (parent-input) and preserving that semantic boundary (#135)
+- Simplify `hd-pagination` to a compact, container-agnostic layout — chevron buttons (`‹` / `›`) with accessible labels replace "Prev"/"Next", the "Page X of N" caption collapses to `[input] / N`, the page-size select keeps a visible "Page Size" label, native number-input spinners are hidden so the page input auto-sizes to its digit count (forward-compat for ~750k-1M document counts), and prev/next `align-self: stretch` to match the sibling input/select height (#135)
+
 ## v0.5.0-dev.132.134
 
 ### Web Client

--- a/app/client/core/router/index.ts
+++ b/app/client/core/router/index.ts
@@ -1,2 +1,2 @@
-export { Router, navigate } from "./router";
+export { Router, navigate, queryParams, updateQuery } from "./router";
 export type { RouteConfig, RouteMatch } from "./types";

--- a/app/client/core/router/router.ts
+++ b/app/client/core/router/router.ts
@@ -7,10 +7,40 @@ export function navigate(path: string): void {
   routerInstance?.navigate(path);
 }
 
+/** Current URL's query string as a flat map of decoded key/value pairs. */
+export function queryParams(): Record<string, string> {
+  const params = new URLSearchParams(location.search);
+  const result: Record<string, string> = {};
+  for (const [key, value] of params) result[key] = value;
+  return result;
+}
+
 /**
- * History API router. Matches URL paths against the route table,
- * mounts the corresponding component into a container element,
- * and sets path/query params as HTML attributes on the mounted component.
+ * Merges a patch into the current URL's query string and replaces history.
+ * Keys whose value is `undefined`, `null`, or `""` are removed from the URL.
+ * Uses `history.replaceState` so the active view is not remounted — callers
+ * remain in place while their shareable URL updates in the address bar.
+ */
+export function updateQuery(
+  patch: Record<string, string | number | undefined | null>,
+): void {
+  const url = new URL(location.href);
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined || value === null || value === "") {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  history.replaceState(null, "", url.pathname + url.search);
+}
+
+/**
+ * History API router. Matches URL paths against the route table and mounts
+ * the corresponding component into a container element. Path params are set
+ * as HTML attributes on the mounted component; query params are not splatted
+ * — views read and write them via the `queryParams` and `updateQuery`
+ * helpers.
  */
 export class Router {
   private container: HTMLElement;
@@ -71,7 +101,8 @@ export class Router {
   private match(path: string, query: Record<string, string>): RouteMatch {
     const segments = path.split("/").filter(Boolean);
 
-    if (this.routes[path]) return { config: this.routes[path], params: {}, query };
+    if (this.routes[path])
+      return { config: this.routes[path], params: {}, query };
 
     for (const [pattern, config] of Object.entries(this.routes)) {
       if (pattern === "*") continue;
@@ -109,10 +140,6 @@ export class Router {
       const el = document.createElement(match.config.component);
 
       for (const [key, value] of Object.entries(match.params)) {
-        el.setAttribute(key, value);
-      }
-
-      for (const [key, value] of Object.entries(match.query)) {
         el.setAttribute(key, value);
       }
 

--- a/app/client/ui/elements/pagination-controls.module.css
+++ b/app/client/ui/elements/pagination-controls.module.css
@@ -17,15 +17,15 @@
   gap: var(--space-2);
 }
 
+.page-size-label {
+  font-size: var(--text-sm);
+  color: var(--color-1);
+}
+
 .page-controls {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-}
-
-.label {
-  font-size: var(--text-sm);
-  color: var(--color-1);
+  gap: var(--space-2);
 }
 
 .page-indicator {
@@ -40,4 +40,19 @@
   width: auto;
   padding: var(--space-2) var(--space-1);
   text-align: center;
+  appearance: textfield;
+}
+
+.page-input::-webkit-inner-spin-button,
+.page-input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.btn-page {
+  align-self: stretch;
+  min-width: auto;
+  padding: 0 var(--space-3);
+  font-size: var(--text-xl);
+  line-height: 1;
 }

--- a/app/client/ui/elements/pagination-controls.ts
+++ b/app/client/ui/elements/pagination-controls.ts
@@ -92,7 +92,7 @@ export class PaginationControls extends LitElement {
     return html`
       <div class="pagination">
         <label class="page-size">
-          <span class="label">Per page:</span>
+          <span class="page-size-label">Page Size</span>
           <select
             class="input"
             .value=${String(this.size)}
@@ -105,14 +105,14 @@ export class PaginationControls extends LitElement {
         </label>
         <div class="page-controls">
           <button
-            class="btn"
+            class="btn btn-page"
+            aria-label="Previous page"
             ?disabled=${this.page <= 1}
             @click=${this.handlePrev}
           >
-            Prev
+            ‹
           </button>
           <span class="page-indicator">
-            Page
             <input
               class="input page-input"
               type="number"
@@ -125,14 +125,15 @@ export class PaginationControls extends LitElement {
               @change=${this.handlePageInput}
               @focus=${this.handlePageFocus}
             />
-            of ${this.totalPages}
+            <span aria-hidden="true">/ ${this.totalPages}</span>
           </span>
           <button
-            class="btn"
+            class="btn btn-page"
+            aria-label="Next Page"
             ?disabled=${this.page >= this.totalPages}
             @click=${this.handleNext}
           >
-            Next
+            ›
           </button>
         </div>
       </div>

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -2,7 +2,7 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { PageResult } from "@core";
-import { navigate } from "@core/router";
+import { navigate, queryParams, updateQuery } from "@core/router";
 import { ClassificationService } from "@domains/classifications";
 import type { WorkflowStage } from "@domains/classifications";
 import { DocumentService } from "@domains/documents";
@@ -12,6 +12,14 @@ import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
 import scrollStyles from "@styles/scroll.module.css";
 import styles from "./document-grid.module.css";
+
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  status: "",
+  sort: "-UploadedAt",
+} as const;
 
 interface ClassifyProgress {
   currentNode: WorkflowStage | null;
@@ -28,11 +36,11 @@ export class DocumentGrid extends LitElement {
   static styles = [buttonStyles, inputStyles, scrollStyles, styles];
 
   @state() private documents: PageResult<Document> | null = null;
-  @state() private page = 1;
-  @state() private pageSize = 12;
-  @state() private search = "";
-  @state() private status = "";
-  @state() private sort = "-UploadedAt";
+  @state() private page: number = DEFAULTS.page;
+  @state() private pageSize: number = DEFAULTS.pageSize;
+  @state() private search: string = DEFAULTS.search;
+  @state() private status: string = DEFAULTS.status;
+  @state() private sort: string = DEFAULTS.sort;
   @state() private classifying = new Map<string, ClassifyProgress>();
   @state() private selectedIds = new Set<string>();
   @state() private deleteDocument: Document | null = null;
@@ -42,6 +50,7 @@ export class DocumentGrid extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.hydrateFromQuery();
     this.fetchDocuments();
   }
 
@@ -54,7 +63,8 @@ export class DocumentGrid extends LitElement {
   }
 
   async refresh() {
-    this.page = 1;
+    this.page = DEFAULTS.page;
+    this.syncQuery();
     await this.fetchDocuments();
   }
 
@@ -66,12 +76,31 @@ export class DocumentGrid extends LitElement {
     };
 
     if (this.search) req.search = this.search;
-
     if (this.status) req.status = this.status;
 
     const result = await DocumentService.search(req);
 
     if (result.ok) this.documents = result.data;
+  }
+
+  private hydrateFromQuery() {
+    const q = queryParams();
+    if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+    if (q.page_size) this.pageSize = Number(q.page_size) || DEFAULTS.pageSize;
+    if (q.search) this.search = q.search;
+    if (q.status) this.status = q.status;
+    if (q.sort) this.sort = q.sort;
+  }
+
+  private syncQuery() {
+    updateQuery({
+      page: this.page === DEFAULTS.page ? undefined : this.page,
+      page_size:
+        this.pageSize === DEFAULTS.pageSize ? undefined : this.pageSize,
+      search: this.search || undefined,
+      status: this.status || undefined,
+      sort: this.sort === DEFAULTS.sort ? undefined : this.sort,
+    });
   }
 
   private handleSearchInput(e: Event) {
@@ -96,12 +125,14 @@ export class DocumentGrid extends LitElement {
 
   private handlePageChange(e: CustomEvent<{ page: number }>) {
     this.page = e.detail.page;
+    this.syncQuery();
     this.fetchDocuments();
   }
 
   private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
     this.pageSize = e.detail.size;
-    this.page = 1;
+    this.page = DEFAULTS.page;
+    this.syncQuery();
     this.fetchDocuments();
   }
 

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -2,6 +2,7 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { PageResult } from "@core";
+import { queryParams, updateQuery } from "@core/router";
 import { PromptService } from "@domains/prompts";
 import type { Prompt, SearchRequest } from "@domains/prompts";
 
@@ -9,6 +10,14 @@ import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
 import scrollStyles from "@styles/scroll.module.css";
 import styles from "./prompt-list.module.css";
+
+const DEFAULTS = {
+  page: 1,
+  pageSize: 12,
+  search: "",
+  stage: "",
+  sort: "Name",
+} as const;
 
 /**
  * Stateful module that manages the prompt browsing experience.
@@ -22,17 +31,18 @@ export class PromptList extends LitElement {
   @property({ type: Object }) selected: Prompt | null = null;
 
   @state() private prompts: PageResult<Prompt> | null = null;
-  @state() private page = 1;
-  @state() private pageSize = 12;
-  @state() private search = "";
-  @state() private stage = "";
-  @state() private sort = "Name";
+  @state() private page: number = DEFAULTS.page;
+  @state() private pageSize: number = DEFAULTS.pageSize;
+  @state() private search: string = DEFAULTS.search;
+  @state() private stage: string = DEFAULTS.stage;
+  @state() private sort: string = DEFAULTS.sort;
   @state() private deletePrompt: Prompt | null = null;
 
   private searchTimer = 0;
 
   connectedCallback() {
     super.connectedCallback();
+    this.hydrateFromQuery();
     this.fetchPrompts();
   }
 
@@ -42,7 +52,8 @@ export class PromptList extends LitElement {
   }
 
   async refresh() {
-    this.page = 1;
+    this.page = DEFAULTS.page;
+    this.syncQuery();
     await this.fetchPrompts();
   }
 
@@ -59,6 +70,26 @@ export class PromptList extends LitElement {
     const result = await PromptService.search(req);
 
     if (result.ok) this.prompts = result.data;
+  }
+
+  private hydrateFromQuery() {
+    const q = queryParams();
+    if (q.page) this.page = Number(q.page) || DEFAULTS.page;
+    if (q.page_size) this.pageSize = Number(q.page_size) || DEFAULTS.pageSize;
+    if (q.search) this.search = q.search;
+    if (q.stage) this.stage = q.stage;
+    if (q.sort) this.sort = q.sort;
+  }
+
+  private syncQuery() {
+    updateQuery({
+      page: this.page === DEFAULTS.page ? undefined : this.page,
+      page_size:
+        this.pageSize === DEFAULTS.pageSize ? undefined : this.pageSize,
+      search: this.search || undefined,
+      stage: this.stage || undefined,
+      sort: this.sort === DEFAULTS.sort ? undefined : this.sort,
+    });
   }
 
   private handleSearchInput(e: Event) {
@@ -83,12 +114,14 @@ export class PromptList extends LitElement {
 
   private handlePageChange(e: CustomEvent<{ page: number }>) {
     this.page = e.detail.page;
+    this.syncQuery();
     this.fetchPrompts();
   }
 
   private handlePageSizeChange(e: CustomEvent<{ size: number }>) {
     this.pageSize = e.detail.size;
-    this.page = 1;
+    this.page = DEFAULTS.page;
+    this.syncQuery();
     this.fetchPrompts();
   }
 


### PR DESCRIPTION
## Summary

Two-way URL binding for `hd-document-grid` and `hd-prompt-list` filter state. Views hydrate pagination, search, filter, and sort from the URL query string on mount via a new `queryParams()` router helper, and write them back on every change via `updateQuery()` — which uses `history.replaceState` to avoid remounting the active view. Defaults are omitted from the URL so shareable links stay clean. Navigating into `/review/:id` and returning, or reloading the page, now restores the prior grid state exactly.

Paired with a visual simplification of `hd-pagination` (folded in as remediation after the full-width layout didn't scale into the narrow prompt-list column): chevron buttons replace textual prev/next, "Page X of N" collapses to `[input] / N`, native number-input spinners are hidden so the page input auto-sizes to its digit count (forward-compat for the ~750k-1M document corpus), and prev/next `align-self: stretch` to match the sibling input/select height.

Closes #135

## Changes

- `app/client/core/router/router.ts` / `index.ts` — add `queryParams()` and `updateQuery()` exports; remove the unused query-attribute splat in `mount()`
- `app/client/ui/modules/document-grid.ts`, `prompt-list.ts` — `DEFAULTS` const at module top; `hydrateFromQuery()` in `connectedCallback`; `syncQuery()` called before every fetch in handlers
- `app/client/ui/elements/pagination-controls.{ts,module.css}` — chevron buttons with `aria-label`s, restored "Page Size" label, `[input] / N` indicator, hidden number-input spinners via `appearance: textfield`, `align-self: stretch` for height matching
- `.claude/skills/web-development/SKILL.md` + `references/router.md` — document the new path-attribute / query-helper split
- `CHANGELOG.md` — `v0.5.0-dev.132.135` entry

## Test plan

- [x] Documents view: each of search / status / sort / page / page_size writes to URL with non-default values only; defaults omitted
- [x] Browser history length constant across filter changes (replaceState)
- [x] `/documents` → `/review/:id` → Back restores filter state exactly
- [x] Hard-reload with query params mounts with those values
- [x] Prompts view: same behavior with `stage` filter and `"Name"` sort default
- [x] Pagination controls render cleanly in both wide documents toolbar and narrow prompt-list column
- [x] `bun run build` succeeds
- [x] `mise run vet` succeeds