### PR TITLE
Bulk delete action and toast service for command feedback

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -96,6 +96,7 @@ See `.claude/skills/web-development/` for full conventions. Key points that are 
 - **Scroll containers**: Never declare `overflow-y: auto` (or `overflow-x: auto`) directly in a component's CSS. Import `@styles/scroll.module.css` and apply `.scroll-y` / `.scroll-x` in the template. The utility bundles `overflow`, `scrollbar-gutter: stable`, and axis padding — layout still lives in the component's own CSS (`flex: 1; min-height: 0;`, `max-height: ...`, etc.).
 - **Flex sizing for scroll**: A scroll container still needs `flex: 1; min-height: 0;` from its parent flex column; the utility does not fix missing flex constraints.
 - **Shared styles**: `@styles/*` for reusable modules (`badge`, `buttons`, `cards`, `inputs`, `labels`, `scroll`). Component `*.module.css` provides layout-specific overrides.
+- **Overlay primitives**: Any UI that overlays the page — tooltips, menus, popovers, toasts, confirmation dialogs, modal forms — MUST use browser-native top-layer primitives: `<dialog>` + `.showModal()` for modals, `popover="auto"` for dismiss-on-outside-click menus, `popover="hint"` for tooltips (does not close open `auto` popovers; closes other hints), `popover="manual"` for long-lived stacks like toasts. No manual `position: fixed; z-index: ...` overlay divs. Top-layer rendering is the single source of stacking truth — no `z-index` arms race. See `.claude/skills/web-development/SKILL.md` ("Overlay Convention") for the full decision matrix and patterns.
 
 ## Gotchas
 

--- a/.claude/context/guides/.archive/139-bulk-delete-action-for-document-list.md
+++ b/.claude/context/guides/.archive/139-bulk-delete-action-for-document-list.md
@@ -1,0 +1,652 @@
+# 139 - Bulk delete action for document list
+
+## Problem Context
+
+Herald's document list already supports bulk classification via "Classify N Documents". Users need the same bulk affordance for deletion. Single-card Delete uses `hd-confirm-dialog`, and the bulk action must follow suit — confirming with "Are you sure you want to delete {N} documents?", deleting in parallel via `Promise.allSettled`, and retaining failed IDs in the selection for retry.
+
+Issue #139 acceptance criteria also specify that per-item failures surface as **error toasts**. Herald currently has no toast/notification infrastructure — grid/list mutations fail silently, and forms use inline error divs. This session therefore introduces a minimal toast service used for **all** command executions (API calls that mutate state) and wires every existing mutation call site through it, alongside the bulk-delete work.
+
+## Architecture Approach
+
+### Toast service
+
+A new `app/client/ui/elements/toast.ts` hosts both the element (`<hd-toast-container>`) and the service (`Toast` namespace). A module-level `ToastBus` singleton holds the toast array, notifies subscribed elements, and manages per-toast auto-dismiss timers.
+
+- **Kinds**: `success`, `error`, `warning`, `info`. Auto-dismiss durations: 3s success/info, 5s warning, 6s error.
+- **Click-to-dismiss**: clicking a toast cancels its timer and removes it.
+- **Stacking**: fixed bottom-center, newest at the bottom, max 5 visible (oldest evicted).
+- **Styling**: semantic border-left accent + matching `-bg` background, monospace text, consistent with Herald's terminal aesthetic.
+- **Mount**: `<hd-toast-container>` is appended once to `document.body` from `app/client/app.ts` after the Router starts — matching Herald's existing pattern (the user menu is also wired dynamically from `app.ts`, and `app.html` stays a pure server-rendered shell). Element registration still flows through the `@ui/elements` barrel.
+
+### Bulk-delete state model
+
+`document-grid.ts` gains a second delete state `deleteDocuments: Document[] | null` that mirrors the existing singular `deleteDocument: Document | null`. Opening the bulk dialog snapshots the currently-selected documents (so the count shown in the dialog does not shift if selection changes while open). Only one dialog renders at a time.
+
+On confirm: `Promise.allSettled` over `DocumentService.delete(id)`, then:
+- Successful IDs drop out of `selectedIds`.
+- Failed IDs are retained in `selectedIds` for retry; each failure fires `Toast.error` and logs via `console.error`.
+- A single `Toast.success("Deleted N documents")` fires for the succeeded batch.
+- `fetchDocuments()` refreshes the grid.
+
+### Cross-cutting toast wiring
+
+Convention applied to every mutation:
+- **Success**: `Toast.success("<verb past-tense> <noun>")`.
+- **Failure**: `Toast.error("<context>: <result.error>")`.
+- **Forms** (`classification-panel`, `prompt-form`): keep the existing inline `this.error` display for form-local context; toasts are additive.
+- **SSE classify** in `document-grid`: look the filename up from the current page (`this.documents?.data`) and fire `Toast.success("Classified <filename>")` / `Toast.error("Classification failed for <filename>")` inside the existing `onComplete` / `onError` callbacks.
+- **Batch upload** in `document-upload`: after `Promise.allSettled` resolves, summarize with one success toast for the succeeded count and one error toast for the failed count.
+
+### No new CSS in `document-grid.module.css`
+
+The issue mentions "Delete variant styling for the new button" in `document-grid.module.css`, but the shared `.btn-red` utility (in `@styles/buttons.module.css`) already matches the `document-card` Delete styling. No scoped CSS is required; call this out in the session summary.
+
+## Implementation
+
+### Step 1: Create `app/client/ui/elements/toast.module.css`
+
+```css
+.stack {
+  position: fixed;
+  bottom: var(--space-4);
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  width: min(72ch, calc(100dvw - var(--space-8)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  z-index: 200;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: block;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--divider);
+  border-left-width: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: break-word;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  animation: slide-in 0.15s ease-out;
+  transition: opacity 0.15s;
+}
+
+.toast:hover {
+  opacity: 0.9;
+}
+
+.toast.success {
+  border-left-color: var(--green);
+  background: var(--green-bg);
+}
+
+.toast.error {
+  border-left-color: var(--red);
+  background: var(--red-bg);
+}
+
+.toast.warning {
+  border-left-color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.toast.info {
+  border-left-color: var(--blue);
+  background: var(--blue-bg);
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(20%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+```
+
+### Step 2: Create `app/client/ui/elements/toast.ts`
+
+```ts
+import { LitElement, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import styles from "./toast.module.css";
+
+export type ToastKind = "success" | "error" | "warning" | "info";
+
+export interface ToastItem {
+  id: string;
+  kind: ToastKind;
+  message: string;
+}
+
+type Listener = (toasts: ToastItem[]) => void;
+
+const DURATIONS: Record<ToastKind, number> = {
+  success: 3000,
+  info: 3000,
+  warning: 5000,
+  error: 6000,
+};
+
+const MAX_VISIBLE = 5;
+
+class ToastBus {
+  private toasts: ToastItem[] = [];
+  private listeners = new Set<Listener>();
+  private timers = new Map<string, number>();
+
+  subscribe(fn: Listener): () => void {
+    this.listeners.add(fn);
+    fn(this.toasts);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  }
+
+  push(kind: ToastKind, message: string): string {
+    const id = crypto.randomUUID();
+    this.toasts = [...this.toasts, { id, kind, message }];
+
+    while (this.toasts.length > MAX_VISIBLE) {
+      const oldest = this.toasts[0];
+      this.clearTimer(oldest.id);
+      this.toasts = this.toasts.slice(1);
+    }
+
+    this.timers.set(
+      id,
+      window.setTimeout(() => this.dismiss(id), DURATIONS[kind]),
+    );
+    this.emit();
+    return id;
+  }
+
+  dismiss(id: string): void {
+    this.clearTimer(id);
+    const next = this.toasts.filter((t) => t.id !== id);
+    if (next.length === this.toasts.length) return;
+    this.toasts = next;
+    this.emit();
+  }
+
+  private clearTimer(id: string) {
+    const timer = this.timers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  private emit() {
+    for (const fn of this.listeners) fn(this.toasts);
+  }
+}
+
+const bus = new ToastBus();
+
+export const Toast = {
+  success(message: string): string {
+    return bus.push("success", message);
+  },
+  error(message: string): string {
+    return bus.push("error", message);
+  },
+  warning(message: string): string {
+    return bus.push("warning", message);
+  },
+  info(message: string): string {
+    return bus.push("info", message);
+  },
+  dismiss(id: string): void {
+    bus.dismiss(id);
+  },
+  subscribe(fn: Listener): () => void {
+    return bus.subscribe(fn);
+  },
+};
+
+@customElement("hd-toast-container")
+export class ToastContainer extends LitElement {
+  static styles = [styles];
+
+  @state() private toasts: ToastItem[] = [];
+
+  private unsubscribe?: () => void;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.unsubscribe = Toast.subscribe((toasts) => {
+      this.toasts = toasts;
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+
+  private handleDismiss(id: string) {
+    Toast.dismiss(id);
+  }
+
+  render() {
+    if (this.toasts.length === 0) return nothing;
+
+    return html`
+      <div class="stack" role="status" aria-live="polite">
+        ${this.toasts.map(
+          (t) => html`
+            <button
+              type="button"
+              class="toast ${t.kind}"
+              @click=${() => this.handleDismiss(t.id)}
+            >
+              ${t.message}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-toast-container": ToastContainer;
+  }
+}
+```
+
+### Step 3: Export `ToastContainer` from the elements barrel
+
+Edit `app/client/ui/elements/index.ts` — add the re-export alphabetically (after `PromptCard`):
+
+```ts
+export { PromptCard } from "./prompt-card";
+export { Toast, ToastContainer } from "./toast";
+export type { ToastItem, ToastKind } from "./toast";
+```
+
+### Step 4: Mount the toast container from `app.ts`
+
+Edit `app/client/app.ts` — after `router.start()` (line 20), append a `<hd-toast-container>` to the document body. Matches the dynamic-mount pattern already used for the user menu below it.
+
+```ts
+  const router = new Router("app-content", routes);
+  router.start();
+
+  document.body.appendChild(document.createElement("hd-toast-container"));
+
+  if (Auth.isEnabled()) {
+```
+
+`app/server/layouts/app.html` is **not** modified — the server template stays a pure shell.
+
+### Step 5: Bulk delete + toast wiring in `document-grid.ts`
+
+1. Add a `Toast` import alongside the other `@ui/elements` usage:
+
+```ts
+import { Toast } from "@ui/elements";
+```
+
+2. Add a new state field next to the existing `deleteDocument`:
+
+```ts
+@state() private deleteDocument: Document | null = null;
+@state() private deleteDocuments: Document[] | null = null;
+```
+
+3. Update the existing `confirmDelete` to emit toasts (replace the current method body):
+
+```ts
+private async confirmDelete() {
+  if (!this.deleteDocument) return;
+
+  const id = this.deleteDocument.id;
+  const filename = this.deleteDocument.filename;
+  this.deleteDocument = null;
+
+  const result = await DocumentService.delete(id);
+
+  if (result.ok) {
+    this.selectedIds.delete(id);
+    this.fetchDocuments();
+    Toast.success(`Deleted ${filename}`);
+  } else {
+    Toast.error(`Failed to delete ${filename}: ${result.error}`);
+  }
+}
+```
+
+4. Add the three new handlers immediately after `handleBulkClassify`:
+
+```ts
+private handleBulkDelete() {
+  if (!this.documents) return;
+
+  const selected = this.documents.data.filter((d) =>
+    this.selectedIds.has(d.id),
+  );
+  if (selected.length === 0) return;
+
+  this.deleteDocuments = selected;
+}
+
+private async confirmBulkDelete() {
+  const batch = this.deleteDocuments;
+  this.deleteDocuments = null;
+  if (!batch) return;
+
+  const outcomes = await Promise.all(
+    batch.map(async (doc) => {
+      try {
+        const result = await DocumentService.delete(doc.id);
+        return result.ok
+          ? { doc, ok: true as const }
+          : { doc, ok: false as const, error: result.error };
+      } catch (err) {
+        return { doc, ok: false as const, error: String(err) };
+      }
+    }),
+  );
+
+  const failed = new Set<string>();
+  let succeeded = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.ok) {
+      succeeded++;
+      continue;
+    }
+    failed.add(outcome.doc.id);
+    console.error(
+      `Failed to delete document ${outcome.doc.id}:`,
+      outcome.error,
+    );
+    Toast.error(`Failed to delete ${outcome.doc.filename}: ${outcome.error}`);
+  }
+
+  if (succeeded > 0) {
+    Toast.success(
+      `Deleted ${succeeded} document${succeeded === 1 ? "" : "s"}`,
+    );
+  }
+
+  this.selectedIds = failed;
+  this.fetchDocuments();
+}
+
+private cancelBulkDelete() {
+  this.deleteDocuments = null;
+}
+```
+
+5. Extend the SSE classify callbacks in `handleClassify` to emit toasts. Replace the existing `onComplete` and `onError` bodies with:
+
+```ts
+onComplete: () => {
+  this.abortControllers.delete(docId);
+  const updated = new Map(this.classifying);
+  updated.delete(docId);
+  this.classifying = updated;
+  const filename =
+    this.documents?.data.find((d) => d.id === docId)?.filename ??
+    "document";
+  Toast.success(`Classified ${filename}`);
+  this.fetchDocuments();
+},
+onError: () => {
+  this.abortControllers.delete(docId);
+  const updated = new Map(this.classifying);
+  updated.delete(docId);
+  this.classifying = updated;
+  const filename =
+    this.documents?.data.find((d) => d.id === docId)?.filename ??
+    "document";
+  Toast.error(`Classification failed for ${filename}`);
+  this.fetchDocuments();
+},
+```
+
+6. Add the bulk-delete button to `renderToolbar`. Insert immediately after the existing bulk-classify block so both live in the same conditional region:
+
+```ts
+${this.selectedIds.size > 0
+  ? html`
+      <button class="btn btn-blue" @click=${this.handleBulkClassify}>
+        Classify ${this.selectedIds.size} Documents
+      </button>
+      <button class="btn btn-red" @click=${this.handleBulkDelete}>
+        Delete ${this.selectedIds.size} Documents
+      </button>
+    `
+  : nothing}
+```
+
+7. Add the second confirm-dialog block. In the `render()` method, right after the existing `${this.deleteDocument ? html\`<hd-confirm-dialog .../>\` : nothing}` block, append:
+
+```ts
+${this.deleteDocuments
+  ? html`
+      <hd-confirm-dialog
+        message="Are you sure you want to delete ${this.deleteDocuments
+          .length} documents?"
+        @confirm=${this.confirmBulkDelete}
+        @cancel=${this.cancelBulkDelete}
+      ></hd-confirm-dialog>
+    `
+  : nothing}
+```
+
+### Step 6: Toast wiring in `classification-panel.ts`
+
+1. Add `Toast` import:
+
+```ts
+import { Toast } from "@ui/elements";
+```
+
+2. Update `handleValidate` failure + success paths (keep the inline `this.error` behavior):
+
+```ts
+if (!result.ok) {
+  this.error = result.error;
+  Toast.error(`Validation failed: ${result.error}`);
+  return;
+}
+
+this.classification = result.data;
+this.mode = "view";
+this.error = "";
+
+Toast.success("Classification validated");
+
+this.dispatchEvent(
+  new CustomEvent("validate", {
+    detail: { classification: result.data },
+    bubbles: true,
+    composed: true,
+  }),
+);
+```
+
+3. Update `handleUpdate` identically:
+
+```ts
+if (!result.ok) {
+  this.error = result.error;
+  Toast.error(`Update failed: ${result.error}`);
+  return;
+}
+
+this.classification = result.data;
+this.mode = "view";
+this.error = "";
+
+Toast.success("Classification updated");
+
+this.dispatchEvent(
+  new CustomEvent("update", {
+    detail: { classification: result.data },
+    bubbles: true,
+    composed: true,
+  }),
+);
+```
+
+### Step 7: Toast wiring in `prompt-list.ts`
+
+1. Add `Toast` import:
+
+```ts
+import { Toast } from "@ui/elements";
+```
+
+2. Replace `handleToggleActive` body:
+
+```ts
+private async handleToggleActive(
+  e: CustomEvent<{ id: string; active: boolean }>,
+) {
+  const { id, active } = e.detail;
+  const result = active
+    ? await PromptService.activate(id)
+    : await PromptService.deactivate(id);
+
+  if (result.ok) {
+    Toast.success(`Prompt ${active ? "activated" : "deactivated"}`);
+    this.fetchPrompts();
+  } else {
+    Toast.error(
+      `Failed to ${active ? "activate" : "deactivate"} prompt: ${result.error}`,
+    );
+  }
+}
+```
+
+3. Replace `confirmDelete` body:
+
+```ts
+private async confirmDelete() {
+  if (!this.deletePrompt) return;
+
+  const id = this.deletePrompt.id;
+  const name = this.deletePrompt.name;
+  this.deletePrompt = null;
+
+  const result = await PromptService.delete(id);
+
+  if (result.ok) {
+    Toast.success(`Deleted ${name}`);
+    this.dispatchEvent(
+      new CustomEvent("delete", {
+        detail: { id },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.fetchPrompts();
+  } else {
+    Toast.error(`Failed to delete ${name}: ${result.error}`);
+  }
+}
+```
+
+### Step 8: Toast wiring in `prompt-form.ts`
+
+1. Add `Toast` import:
+
+```ts
+import { Toast } from "@ui/elements";
+```
+
+2. Update `handleSubmit` failure + success paths (keep the inline error):
+
+```ts
+this.submitting = false;
+
+if (!result.ok) {
+  this.error = result.error ?? "An unexpected error occurred.";
+  Toast.error(
+    `Failed to ${this.isEdit ? "update" : "create"} prompt: ${this.error}`,
+  );
+  return;
+}
+
+Toast.success(`Prompt ${this.isEdit ? "updated" : "created"}`);
+
+this.dispatchEvent(
+  new CustomEvent("save", {
+    detail: { prompt: result.data },
+    bubbles: true,
+    composed: true,
+  }),
+);
+```
+
+### Step 9: Toast summary in `document-upload.ts`
+
+1. Add `Toast` import:
+
+```ts
+import { Toast } from "@ui/elements";
+```
+
+2. Replace the tail of `handleUpload` (from `this.uploading = false;` onward):
+
+```ts
+this.uploading = false;
+
+const succeeded = results.filter((r) => r.status === "fulfilled").length;
+const failed = results.length - succeeded;
+
+if (succeeded > 0) {
+  Toast.success(`Uploaded ${succeeded} file${succeeded === 1 ? "" : "s"}`);
+  this.dispatchEvent(
+    new CustomEvent("upload-complete", {
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}
+
+if (failed > 0) {
+  Toast.error(`Failed to upload ${failed} file${failed === 1 ? "" : "s"}`);
+}
+```
+
+Note: the existing code dispatched `upload-complete` when at least one file succeeded; preserve that semantic by guarding the dispatch inside `succeeded > 0`.
+
+## Validation Criteria
+
+- [ ] `<hd-toast-container>` renders once at the shell and disappears when no toasts are active.
+- [ ] Clicking any toast dismisses it immediately (timer cancelled, no double-dismiss error).
+- [ ] More than 5 simultaneous toasts: oldest are evicted so the stack stays at 5.
+- [ ] Bulk-delete button renders only when `selectedIds.size > 0` and sits adjacent to the bulk-classify button with red (`btn-red`) styling.
+- [ ] Clicking "Delete N Documents" opens `hd-confirm-dialog` with message "Are you sure you want to delete {N} documents?".
+- [ ] Confirm deletes all selected documents in parallel (`Promise.allSettled`), clears the succeeded IDs from selection, and fires one success toast.
+- [ ] On partial failure, each failed ID remains in `selectedIds` (its card stays checkbox-selected after grid refresh), one error toast per failed ID, and `console.error` logged per failure.
+- [ ] Cancel dismisses the bulk dialog with no side effects (selection preserved, no API call, no toast).
+- [ ] Single-card delete still works: confirm dialog with filename, refresh, now also emits a success toast.
+- [ ] Bulk classify still works and emits a success toast on each completion, error toast on each failure.
+- [ ] Prompt activate/deactivate/delete/create/update all surface success + error toasts.
+- [ ] Classification validate/update surface success + error toasts while preserving the existing inline error div.
+- [ ] Batch upload emits one success toast and/or one error toast summarizing the batch.
+- [ ] `bun run build` (inside `app/`) completes without TypeScript errors.
+- [ ] `mise run vet` passes (Go surface unchanged but verify).

--- a/.claude/context/sessions/139-bulk-delete-action-for-document-list.md
+++ b/.claude/context/sessions/139-bulk-delete-action-for-document-list.md
@@ -1,0 +1,62 @@
+# 139 - Bulk delete action for document list
+
+## Summary
+
+Added a "Delete N Documents" bulk action to the document grid, mirroring the existing "Classify N Documents" bulk action. Per the issue, per-item failures surface as error toasts and leave failed IDs selected for retry. Scope expanded at the user's direction to introduce a minimal toast service used for all command executions (API calls that mutate state); every existing mutation call site in the web client now emits success and failure toasts.
+
+A follow-up task was filed during this session (#145) to adopt native overlay primitives — `<dialog>.showModal()` for `hd-confirm-dialog`, `popover="manual"` for `hd-toast-container`, and a new `<hd-tooltip>` using `popover="hint"` — and the overlay convention is now documented in CLAUDE.md and the web-development skill.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Toast service surface | Global namespace (`Toast.success`, `Toast.error`, etc.) + `<hd-toast-container>` element | Matches existing domain-service pattern (`DocumentService.*`); element subscribes to a module-level bus so any call site can fire without importing the element |
+| Error handling for bulk delete | `Promise.all` over per-doc promises that pair `{ doc, ok, error? }` | Eliminates parallel-array index bookkeeping between ids/batch/results; a future edit that reorders one array can't silently corrupt the others |
+| Retry semantics | Failed IDs remain in `selectedIds`; successful IDs drop out | Directly matches issue acceptance criterion "leave failed IDs selected for retry" |
+| Dialog rendering | Two separate conditional `<hd-confirm-dialog>` blocks (one per state) | Clearer than overloading a single dialog with branching logic; only one renders at a time |
+| Button placement | "Delete N Documents" adjacent to "Classify N Documents" in the same conditional block | Both bulk actions share identical visibility rule (`selectedIds.size > 0`) |
+| No new CSS in `document-grid.module.css` | Reuse shared `.btn-red` from `@styles/buttons.module.css` | The issue mentioned a "Delete variant" but the existing utility already matches the card Delete styling |
+| Toast container mount point | Programmatic `document.body.appendChild` from `app.ts` after Router starts | Matches Herald's pattern (user menu is also wired dynamically); keeps `app/server/layouts/app.html` a pure shell |
+| Toast stack width | Fixed `min(72ch, calc(100dvw - var(--space-8)))` | Consistent toast width regardless of content; `ch` hugs the monospace font, `dvw` tracks the dynamic viewport |
+| Click-to-dismiss | Clicking any toast cancels its timer and removes it | Lightweight user control without inventing a close button |
+| Forms keep inline error | `classification-panel` and `prompt-form` retain their `this.error` state alongside toasts | Inline errors anchor to form context; toasts are the global feedback layer — additive, not replacement |
+
+## Files Modified
+
+**New:**
+- `app/client/ui/elements/toast.ts` — `Toast` service + `<hd-toast-container>` element
+- `app/client/ui/elements/toast.module.css` — bottom-center fixed stack + kind-specific styling
+
+**Modified:**
+- `app/client/ui/elements/index.ts` — re-export `Toast`, `ToastContainer`, `ToastItem`, `ToastKind`
+- `app/client/app.ts` — mount `<hd-toast-container>` via `document.body.appendChild`
+- `app/client/ui/modules/document-grid.ts` — `deleteDocuments` state, `handleBulkDelete`/`confirmBulkDelete`/`cancelBulkDelete`, second confirm-dialog block, bulk-delete button, toast wiring on single-delete and SSE classify callbacks
+- `app/client/ui/modules/classification-panel.ts` — toast wiring around `validate()` and `update()` (inline error retained)
+- `app/client/ui/modules/prompt-list.ts` — toast wiring around `activate`/`deactivate`/`delete`
+- `app/client/ui/modules/prompt-form.ts` — toast wiring around `create`/`update` (inline error retained)
+- `app/client/ui/modules/document-upload.ts` — batch toast summary after `Promise.allSettled`
+- `.claude/CLAUDE.md` — overlay-primitives convention under Web Client Conventions
+- `.claude/skills/web-development/SKILL.md` — new "Overlay Convention" section with decision matrix and patterns
+
+## Patterns Established
+
+- **Command-execution feedback**: Every mutation API call surfaces success + failure via `Toast.success` / `Toast.error`. Error messages follow the shape `Failed to <verb> <noun>: <result.error>`; success uses `<past-tense-verb> <noun>`.
+- **Toast service**: Module-level namespace + subscribable bus, mirroring the stateless domain-service pattern. Element mount happens in `app.ts`, not `app.html`.
+- **Promise-all with carried payload**: For bulk operations that need both `Promise.allSettled` safety and per-item context, map each input to `async (item) => ({ item, ok, error? })` inside a `try`/`catch` and iterate the outcome array once. No parallel-array zipping.
+- **Overlay primitives convention**: Any UI that overlays the page (tooltips, menus, toasts, modals) must use `<dialog>` or the Popover API — no manual `position: fixed; z-index` overlay divs. Captured in CLAUDE.md and SKILL.md; implemented across the three relevant elements in the follow-up task #145.
+
+## Validation Results
+
+- `(cd app && bun run build)` — passes, no TS errors; artifacts: `dist/app.js`, `dist/app.css`.
+- `mise run vet` — passes (Go surface unchanged, verified as a sanity check).
+- Manual verification in the browser (screenshots provided by user):
+  - Bulk delete button appears adjacent to bulk classify when ≥1 document selected.
+  - Confirm dialog renders with "Are you sure you want to delete {N} documents?".
+  - Parallel deletes complete; grid refreshes; one success toast per batch.
+  - Prompt activate/deactivate toasts observed live.
+- No automated web-client tests exist in Herald; validation is build + manual per project convention.
+
+## Known Gaps / Follow-ups
+
+- **hd-toast-container `z-index: 200`** will collide with modals once #145 lands (which moves `hd-confirm-dialog` to top-layer via `<dialog>.showModal()`). Resolved there by refactoring the stack to `popover="manual"`.
+- **Single-delete error path initially had a missing space** (`Failed to delete${filename}`) and **classification-panel update failure was missing a toast call**; both caught during closeout validation and fixed before commit.

--- a/.claude/plans/linear-wandering-journal.md
+++ b/.claude/plans/linear-wandering-journal.md
@@ -1,0 +1,179 @@
+# Issue #139 — Bulk delete action for document list
+
+## Context
+
+Post-IL6 quality-of-life work (sub-issue of objective #132). The document list already supports bulk classification via "Classify N Documents"; users should have the same bulk affordance for deletion. Single-card Delete uses `hd-confirm-dialog`; the bulk action must follow suit.
+
+The issue acceptance criteria also require **"per-item failures surface as error toasts and leave failed IDs selected for retry."** No toast/notification infrastructure currently exists in the Herald web client — mutation failures today are either silent (grid/list actions) or shown as inline error divs (forms). The user has directed that this task additionally introduce **a minimal toast service used for all command executions (API calls that mutate state)**, with the bulk-delete failure path specifically keeping `console.error` + retry retention on top of the toast surface.
+
+## Scope (broader than the issue as filed)
+
+1. **Toast infrastructure** — new `hd-toast-container` element + `Toast` service module. Mounted once at the app shell.
+2. **Wire every mutation call site** to emit a toast on success and on failure (11 sites across 5 components).
+3. **Add bulk-delete action** to `document-grid` using the new toast service + `Promise.allSettled` retry-retention semantics specified by the issue.
+
+## Architecture
+
+### Toast service
+
+File: `app/client/ui/elements/toast.ts` (co-locate element + service; same pattern as existing domain namespaces).
+
+```ts
+type ToastKind = "success" | "error" | "warning" | "info";
+interface Toast { id: string; kind: ToastKind; message: string; }
+
+// Module-level singleton bus
+// Subscribers = ToastContainer instances (usually one)
+// push() appends, schedules auto-dismiss via setTimeout
+// dismiss() removes by id and notifies subscribers
+
+export const Toast = {
+  success(message: string): void,
+  error(message: string): void,
+  warning(message: string): void,
+  info(message: string): void,
+};
+
+@customElement("hd-toast-container")
+export class ToastContainer extends LitElement { ... }
+```
+
+Design points:
+- **Auto-dismiss**: success/info = 3s, warning = 5s, error = 6s. Hover pauses dismiss (optional; skip if it bloats scope).
+- **Click-to-dismiss**: clicking a toast immediately removes it (cancels the auto-dismiss timer).
+- **Stacking**: newest at the bottom of a fixed-position column (`position: fixed; bottom: var(--space-4); right: var(--space-4);`), capped at say 5 visible; overflow removes oldest.
+- **Styling**: uses existing semantic tokens — `--green/--green-bg` (success), `--red/--red-bg` (error), `--yellow/--yellow-bg` (warning), `--blue/--blue-bg` (info). Border-left accent + monospace text, matching Herald's terminal aesthetic.
+- **Register globally**: `app/client/app.ts` imports the element (side-effect registration). Mount `<hd-toast-container></hd-toast-container>` once in `app/server/layouts/app.html` after `<main>`.
+
+### Bulk delete handler (`document-grid.ts`)
+
+Mirror the bulk-classify template block but use `btn-red` styling and route through a second `hd-confirm-dialog` instance. Introduce a new `@state() private deleteDocuments: Document[] | null` that holds the snapshot of selected documents when the dialog opens (plural mirror of the existing singular `deleteDocument: Document | null`).
+
+```ts
+private handleBulkDelete() {
+  if (!this.documents) return;
+  const selected = this.documents.data.filter((d) => this.selectedIds.has(d.id));
+  if (selected.length === 0) return;
+  this.deleteDocuments = selected;
+}
+
+private async confirmBulkDelete() {
+  const batch = this.deleteDocuments;
+  this.deleteDocuments = null;
+  if (!batch) return;
+
+  const ids = batch.map((d) => d.id);
+  const results = await Promise.allSettled(
+    ids.map((id) => DocumentService.delete(id)),
+  );
+
+  const failed = new Set<string>();
+  let succeeded = 0;
+
+  results.forEach((result, i) => {
+    const id = ids[i];
+    if (result.status === "fulfilled" && result.value.ok) {
+      succeeded++;
+    } else {
+      failed.add(id);
+      const error =
+        result.status === "rejected"
+          ? String(result.reason)
+          : result.value.error;
+      const doc = batch[i];
+      console.error(`Failed to delete document ${id}:`, error);
+      Toast.error(`Failed to delete ${doc.filename}: ${error}`);
+    }
+  });
+
+  if (succeeded > 0) {
+    Toast.success(`Deleted ${succeeded} document${succeeded === 1 ? "" : "s"}`);
+  }
+
+  this.selectedIds = failed;
+  this.fetchDocuments();
+}
+
+private cancelBulkDelete() {
+  this.deleteDocuments = null;
+}
+```
+
+Only one `hd-confirm-dialog` is open at a time (bulk vs. single), but render them as two separate conditional blocks for clarity:
+
+```html
+${this.deleteDocument
+  ? html`<hd-confirm-dialog message="Are you sure you want to delete ${this.deleteDocument.filename}?" ...></hd-confirm-dialog>`
+  : nothing}
+${this.deleteDocuments
+  ? html`<hd-confirm-dialog message="Are you sure you want to delete ${this.deleteDocuments.length} documents?" ...></hd-confirm-dialog>`
+  : nothing}
+```
+
+Button markup (placed immediately after the bulk-classify conditional block in `renderToolbar`):
+
+```html
+${this.selectedIds.size > 0
+  ? html`<button class="btn btn-red" @click=${this.handleBulkDelete}>
+      Delete ${this.selectedIds.size} Documents
+    </button>`
+  : nothing}
+```
+
+The `btn-red` class already exists in `@styles/buttons.module.css` (line 41) — **no new CSS is needed** for the button itself. The issue's mention of "Delete variant styling for the new button" in `document-grid.module.css` is satisfied by reusing the shared utility; flag this in the session summary.
+
+### Mutation-site toast wiring
+
+Convention applied uniformly:
+- **Success**: `Toast.success("<verb past tense> <noun>")` — e.g., `"Document deleted"`, `"Prompt activated"`, `"Classification validated"`.
+- **Failure**: `Toast.error(result.error ?? "Unexpected error")`.
+- **Forms** (`classification-panel`, `prompt-form`): keep the existing inline `this.error` state (used for form-validation context). Add a toast call alongside, so the global feedback surface is consistent without breaking form UX.
+- **SSE classify**: on `onComplete` fire `Toast.success("Classified <filename>")` if we can plumb the filename; otherwise `"Classified document"`. On `onError` fire `Toast.error("Classification failed")`.
+
+## Critical files
+
+| File | Change |
+|------|--------|
+| `app/client/ui/elements/toast.ts` | **NEW** — `Toast` service + `hd-toast-container` element |
+| `app/client/ui/elements/toast.module.css` | **NEW** — toast stack + item styling |
+| `app/client/ui/elements/index.ts` | Re-export `ToastContainer` (match existing barrel convention) |
+| `app/client/app.ts` | Import `toast.ts` for side-effect registration |
+| `app/server/layouts/app.html` | Mount `<hd-toast-container></hd-toast-container>` after `<main>` |
+| `app/client/ui/modules/document-grid.ts` | Add bulk-delete button, `deleteDocuments` state, `handleBulkDelete`/`confirmBulkDelete`/`cancelBulkDelete`, second confirm-dialog block, success/error toasts on all existing mutations (delete + classify) |
+| `app/client/ui/modules/classification-panel.ts` | Add `Toast.success` / `Toast.error` around `validate()` and `update()` (keep inline error) |
+| `app/client/ui/modules/prompt-list.ts` | Add `Toast.success` / `Toast.error` around `activate`/`deactivate`/`delete` |
+| `app/client/ui/modules/prompt-form.ts` | Add `Toast.success` / `Toast.error` around `create`/`update` (keep inline error) |
+| `app/client/ui/modules/document-upload.ts` | Add `Toast.success`/`Toast.error` summary after batch upload completes |
+| `app/client/ui/modules/document-grid.module.css` | **No change** — shared `btn-red` suffices |
+
+## Reused primitives (do not reinvent)
+
+- `DocumentService.delete(id)` — `app/client/domains/documents/service.ts:51` — returns `Result<void>`.
+- `hd-confirm-dialog` — `app/client/ui/elements/confirm-dialog.ts` — dispatches `confirm` / `cancel`.
+- `@styles/buttons.module.css` — `.btn`, `.btn-red`, `.btn-blue` variants already available.
+- Semantic color tokens — `--green`, `--red`, `--yellow`, `--blue` (+ `-bg` variants) in `app/client/design/core/tokens.css:40-57`.
+- `Result<T>` shape — `{ ok: true, data } | { ok: false, error: string }` — used by every non-SSE mutation.
+
+## Verification
+
+1. `mise run dev` — start the server with hot reload.
+2. **Bulk delete happy path**: upload 3–5 test PDFs from `_project/marked-documents/`, select multiple cards, click "Delete N Documents", confirm. Expect: confirm dialog with correct count, parallel deletes, grid refreshes, success toast `"Deleted N documents"`, selection cleared.
+3. **Bulk delete cancel**: open the dialog, click cancel. Expect: dialog closes, selection preserved, no API call, no toast.
+4. **Bulk delete partial failure**: simulate failure via DevTools → Network throttling with offline mode toggled mid-operation, or by deleting the same ID twice via two tabs. Expect: `console.error` entries, one error toast per failed ID, success toast for the batch total, failed IDs remain in `selectedIds` and remain checkbox-selected in the grid.
+5. **Single-card delete regression**: open a single card's Delete button, confirm. Expect: existing flow intact (dialog with filename, delete, grid refresh), now also emits a success toast.
+6. **Bulk classify regression**: select documents, click "Classify N Documents". Expect: existing SSE progress works, on completion each document emits a success toast, on error an error toast fires.
+7. **Forms**: save a prompt / validate a classification; confirm inline error state still works AND a toast appears on both success and failure.
+8. `mise run vet` — no Go vet regressions (Go surface unchanged, but run it anyway).
+9. Web client build (`cd app && bun run build`) — ensure no TS errors.
+10. No automated web-client tests exist; validation is manual-plus-typecheck per Herald conventions.
+
+## Risk notes
+
+- **Scope**: this task now touches 5 client modules beyond the originally scoped `document-grid.{ts,module.css}`. Called out here so reviewers know the expanded footprint maps to the user's "toast for all command executions" directive and not scope creep inside the AI.
+- **No new CSS in `document-grid.module.css`** despite the issue listing it — the shared `btn-red` covers it. Plan will be explicit about why.
+- **Inline form errors kept** to avoid regressing form validation UX. Toast is additive, not replacement.
+- **SSE classify toast** requires threading the filename into the callback context; if that's awkward, fall back to a generic message. Low-risk cosmetic.
+
+## CHANGELOG tag at closeout
+
+`v0.5.0-dev.132.139` (objective 132, issue 139).

--- a/.claude/skills/web-development/SKILL.md
+++ b/.claude/skills/web-development/SKILL.md
@@ -91,6 +91,41 @@ Lit lifecycle hooks and when to use each: `connectedCallback` for initial data f
 
 Single shell pattern: `app/app.go` embeds `dist/*`, `server/layouts/*`, `server/views/*`. Catch-all `/{path...}` route serves the HTML shell. Template variables: `{{ .BasePath }}`, `{{ .Title }}`, `{{ .Bundle }}`. `<base href>` tag enables client-side router path resolution.
 
+## Overlay Convention
+
+Any UI intended to overlay the page — tooltips, menus, popovers, toasts, confirmation dialogs, modal forms — MUST use browser-native top-layer primitives. Do not build overlay UI with manual `position: fixed; z-index: ...` divs. The top layer is the single source of stacking truth, so `z-index` arithmetic is eliminated and focus/Escape/backdrop behavior comes from the platform.
+
+### Decision matrix
+
+| Overlay type | Primitive | Why |
+|--------------|-----------|-----|
+| Modal dialog (confirmation, blocking form) | `<dialog>` + `.showModal()` | Top layer, built-in `::backdrop`, focus trap, Escape → `cancel` event, focus return to trigger, implicit `role="dialog"` / `aria-modal="true"`, body scroll lock |
+| Dismiss-on-outside-click menu / picker | `popover="auto"` | Light-dismiss (click anywhere outside closes), Escape closes, top layer, only one `auto` popover open at a time |
+| Tooltip / hover hint | `popover="hint"` | Semantically correct for hints. Hints do NOT close open `auto` popovers (hovering a tooltip inside an open menu leaves the menu open), but DO close other hints so only one is visible at a time. Light-dismissible and responds to close requests. Shown/hidden explicitly on `mouseenter`/`focus` + `mouseleave`/`blur`. |
+| Toast / long-lived overlay | `popover="manual"` | No light-dismiss — caller owns show/hide. Correct when outside-click dismissal would be destructive (would kill every toast on any page click) |
+
+### Patterns
+
+- **Modal dialog**: render `<dialog>` in the component template, call `.showModal()` in `firstUpdated`, wire the native `cancel` event (Escape) and backdrop click (`event.target === dialogEl`) to emit `cancel`, put `autofocus` on the primary action. Style the backdrop with the `::backdrop` pseudo-element. Drop all `z-index`.
+- **Popover stack (toast container, `popover="manual"`)**: set `popover="manual"` on the host (via `setAttribute` in `connectedCallback` or a reflected `@property`), call `.showPopover()` in `connectedCallback` after `super.connectedCallback()`, and `.hidePopover()` in `disconnectedCallback` guarded by `this.matches(":popover-open")`. Layout (position, size) stays in CSS.
+- **Anchored tooltip (`popover="hint"`)**: pair `popover="hint"` with CSS Anchor Positioning — `anchor-name` on the trigger, `position-anchor` + `inset-area` (or `top`/`bottom` with `anchor()`) + `position-try-fallbacks` on the popover — so the overlay flips above/below/left/right when space is tight. Show on `mouseenter`/`focusin`, hide on `mouseleave`/`focusout`. Detect truncation via `scrollWidth > clientWidth` so non-truncated triggers are no-ops.
+
+### Anti-patterns (do not do these)
+
+- `position: fixed; inset: 0; z-index: 100` overlay divs
+- Manual scrim-blur backdrops via a sibling element — use `::backdrop`
+- Rolling your own Escape handler, focus trap, or focus-return logic when `<dialog>.showModal()` gives all three for free
+- Setting `z-index` on overlay elements — the top layer makes it meaningless and misleads future maintainers
+- Using `popover="auto"` for tooltips — opening a tooltip over a menu would close the menu. Use `popover="hint"` for tooltips.
+
+### Reference components
+
+- `<hd-confirm-dialog>` — `<dialog>` + `.showModal()`
+- `<hd-toast-container>` — `popover="manual"`
+- `<hd-tooltip>` — `popover="hint"` + CSS anchor positioning
+
+See `references/components.md` for complete code examples of each pattern.
+
 ## Template Patterns
 
 These patterns recur across all component tiers and are worth keeping top of mind.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.5.0-dev.132.139
+
+### Web Client
+
+- Add bulk-delete action to the document grid — a "Delete N Documents" button renders adjacent to the existing bulk classify button when ≥1 document is selected, opens `hd-confirm-dialog` with "Are you sure you want to delete {N} documents?", and on confirm runs `DocumentService.delete(id)` in parallel across the selection. Successful IDs drop out of the selection, failed IDs remain selected for retry, and each failure emits an error toast with the filename + error (#139)
+- Introduce a minimal `Toast` service + `<hd-toast-container>` element in `app/client/ui/elements/toast.ts` — module-level singleton bus with `success`/`error`/`warning`/`info` helpers, kind-specific auto-dismiss (3s/6s/5s/3s), stack capped at 5 visible, click-to-dismiss cancels the timer. Stack is positioned bottom-center at a fixed `min(72ch, 100dvw - var(--space-8))` width via `margin-inline: auto`, monospace styling with semantic border-left accent matching Herald's aesthetic (#139)
+- Mount `<hd-toast-container>` from `app.ts` via `document.body.appendChild` after the Router starts — keeps `app/server/layouts/app.html` a pure server shell and matches the existing dynamic-mount pattern used for the user menu (#139)
+- Wire every existing mutation call site through the toast service so every command execution surfaces success and failure feedback: single-document delete, SSE classify `onComplete`/`onError`, bulk classify (per-document outcome via the classify callbacks), classification validate + update, prompt create/update/delete, prompt activate/deactivate, and batch document upload (summary toasts after `Promise.allSettled`). Forms (`classification-panel`, `prompt-form`) keep their inline `this.error` display for form-local context; toasts are additive (#139)
+- Establish an Overlay Convention across `.claude/CLAUDE.md` and `.claude/skills/web-development/SKILL.md`: any UI that overlays the page (tooltips, menus, popovers, toasts, confirmation dialogs, modal forms) must use native `<dialog>` + `.showModal()` or the Popover API (`popover="auto"` / `popover="hint"` / `popover="manual"`). No manual `position: fixed; z-index: ...` overlay divs. Includes a decision matrix for which primitive to pick per overlay type, patterns for each, anti-patterns, and reference components. Follow-up task #145 migrates the three existing overlays (`hd-confirm-dialog`, `hd-toast-container`, new `hd-tooltip`) to these primitives (#139)
+
 ## v0.5.0-dev.132.137
 
 ### Web Client

--- a/app/client/app.ts
+++ b/app/client/app.ts
@@ -19,6 +19,8 @@ import "@design/index.css";
   const router = new Router("app-content", routes);
   router.start();
 
+  document.body.appendChild(document.createElement("hd-toast-container"));
+
   if (Auth.isEnabled()) {
     const account = Auth.getAccount();
     const menu = document.getElementById("user-menu");

--- a/app/client/ui/elements/index.ts
+++ b/app/client/ui/elements/index.ts
@@ -5,3 +5,5 @@ export { DocumentCard } from "./document-card";
 export { MarkingsList } from "./markings-list";
 export { PaginationControls } from "./pagination-controls";
 export { PromptCard } from "./prompt-card";
+export { Toast, ToastContainer } from "./toast";
+export type { ToastItem, ToastKind } from "./toast";

--- a/app/client/ui/elements/toast.module.css
+++ b/app/client/ui/elements/toast.module.css
@@ -1,0 +1,69 @@
+.stack {
+  position: fixed;
+  bottom: var(--space-4);
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  width: min(72ch, calc(100dvw - var(--space-8)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  z-index: 200;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: block;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--divider);
+  border-left-width: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-1);
+  color: var(--color);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: break-word;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  animation: slide-in 0.15s ease-out;
+  transition: opacity 0.15s;
+}
+
+.toast:hover {
+  opacity: 0.9;
+}
+
+.toast.success {
+  border-left-color: var(--green);
+  background: var(--green-bg);
+}
+
+.toast.error {
+  border-left-color: var(--red);
+  background: var(--red-bg);
+}
+
+.toast.warning {
+  border-left-color: var(--yellow);
+  background: var(--yellow-bg);
+}
+
+.toast.info {
+  border-left-color: var(--blue);
+  background: var(--blue-bg);
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(20%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/app/client/ui/elements/toast.ts
+++ b/app/client/ui/elements/toast.ts
@@ -1,0 +1,173 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import styles from "./toast.module.css";
+
+/** Semantic category of a toast, controlling color and auto-dismiss duration. */
+export type ToastKind = "success" | "error" | "warning" | "info";
+
+/** A single toast notification as rendered by {@link ToastContainer}. */
+export interface ToastItem {
+  id: string;
+  kind: ToastKind;
+  message: string;
+}
+
+type Listener = (toasts: ToastItem[]) => void;
+
+const DURATIONS: Record<ToastKind, number> = {
+  success: 3000,
+  info: 3000,
+  warning: 5000,
+  error: 6000,
+};
+
+const MAX_VISIBLE = 5;
+
+class ToastBus {
+  private toasts: ToastItem[] = [];
+  private listeners = new Set<Listener>();
+  private timers = new Map<string, number>();
+
+  subscribe(fn: Listener): () => void {
+    this.listeners.add(fn);
+    fn(this.toasts);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  }
+
+  push(kind: ToastKind, message: string): string {
+    const id = crypto.randomUUID();
+    this.toasts = [...this.toasts, { id, kind, message }];
+
+    while (this.toasts.length > MAX_VISIBLE) {
+      const oldest = this.toasts[0];
+      this.clearTimer(oldest.id);
+      this.toasts = this.toasts.slice(1);
+    }
+
+    this.timers.set(
+      id,
+      window.setTimeout(() => this.dismiss(id), DURATIONS[kind]),
+    );
+    this.emit();
+    return id;
+  }
+
+  dismiss(id: string): void {
+    this.clearTimer(id);
+    const next = this.toasts.filter((t) => t.id !== id);
+    if (next.length === this.toasts.length) return;
+    this.toasts = next;
+    this.emit();
+  }
+
+  private clearTimer(id: string) {
+    const timer = this.timers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  private emit() {
+    for (const fn of this.listeners) fn(this.toasts);
+  }
+}
+
+const bus = new ToastBus();
+
+/**
+ * Global toast notification service. Call from any component to surface
+ * transient feedback for a command execution. Kind-specific helpers push
+ * onto the shared stack rendered by {@link ToastContainer}; `dismiss` and
+ * `subscribe` are lower-level hooks (the element uses them internally).
+ *
+ * Auto-dismiss durations: success/info 3s, warning 5s, error 6s.
+ * Stack cap: 5 visible — oldest is evicted.
+ */
+export const Toast = {
+  /** Push a success toast. Returns the toast id (rarely needed). */
+  success(message: string): string {
+    return bus.push("success", message);
+  },
+  /** Push an error toast. Returns the toast id (rarely needed). */
+  error(message: string): string {
+    return bus.push("error", message);
+  },
+  /** Push a warning toast. Returns the toast id (rarely needed). */
+  warning(message: string): string {
+    return bus.push("warning", message);
+  },
+  /** Push an info toast. Returns the toast id (rarely needed). */
+  info(message: string): string {
+    return bus.push("info", message);
+  },
+  /** Remove a specific toast early (cancels its auto-dismiss timer). */
+  dismiss(id: string): void {
+    bus.dismiss(id);
+  },
+  /** Subscribe to the toast stack. Returns an unsubscribe function. */
+  subscribe(fn: Listener): () => void {
+    return bus.subscribe(fn);
+  },
+};
+
+/**
+ * Global toast stack. Subscribes to the {@link Toast} service and renders
+ * the active queue. Mount once at the shell (see `app.ts`); additional
+ * instances will each render their own view of the same stack.
+ * Toasts dismiss on click or after their kind-specific duration.
+ */
+@customElement("hd-toast-container")
+export class ToastContainer extends LitElement {
+  static styles = [styles];
+
+  @state() private toasts: ToastItem[] = [];
+
+  private unsubscribe?: () => void;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.unsubscribe = Toast.subscribe((toasts) => {
+      this.toasts = toasts;
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+
+  private handleDismiss(id: string) {
+    Toast.dismiss(id);
+  }
+
+  render() {
+    if (this.toasts.length === 0) return nothing;
+
+    return html`
+      <div class="stack" role="status" aria-live="polite">
+        ${this.toasts.map(
+          (t) => html`
+            <button
+              type="button"
+              class="toast ${t.kind}"
+              @click=${() => this.handleDismiss(t.id)}
+            >
+              ${t.message}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hd-toast-container": ToastContainer;
+  }
+}

--- a/app/client/ui/modules/classification-panel.ts
+++ b/app/client/ui/modules/classification-panel.ts
@@ -5,6 +5,7 @@ import { formatDate } from "@core/formatting";
 import { navigate } from "@core/router";
 import { ClassificationService } from "@domains/classifications";
 import type { Classification } from "@domains/classifications";
+import { Toast } from "@ui/elements";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
@@ -84,12 +85,15 @@ export class ClassificationPanel extends LitElement {
 
     if (!result.ok) {
       this.error = result.error;
+      Toast.error(`Validation failed: ${result.error}`);
       return;
     }
 
     this.classification = result.data;
     this.mode = "view";
     this.error = "";
+
+    Toast.success("Classification validated");
 
     this.dispatchEvent(
       new CustomEvent("validate", {
@@ -122,12 +126,15 @@ export class ClassificationPanel extends LitElement {
 
     if (!result.ok) {
       this.error = result.error;
+      Toast.error(`Update failed: ${result.error}`);
       return;
     }
 
     this.classification = result.data;
     this.mode = "view";
     this.error = "";
+
+    Toast.success("Classification updated");
 
     this.dispatchEvent(
       new CustomEvent("update", {

--- a/app/client/ui/modules/document-grid.ts
+++ b/app/client/ui/modules/document-grid.ts
@@ -7,6 +7,7 @@ import { ClassificationService } from "@domains/classifications";
 import type { WorkflowStage } from "@domains/classifications";
 import { DocumentService } from "@domains/documents";
 import type { Document, SearchRequest } from "@domains/documents";
+import { Toast } from "@ui/elements";
 
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
@@ -44,6 +45,7 @@ export class DocumentGrid extends LitElement {
   @state() private classifying = new Map<string, ClassifyProgress>();
   @state() private selectedIds = new Set<string>();
   @state() private deleteDocument: Document | null = null;
+  @state() private deleteDocuments: Document[] | null = null;
 
   private searchTimer = 0;
   private abortControllers = new Map<string, AbortController>();
@@ -194,6 +196,10 @@ export class DocumentGrid extends LitElement {
         const updated = new Map(this.classifying);
         updated.delete(docId);
         this.classifying = updated;
+        const filename =
+          this.documents?.data.find((d) => d.id === docId)?.filename ??
+          "document";
+        Toast.success(`Classified ${filename}`);
         this.fetchDocuments();
       },
       onError: () => {
@@ -201,6 +207,10 @@ export class DocumentGrid extends LitElement {
         const updated = new Map(this.classifying);
         updated.delete(docId);
         this.classifying = updated;
+        const filename =
+          this.documents?.data.find((d) => d.id === docId)?.filename ??
+          "document";
+        Toast.error(`Classification failed for ${filename}`);
         this.fetchDocuments();
       },
     });
@@ -220,6 +230,7 @@ export class DocumentGrid extends LitElement {
     if (!this.deleteDocument) return;
 
     const id = this.deleteDocument.id;
+    const filename = this.deleteDocument.filename;
     this.deleteDocument = null;
 
     const result = await DocumentService.delete(id);
@@ -227,11 +238,73 @@ export class DocumentGrid extends LitElement {
     if (result.ok) {
       this.selectedIds.delete(id);
       this.fetchDocuments();
+      Toast.success(`Deleted ${filename}`);
+    } else {
+      Toast.error(`Failed to delete ${filename}: ${result.error}`);
     }
   }
 
   private cancelDelete() {
     this.deleteDocument = null;
+  }
+
+  private handleBulkDelete() {
+    if (!this.documents) return;
+
+    const selected = this.documents.data.filter((d) =>
+      this.selectedIds.has(d.id),
+    );
+    if (selected.length === 0) return;
+
+    this.deleteDocuments = selected;
+  }
+
+  private async confirmBulkDelete() {
+    const batch = this.deleteDocuments;
+    this.deleteDocuments = null;
+    if (!batch) return;
+
+    const outcomes = await Promise.all(
+      batch.map(async (doc) => {
+        try {
+          const result = await DocumentService.delete(doc.id);
+          return result.ok
+            ? { doc, ok: true as const }
+            : { doc, ok: false as const, error: result.error };
+        } catch (err) {
+          return { doc, ok: false as const, error: String(err) };
+        }
+      }),
+    );
+
+    const failed = new Set<string>();
+    let succeeded = 0;
+
+    for (const outcome of outcomes) {
+      if (outcome.ok) {
+        succeeded++;
+        continue;
+      }
+      failed.add(outcome.doc.id);
+      console.error(
+        `Failed to delete document ${outcome.doc.id}:`,
+        outcome.error,
+      );
+      Toast.error(`Failed to delete ${outcome.doc.filename}: ${outcome.error}`);
+    }
+
+    if (succeeded > 0) {
+      Toast.success(
+        `Deleted ${succeeded} document${succeeded === 1 ? "" : "s"}`,
+      );
+    }
+
+    this.selectedIds = failed;
+    this.fetchDocuments();
+  }
+
+  private cancelBulkDelete() {
+    this.deleteDocuments = null;
   }
 
   private handleBulkClassify() {
@@ -283,6 +356,9 @@ export class DocumentGrid extends LitElement {
           ? html`
               <button class="btn btn-blue" @click=${this.handleBulkClassify}>
                 Classify ${this.selectedIds.size} Documents
+              </button>
+              <button class="btn btn-red" @click=${this.handleBulkDelete}>
+                Delete ${this.selectedIds.size} Documents
               </button>
             `
           : nothing}
@@ -338,6 +414,16 @@ export class DocumentGrid extends LitElement {
                 .filename}?"
               @confirm=${this.confirmDelete}
               @cancel=${this.cancelDelete}
+            ></hd-confirm-dialog>
+          `
+        : nothing}
+      ${this.deleteDocuments
+        ? html`
+            <hd-confirm-dialog
+              message="Are you sure you want to delete ${this.deleteDocuments
+                .length} documents?"
+              @confirm=${this.confirmBulkDelete}
+              @cancel=${this.cancelBulkDelete}
             ></hd-confirm-dialog>
           `
         : nothing}

--- a/app/client/ui/modules/document-upload.ts
+++ b/app/client/ui/modules/document-upload.ts
@@ -4,6 +4,7 @@ import { customElement, state } from "lit/decorators.js";
 import { formatBytes } from "@core/formatting";
 import { DocumentService } from "@domains/documents";
 import type { UploadEntry } from "@domains/documents";
+import { Toast } from "@ui/elements";
 
 import badgeStyles from "@styles/badge.module.css";
 import buttonStyles from "@styles/buttons.module.css";
@@ -137,14 +138,21 @@ export class DocumentUpload extends LitElement {
 
     this.uploading = false;
 
-    const hasSuccess = results.some((r) => r.status === "fulfilled");
-    if (hasSuccess) {
+    const succeeded = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.length - succeeded;
+
+    if (succeeded > 0) {
+      Toast.success(`Uploaded ${succeeded} file${succeeded === 1 ? "" : "s"}`);
       this.dispatchEvent(
         new CustomEvent("upload-complete", {
           bubbles: true,
           composed: true,
         }),
       );
+    }
+
+    if (failed > 0) {
+      Toast.error(`Failed to upload ${failed} file${failed === 1 ? "" : "s"}`);
     }
   }
 
@@ -172,7 +180,6 @@ export class DocumentUpload extends LitElement {
   }
 
   private renderQueueEntry(entry: UploadEntry, index: number) {
-    const settled = entry.status === "success" || entry.status === "error";
     const editable = entry.status === "pending";
 
     return html`

--- a/app/client/ui/modules/prompt-form.ts
+++ b/app/client/ui/modules/prompt-form.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import { PromptService } from "@domains/prompts";
 import type { Prompt } from "@domains/prompts";
+import { Toast } from "@ui/elements";
 
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
@@ -91,8 +92,13 @@ export class PromptForm extends LitElement {
 
     if (!result.ok) {
       this.error = result.error ?? "An unexpected error occurred.";
+      Toast.error(
+        `Failed to ${this.isEdit ? "update" : "create"} prompt: ${this.error}`,
+      );
       return;
     }
+
+    Toast.success(`Prompt ${this.isEdit ? "updated" : "created"}`);
 
     this.dispatchEvent(
       new CustomEvent("save", {

--- a/app/client/ui/modules/prompt-list.ts
+++ b/app/client/ui/modules/prompt-list.ts
@@ -5,6 +5,7 @@ import type { PageResult } from "@core";
 import { queryParams, updateQuery } from "@core/router";
 import { PromptService } from "@domains/prompts";
 import type { Prompt, SearchRequest } from "@domains/prompts";
+import { Toast } from "@ui/elements";
 
 import buttonStyles from "@styles/buttons.module.css";
 import inputStyles from "@styles/inputs.module.css";
@@ -143,7 +144,14 @@ export class PromptList extends LitElement {
       ? await PromptService.activate(id)
       : await PromptService.deactivate(id);
 
-    if (result.ok) this.fetchPrompts();
+    if (result.ok) {
+      Toast.success(`Prompt ${active ? "activated" : "deactivated"}`);
+      this.fetchPrompts();
+    } else {
+      Toast.error(
+        `Failed to ${active ? "activate" : "deactivate"} prompt: ${result.error}`,
+      );
+    }
   }
 
   private handleDelete(e: CustomEvent<{ prompt: Prompt }>) {
@@ -154,11 +162,13 @@ export class PromptList extends LitElement {
     if (!this.deletePrompt) return;
 
     const id = this.deletePrompt.id;
+    const name = this.deletePrompt.name;
     this.deletePrompt = null;
 
     const result = await PromptService.delete(id);
 
     if (result.ok) {
+      Toast.success(`Deleted ${name}`);
       this.dispatchEvent(
         new CustomEvent("delete", {
           detail: { id },
@@ -167,6 +177,8 @@ export class PromptList extends LitElement {
         }),
       );
       this.fetchPrompts();
+    } else {
+      Toast.error(`Failed to delete ${name}: ${result.error}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a "Delete N Documents" bulk action to the document grid — mirroring the existing "Classify N Documents" button — using `Promise.all` over per-doc outcome pairs so failed IDs remain in `selectedIds` for retry and successful IDs drop out.

Expands scope (per direction during planning) to introduce a minimal `Toast` service + `<hd-toast-container>` and wire every existing mutation call site through it, so every command execution now surfaces success and failure feedback instead of silently ignoring errors (grid/list) or only displaying inline form errors.

Establishes an **Overlay Convention** in `CLAUDE.md` and the web-development skill: any UI that overlays the page must use native `<dialog>` or the Popover API, not manual `position: fixed; z-index` divs. Follow-up #145 migrates the three existing overlays (`hd-confirm-dialog`, `hd-toast-container`, new `hd-tooltip`) to these primitives.

Closes #139

## Changes

- **New**: `app/client/ui/elements/toast.{ts,module.css}` — `Toast` service (module-level bus) + `<hd-toast-container>` (subscribes, renders stack, click-to-dismiss, auto-dismiss 3s/6s/5s/3s by kind, max 5 visible).
- **Mount**: `document.body.appendChild(document.createElement("hd-toast-container"))` in `app.ts` after the Router starts — `app.html` remains a pure server shell.
- **document-grid**: new `deleteDocuments: Document[] | null` state, `handleBulkDelete`/`confirmBulkDelete`/`cancelBulkDelete`, second `<hd-confirm-dialog>` block, bulk-delete button with `btn-red` styling, toast wiring on single-delete and SSE classify.
- **Mutation toasts everywhere**: `classification-panel` (validate + update), `prompt-list` (activate/deactivate/delete), `prompt-form` (create/update), `document-upload` (batch summary). Forms keep their inline `this.error` display; toasts are additive.
- **Convention docs**: overlay bullet added to CLAUDE.md Web Client Conventions; new "Overlay Convention" section in SKILL.md with decision matrix, patterns, anti-patterns, reference components.