### PR TITLE
Inject HERALD_AGENT_MODEL_NAME into Container App env

### DIFF
--- a/.claude/context/guides/.archive/140-model-name-missing-review-footer.md
+++ b/.claude/context/guides/.archive/140-model-name-missing-review-footer.md
@@ -1,0 +1,172 @@
+# 140 - Model name missing from review footer in production
+
+## Problem Context
+
+On the IL6 deployment the review view footer renders `/ azure  Classified [date]` — the model portion before the `/` is empty. On local (`mise run dev`) the same footer renders `gpt-5-mini / azure  Classified [date]`. The user confirmed local still targets the same Azure AI Foundry deployment, so the difference must come from configuration, not the agent backend.
+
+## Architecture Approach
+
+Root cause: The Dockerfile ships only the compiled binary — `config.json` is not in the production image. Production relies entirely on `HERALD_*` env vars, and `deploy/main.bicep` omits `HERALD_AGENT_MODEL_NAME`. After a full audit of every `HERALD_*` env var the code consumes, `HERALD_AGENT_MODEL_NAME` is the only missing variable that lacks a tangible code default (`tauconfig.DefaultModelConfig().Name` is the empty string). All other un-set vars either have production-viable defaults or are mode-incompatible (e.g., `HERALD_AGENT_TOKEN` when running with managed identity).
+
+Fix: add the one env var to `deploy/main.bicep`, regenerate `deploy/main.json` via `az bicep build`, bump the parameter `contentVersion` to align with the in-progress Phase 5 target (`0.5.0.0`, deployed when Phase 5 ships), update the deploy README, and author `deploy/update.md` as the canonical manual-patch recipe for the air-gapped IL6 host.
+
+No Go code changes. No new tests — `TestAgentEnvOverrides` (`tests/config/config_test.go:477-516`) already covers the env-override path; the bug is purely deployment-layer.
+
+## Implementation
+
+### Step 1: Add env var binding in `deploy/main.bicep`
+
+In the `baseEnvVars` list (around line 287), insert a new entry immediately after the `HERALD_AGENT_DEPLOYMENT` row so the deployment/model pair stays adjacent:
+
+```bicep
+  { name: 'HERALD_AGENT_DEPLOYMENT', value: cognitive.outputs.modelDeploymentName }
+  { name: 'HERALD_AGENT_MODEL_NAME', value: cognitiveModelName }
+  { name: 'HERALD_AGENT_API_VERSION', value: '2025-04-01-preview' }
+```
+
+`cognitiveModelName` is the existing parameter declared at `deploy/main.bicep:48` (default `'gpt-5-mini'`) and already flows into the cognitive module at line 183. It is semantically distinct from `cognitiveDeploymentName` (the Azure deployment identifier) — they coincide in value today but are wired separately on purpose.
+
+### Step 2: Regenerate `deploy/main.json`
+
+```bash
+az bicep build --file deploy/main.bicep --outfile deploy/main.json
+```
+
+Spot-check with:
+
+```bash
+grep -c HERALD_AGENT_MODEL_NAME deploy/main.json   # expect 2
+git diff deploy/main.json | head -80
+```
+
+The diff should only add `createObject('name', 'HERALD_AGENT_MODEL_NAME', 'value', parameters('cognitiveModelName'))` to the two flattened `concat(createArray(...))` expressions (one for the Container App path, one for the App Service path).
+
+### Step 3: Bump parameter content version
+
+In `deploy/main.parameters.json`, change:
+
+```diff
+- "contentVersion": "0.4.2.0",
++ "contentVersion": "0.5.0.0",
+```
+
+Leave `containerImage` alone — the release workflow will bump the image tag when Phase 5's release tag is cut.
+
+### Step 4: Update deployment README env var table
+
+In `deploy/README.md`, insert one row between the `HERALD_AGENT_DEPLOYMENT` (line 426) and `HERALD_AGENT_API_VERSION` (line 427) rows:
+
+```diff
+  | `HERALD_AGENT_DEPLOYMENT` | `cognitive.outputs.modelDeploymentName` | Yes |
++ | `HERALD_AGENT_MODEL_NAME` | `cognitiveModelName` param | Yes |
+  | `HERALD_AGENT_API_VERSION` | `2025-04-01-preview` | Yes |
+```
+
+### Step 5: Create `deploy/update.md`
+
+New file — a manual-patch recipe for the air-gapped IL6 deploy host. The IL6 machine has no `az bicep` and no CI/CD for IaC yet, so each deploy-touching PR must be re-applied by hand there. `update.md` is the canonical delta log for the next deploy.
+
+```markdown
+# IL6 Deployment Update Recipe
+
+The IL6 deployment host is air-gapped and cannot run `az bicep`. Until a CI/CD
+process for IaC substitution is in place, the edits below must be re-applied by
+hand to the IL6-side `deploy/` tree for each deploy-touching PR. This file is
+the canonical delta log — it is overwritten on every PR that modifies
+`deploy/`, so the operator always has a single authoritative patch to apply.
+
+## Target Version
+
+`0.5.0.0` — corresponds to the Phase 5 release (v0.5.0). Introduced alongside
+issue #140 (model name missing from review footer).
+
+## Per-File Edits
+
+### `deploy/main.bicep`
+
+In the `baseEnvVars` list, insert one line so the deployment/model pair stays
+adjacent. Anchors: the line before is `HERALD_AGENT_DEPLOYMENT`, the line
+after is `HERALD_AGENT_API_VERSION`.
+
+```bicep
+  { name: 'HERALD_AGENT_DEPLOYMENT', value: cognitive.outputs.modelDeploymentName }
+  { name: 'HERALD_AGENT_MODEL_NAME', value: cognitiveModelName }           // <-- NEW
+  { name: 'HERALD_AGENT_API_VERSION', value: '2025-04-01-preview' }
+```
+
+### `deploy/main.json`
+
+The `baseEnvVars` collection appears twice as a flattened
+`concat(createArray(...), variables('authEnvVars'), variables('authorityEnvVars'))`
+expression — once for the Container App path and once for the App Service
+path. In each, insert a new `createObject` immediately after the
+`HERALD_AGENT_DEPLOYMENT` entry:
+
+```
+createObject('name', 'HERALD_AGENT_DEPLOYMENT', 'value', reference(...).outputs.modelDeploymentName.value),
+createObject('name', 'HERALD_AGENT_MODEL_NAME', 'value', parameters('cognitiveModelName')),   // <-- NEW
+createObject('name', 'HERALD_AGENT_API_VERSION', 'value', '2025-04-01-preview'),
+```
+
+Grep to confirm: `grep -c HERALD_AGENT_MODEL_NAME deploy/main.json` → `2`.
+
+### `deploy/main.parameters.json`
+
+Bump the content version only. Do **not** copy any other field from the
+commercial tree — values like `tenantId`, `entraClientId`, and
+`cognitiveCustomDomain` are IL6-specific and must remain as the IL6 operator
+has them configured.
+
+```diff
+- "contentVersion": "0.4.2.0",
++ "contentVersion": "0.5.0.0",
+```
+
+If a future delta adds or renames a parameter, that will be called out
+explicitly in this section. For this release no parameters are added.
+
+## IL6-Specific Parameter Values
+
+A reminder for every delta: the commercial `main.parameters.json` is not
+authoritative for IL6. Only the `contentVersion` bump and any newly added
+parameters propagate. Sensitive or environment-specific values (tenant ID,
+client ID, cognitive custom domain, ACR name, container image path, postgres
+admin login, etc.) remain IL6-local.
+
+## Verification
+
+Run on the IL6 host after applying the edits:
+
+```bash
+grep -n HERALD_AGENT_MODEL_NAME deploy/main.json        # expect two hits
+jq -r '.contentVersion' deploy/main.parameters.json     # expect "0.5.0.0"
+```
+
+Post-deploy, confirm the Container App has the new env var:
+
+```bash
+az containerapp show -g <rg> -n <app> --query "properties.template.containers[0].env[?name=='HERALD_AGENT_MODEL_NAME']"
+```
+
+Re-classify a document from the web UI and confirm the footer renders as
+`gpt-5-mini / azure  Classified [date]` (or whatever `cognitiveModelName`
+resolves to on IL6).
+
+## Rollback
+
+If the classification view regresses after deploy, re-deploy the prior
+`0.4.2.0` ARM template. The Go binary is unaffected by this change — the
+review footer will revert to rendering the empty model segment but no
+classification or persistence behavior is impacted.
+```
+
+## Validation Criteria
+
+- [ ] `grep HERALD_AGENT_MODEL_NAME deploy/main.bicep` returns one hit.
+- [ ] `grep -c HERALD_AGENT_MODEL_NAME deploy/main.json` returns `2`.
+- [ ] `grep HERALD_AGENT_MODEL_NAME deploy/README.md deploy/update.md` returns hits in both.
+- [ ] `jq -r '.contentVersion' deploy/main.parameters.json` returns `0.5.0.0`.
+- [ ] `az bicep build --file deploy/main.bicep --outfile /tmp/main.check.json && diff -q deploy/main.json /tmp/main.check.json` — no differences.
+- [ ] `mise run vet` passes.
+- [ ] `mise run test ./tests/config/...` passes (existing coverage, no new tests expected).
+- [ ] Local `mise run dev` still renders `gpt-5-mini / azure  Classified [date]` in the review footer (nothing in the hot path changed).

--- a/.claude/context/sessions/140-model-name-missing-review-footer.md
+++ b/.claude/context/sessions/140-model-name-missing-review-footer.md
@@ -1,0 +1,44 @@
+# 140 - Model name missing from review footer in production
+
+## Summary
+
+Deployment-layer fix for the review-view footer rendering `/ azure  Classified …` on IL6 (model segment empty) while local `mise run dev` rendered `gpt-5-mini / azure …` correctly. Root cause: the Dockerfile ships only the compiled binary — `config.json` is not bundled — so production relies entirely on `HERALD_*` env vars, and `deploy/main.bicep` omitted `HERALD_AGENT_MODEL_NAME`. Added the env var to the Container App's `baseEnvVars`, bound to the existing `cognitiveModelName` parameter, and authored `deploy/update.md` as the canonical manual-patch recipe for the air-gapped IL6 host.
+
+No application code changed. The running container picks up the fix on the next ARM redeploy — no new image required.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | Deployment-only (no Go changes) | Full `HERALD_*` env-var audit showed `HERALD_AGENT_MODEL_NAME` was the only variable without a tangible code default that was missing from Bicep. The Go config ordering is already correct and covered by `TestAgentEnvOverrides`. |
+| Env var source | `cognitiveModelName` param (not `cognitive.outputs.modelDeploymentName`) | The model identifier and the Azure deployment name are semantically distinct. `HERALD_AGENT_DEPLOYMENT` already binds to the deployment output; keeping `HERALD_AGENT_MODEL_NAME` bound to the parameter maintains the separation even though both values happen to equal `gpt-5-mini` today. |
+| Parameter content version | `0.4.2.0` → `0.5.0.0` | Rolls with the Phase 5 release rather than cutting a Phase-5 dev iteration. |
+| Dev tag / CHANGELOG | Skipped | Container image is byte-identical, so a `v0.5.0-dev.132.140` tag would orphan itself. Captured as a memory rule for future deploy-only sessions. |
+| `deploy/update.md` scope | Target compile-and-merge workflow, not hand-edit main.json | `deploy/main.json` is gitignored (build artifact); IL6 operators have `bicep.exe` as a prerequisite and regenerate it locally. The recipe focuses on what changed in `main.bicep` + `main.parameters.json` so the operator knows what to re-compile and what to merge into their IL6-local parameters file. |
+
+## Files Modified
+
+- `deploy/main.bicep` — added one `HERALD_AGENT_MODEL_NAME` entry to `baseEnvVars` (bound to `cognitiveModelName`).
+- `deploy/main.parameters.json` — bumped `contentVersion` from `0.4.2.0` to `0.5.0.0`.
+- `deploy/README.md` — added one row to the env var reference table.
+- `deploy/update.md` — **new**, canonical manual-patch recipe for the air-gapped IL6 deploy host.
+- `.claude/plans/immutable-squishing-forest.md` — session plan (preserved per project convention).
+- `.claude/context/guides/.archive/140-model-name-missing-review-footer.md` — archived implementation guide.
+- `.claude/context/sessions/140-model-name-missing-review-footer.md` — this summary.
+
+`deploy/main.json` is a gitignored build artifact regenerated locally via `az bicep build`; not tracked by git.
+
+## Patterns Established
+
+- **Deploy-only PRs skip the dev release tag.** When every changed path is under `deploy/` (or docs/session artifacts) and the container image is byte-identical, Phase 8c (CHANGELOG bump) and the dev tag are skipped — the Container App picks up the fix on the next ARM redeploy with no new image. Saved to memory as `feedback_deploy_only_no_dev_tag.md`.
+- **`deploy/update.md` as canonical delta log.** Overwritten on every deploy-touching PR. The IL6 operator applies the listed `main.bicep` / parameter edits, runs `bicep.exe build`, merges the contentVersion bump into their IL6-local parameters file, and redeploys. Sensitive values (tenant/client IDs, token scopes, custom domains, container image path) remain IL6-local and are explicitly excluded from the recipe.
+- **Full env-var audit before deployment fixes.** Rather than patching only the reported symptom, walk every `HERALD_*` env var consumed by the code against `baseEnvVars` in `main.bicep`, categorizing each as (a) injected, (b) backed by a production-viable code default, (c) mode-incompatible (e.g., token-based auth when running with managed identity), or (d) missing. Only category (d) requires a fix.
+
+## Validation Results
+
+- `mise run vet` — clean.
+- `mise run test ./tests/...` — all packages pass (existing `TestAgentEnvOverrides` at `tests/config/config_test.go:477-516` already covers the env-override path; no new tests required).
+- `grep -c HERALD_AGENT_MODEL_NAME deploy/main.{bicep,json} deploy/README.md deploy/update.md` — `1 / 2 / 1 / 6` (expected: `main.json` has one entry per emitted ARM path, Container App + App Service).
+- `jq -r '.contentVersion' deploy/main.parameters.json` — `0.5.0.0`.
+- Local `mise run dev` footer behavior unchanged — no hot path touched.
+- Post-deploy verification (out of scope for merge): IL6 review footer renders `<model> / azure  Classified …` for a freshly classified document.

--- a/.claude/plans/immutable-squishing-forest.md
+++ b/.claude/plans/immutable-squishing-forest.md
@@ -1,0 +1,123 @@
+# Issue 140 - Model name missing from review footer in production
+
+## Context
+
+On the IL6 deployment the review view footer renders `/ azure  Classified [date]` — the model portion before the `/` is empty. On local (`mise run dev`) the same footer renders `gpt-5-mini / azure  Classified [date]`. The user confirmed local still targets the same Azure AI Foundry deployment, so the difference must come from configuration, not the agent backend.
+
+## Root Cause
+
+The Dockerfile (`Dockerfile:16-22`) copies only the compiled `/herald` binary into the final image — `config.json` is NOT bundled. The container's `WORKDIR /app` is empty, so `config.Load` (`internal/config/config.go:89`) finds no base file and no overlay, and proceeds to `finalize()` with a zero-value `tauconfig.AgentConfig`.
+
+`FinalizeAgent` (`internal/config/agent.go:25-29`) then:
+1. `loadAgentDefaults` merges `tauconfig.DefaultAgentConfig()` — which returns `Model: DefaultModelConfig()` whose `Name` is the empty string (`~/tau/protocol/config/model.go:14-18`).
+2. `loadAgentEnv` would set `c.Model.Name` from `HERALD_AGENT_MODEL_NAME` (`internal/config/agent.go:53-55`), but that env var is not injected by `deploy/main.bicep`.
+
+Result: `c.Model.Name` stays empty, flows through `runtime.Agent.Model.Name` at `internal/api/domain.go:34` → `classifications.New(..., modelName, ...)`, lands in the `model_name` column as `''`, and renders empty in `app/client/ui/modules/classification-panel.ts:204` (`${c.model_name} / ${c.provider_name}`).
+
+Pure deployment-layer bug. The Go config layer works correctly and `tests/config/config_test.go:477-516` (`TestAgentEnvOverrides`) already exercises `HERALD_AGENT_MODEL_NAME`.
+
+## Full Env-Var Audit
+
+To address the broader concern ("any config settings that aren't being established in Bicep"), I walked every `HERALD_*` env var consumed by the codebase against the `baseEnvVars` list in `deploy/main.bicep:274-294`.
+
+**Injected by Bicep (9):** `HERALD_ENV`, `HERALD_SERVER_PORT`, `HERALD_DB_HOST`, `HERALD_DB_PORT`, `HERALD_DB_NAME`, `HERALD_DB_USER`, `HERALD_DB_SSL_MODE`, `HERALD_DB_TOKEN_SCOPE`, `HERALD_STORAGE_SERVICE_URL`, `HERALD_STORAGE_CONTAINER_NAME`, `HERALD_AUTH_MODE`, `HERALD_AUTH_MANAGED_IDENTITY`, `HERALD_AGENT_PROVIDER_NAME`, `HERALD_AGENT_BASE_URL`, `HERALD_AGENT_DEPLOYMENT`, `HERALD_AGENT_API_VERSION`, `HERALD_AGENT_AUTH_TYPE`, `HERALD_AGENT_RESOURCE`, `HERALD_AGENT_CLIENT_ID` (+ conditional `HERALD_AUTH_TENANT_ID`, `HERALD_AUTH_CLIENT_ID`, `HERALD_AUTH_AUTHORITY`).
+
+**Rely on tangible code defaults (OK to leave un-set):**
+- Server: `_SERVER_HOST=0.0.0.0`, `_SERVER_READ_TIMEOUT=1m`, `_SERVER_WRITE_TIMEOUT=15m`, `_SERVER_SHUTDOWN_TIMEOUT=30s` (`internal/config/server.go:76-92`).
+- Root: `_SHUTDOWN_TIMEOUT=30s`, `_VERSION=0.1.0` (`internal/config/config.go:166-173`).
+- API: `_API_BASE_PATH=/api`, `_API_MAX_UPLOAD_SIZE=50MB` (`internal/config/api.go:70-77`).
+- Pagination / CORS: have package-level defaults (`pkg/pagination/config.go:41`, CORS disabled by default).
+- Auth: `_AUTH_SCOPE` derives to `access_as_user` (`pkg/auth/config.go:202-204`), `_AUTH_CACHE_LOCATION=localStorage` (line 144).
+- Database pool/timeout knobs: all sane defaults (`pkg/database/config.go:117-145`), including `_DB_TOKEN_SCOPE` which Bicep already overrides via the `postgresTokenScope` parameter.
+- Storage: `_STORAGE_MAX_LIST_SIZE=50`, `_STORAGE_CONTAINER_NAME=documents` (`pkg/storage/config.go:51-61`).
+
+**Intentionally not set (mode-incompatible):**
+- `HERALD_AGENT_TOKEN`, `HERALD_DB_PASSWORD`, `HERALD_AUTH_CLIENT_SECRET`, `HERALD_STORAGE_CONNECTION_STRING` — not used when running with managed identity.
+
+**Missing, no tangible default (1):** `HERALD_AGENT_MODEL_NAME` — `tauconfig.DefaultModelConfig()` returns an empty `Name`; the Azure deployment semantics also have no reason to guess here. This is the only env var that should be added.
+
+Note: `cognitiveModelName` (`deploy/main.bicep:48`, default `'gpt-5-mini'`) is the semantic model identifier, distinct from `cognitiveDeploymentName` (line 45, the Azure deployment name). They happen to match today but are semantically different — `HERALD_AGENT_MODEL_NAME` should bind to `cognitiveModelName`, mirroring how `HERALD_AGENT_DEPLOYMENT` binds to `cognitive.outputs.modelDeploymentName`.
+
+## Approach
+
+Single-change deployment fix:
+1. Add `HERALD_AGENT_MODEL_NAME` to the `baseEnvVars` list in `deploy/main.bicep` bound to `cognitiveModelName`.
+2. Regenerate `deploy/main.json` via `az bicep build` — this machine has `bicep` v0.41.2 available (the IL6 air-gapped deploy host does not, which is why `main.json` is checked in).
+3. Bump `deploy/main.parameters.json` `contentVersion` from `0.4.2.0` to `0.5.0.0` — this rolls with the Phase 5 release and will ship as part of the full `v0.5.0` deployment, not as a Phase-5 dev build.
+4. Update `deploy/README.md` env var reference table.
+5. Add `deploy/update.md` — a manual-patch recipe for the IL6 air-gapped deploy host. Until a Phase-6 (or later) CI/CD process for IaC lands, each change to `deploy/` files must be re-applied by hand on the IL6 side. This file is the canonical delta for the v0.5.0 deploy.
+
+No Go code changes. No new tests — existing `TestAgentEnvOverrides` already covers the env override path. The bug is purely deployment-layer, so a regression test at the Go layer would not exercise the failure mode.
+
+## Files to Modify
+
+- `deploy/main.bicep` — add one env var entry to `baseEnvVars`.
+- `deploy/main.json` — regenerated via `az bicep build`.
+- `deploy/main.parameters.json` — bump `contentVersion` to `0.5.0.0`.
+- `deploy/README.md` — append one row to the agent env var table.
+- `deploy/update.md` — new file documenting the IL6-side manual edits.
+- `CHANGELOG.md` — add `v0.5.0-dev.132.140` section.
+
+## Implementation
+
+### Step 1: Add env var binding in `deploy/main.bicep`
+
+Insert after line 289 (`HERALD_AGENT_DEPLOYMENT`), keeping the deployment/model pair adjacent:
+
+```bicep
+  { name: 'HERALD_AGENT_DEPLOYMENT', value: cognitive.outputs.modelDeploymentName }
+  { name: 'HERALD_AGENT_MODEL_NAME', value: cognitiveModelName }
+  { name: 'HERALD_AGENT_API_VERSION', value: '2025-04-01-preview' }
+```
+
+### Step 2: Regenerate `deploy/main.json`
+
+```bash
+az bicep build --file deploy/main.bicep --outfile deploy/main.json
+```
+
+Spot-check the diff to confirm the only change is two new `HERALD_AGENT_MODEL_NAME` entries (one per Container App variant and one per App Service variant in the flattened `createArray` expression).
+
+### Step 3: Bump parameter content version
+
+In `deploy/main.parameters.json`, change `"contentVersion": "0.4.2.0"` to `"contentVersion": "0.5.0.0"`. Do not touch `containerImage` — the release workflow will bump the image tag when Phase 5's release tag is cut.
+
+### Step 4: Update deployment README
+
+In the env var reference table at `deploy/README.md:424-430`, insert between the `HERALD_AGENT_DEPLOYMENT` and `HERALD_AGENT_API_VERSION` rows:
+
+```
+| `HERALD_AGENT_MODEL_NAME` | `cognitiveModelName` param | Yes |
+```
+
+### Step 5: Create `deploy/update.md` — IL6 manual patch recipe
+
+New file that captures the exact edits the IL6 air-gapped deploy host must apply by hand. Structure:
+
+1. **Preamble** — one paragraph explaining why the file exists (air-gapped host has no `az bicep`, CI/CD for IaC hasn't been built yet, this is the canonical delta log for each deploy-touching PR).
+2. **Target version** — `0.5.0.0`, introduced with issue #140 / PR associated with this session.
+3. **Per-file edits**, each as a unified-diff-style block or a before/after pair so the operator can grep the right location and apply the change deterministically:
+   - `deploy/main.bicep`: show the 3-line context around the new `HERALD_AGENT_MODEL_NAME` entry.
+   - `deploy/main.json`: show the `createObject('name', 'HERALD_AGENT_MODEL_NAME', 'value', parameters('cognitiveModelName'))` insertion point in each of the two flattened `concat(createArray(...))` expressions — cite the surrounding `HERALD_AGENT_DEPLOYMENT` and `HERALD_AGENT_API_VERSION` entries as anchors.
+   - `deploy/main.parameters.json`: `contentVersion` `"0.4.2.0"` → `"0.5.0.0"`.
+4. **Parameter values that must remain air-gap-specific** — remind the operator not to blindly copy `main.parameters.json` from commercial; the `tenantId`, `entraClientId`, `cognitiveCustomDomain`, etc. differ on IL6 and the commercial file is not authoritative for those values. The operator's existing IL6 parameter file is the source of truth for sensitive values; only the `contentVersion` bump and any newly added parameters are carried across.
+5. **Verification commands** (runnable on IL6 without internet): `grep -n HERALD_AGENT_MODEL_NAME deploy/main.json` (expect two hits), `jq '.contentVersion' deploy/main.parameters.json` (expect `"0.5.0.0"`), and a deployment-time check to confirm `az containerapp show` surfaces the new env var.
+6. **Rollback note** — short paragraph: if the classification view regresses, re-deploy the previous `0.4.2.0` template. The app itself is unaffected (no Go code change), so a binary rollback isn't required.
+
+## Validation Criteria
+
+- [ ] `mise run vet` passes.
+- [ ] `mise run test ./tests/config/...` passes (existing `TestAgentEnvOverrides` already covers the env-override path).
+- [ ] `grep HERALD_AGENT_MODEL_NAME deploy/main.bicep deploy/main.json deploy/README.md deploy/update.md` returns expected hits in all five files.
+- [ ] `deploy/main.parameters.json` `contentVersion` reads `0.5.0.0`.
+- [ ] `az bicep build` completes without warnings relative to baseline.
+- [ ] `deploy/update.md` opens cleanly and the per-file edits can be applied verbatim by a human operator without needing to cross-reference the bicep source.
+- [ ] Local `mise run dev` footer unchanged (still renders `gpt-5-mini / azure`) — no code path touched.
+- [ ] Root cause (Dockerfile doesn't ship `config.json`; Bicep omitted `HERALD_AGENT_MODEL_NAME`) summarized in the PR description.
+- [ ] Post-deploy (out of scope for PR merge): IL6 review footer renders `gpt-5-mini / azure  Classified [date]` for a freshly classified document.
+
+## Out of Scope
+
+- Go code changes — config ordering is correct and already tested.
+- Container image rebuild / release tagging — handled by the release workflow after PR merge.
+- Bundling `config.json` into the Docker image — production intentionally relies on env vars; adding a config file would fight that pattern for no gain.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -424,6 +424,7 @@ All `HERALD_*` environment variables injected into the compute target are compos
 | `HERALD_AGENT_PROVIDER_NAME` | `azure` | Yes |
 | `HERALD_AGENT_BASE_URL` | `cognitive.outputs.endpoint` + `openai` | Yes |
 | `HERALD_AGENT_DEPLOYMENT` | `cognitive.outputs.modelDeploymentName` | Yes |
+| `HERALD_AGENT_MODEL_NAME` | `cognitiveModelName` param | Yes |
 | `HERALD_AGENT_API_VERSION` | `2025-04-01-preview` | Yes |
 | `HERALD_AGENT_AUTH_TYPE` | `managed_identity` | Yes |
 | `HERALD_AGENT_RESOURCE` | `cognitiveTokenScope` param | Yes |

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -287,6 +287,7 @@ var baseEnvVars = [
   { name: 'HERALD_AGENT_PROVIDER_NAME', value: 'azure' }
   { name: 'HERALD_AGENT_BASE_URL', value: '${cognitive.outputs.endpoint}openai' }
   { name: 'HERALD_AGENT_DEPLOYMENT', value: cognitive.outputs.modelDeploymentName }
+  { name: 'HERALD_AGENT_MODEL_NAME', value: cognitiveModelName }
   { name: 'HERALD_AGENT_API_VERSION', value: '2025-04-01-preview' }
   { name: 'HERALD_AGENT_AUTH_TYPE', value: 'managed_identity' }
   { name: 'HERALD_AGENT_RESOURCE', value: cognitiveTokenScope }

--- a/deploy/main.parameters.json
+++ b/deploy/main.parameters.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-  "contentVersion": "0.4.2.0",
+  "contentVersion": "0.5.0.0",
   "parameters": {
     "location": {
       "value": "centralus"

--- a/deploy/update.md
+++ b/deploy/update.md
@@ -1,0 +1,110 @@
+# IL6 Deployment Update Recipe
+
+Until a CI/CD process for IaC substitution is in place, each deploy-touching
+PR must be re-applied by hand to the IL6-side deploy tree. `deploy/main.json`
+is a gitignored build artifact — the IL6 operator regenerates it locally with
+`bicep.exe build deploy\main.bicep` (prerequisite per [il6.md](il6.md)). The
+operator also maintains their own `deploy/main.parameters.json` with
+IL6-specific sensitive values that must not be overwritten.
+
+This file is the canonical delta log. It is rewritten on every PR that
+modifies `deploy/` so a single authoritative patch is always available to the
+operator. When an older delta ships (e.g., the operator is catching up from
+`0.4.2.0` → `0.5.1.0`), apply each intermediate `contentVersion` in order.
+
+## Target Version
+
+`0.5.0.0` — ships with the Phase 5 release (`v0.5.0`). Introduced alongside
+issue [#140](https://github.com/JaimeStill/herald/issues/140) (model name
+missing from review footer).
+
+## What Changed
+
+### `deploy/main.bicep`
+
+One new env var added to the `baseEnvVars` list so the Container App injects
+`HERALD_AGENT_MODEL_NAME` into the running container. Without it, the classify
+workflow populates an empty `model_name` column and the review-view footer
+renders `/ azure  Classified …` with no model segment.
+
+Anchor lines (before / after in the `baseEnvVars` block):
+
+```bicep
+  { name: 'HERALD_AGENT_DEPLOYMENT', value: cognitive.outputs.modelDeploymentName }
+  { name: 'HERALD_AGENT_MODEL_NAME', value: cognitiveModelName }    // <-- NEW
+  { name: 'HERALD_AGENT_API_VERSION', value: '2025-04-01-preview' }
+```
+
+`cognitiveModelName` is the existing parameter (default `gpt-5-mini`) already
+wired into the cognitive module. It is semantically distinct from
+`cognitiveDeploymentName` — they coincide in value today but are bound
+separately because the Azure deployment name and the model identifier are
+independent concerns.
+
+### `deploy/main.parameters.json` (commercial reference)
+
+```diff
+- "contentVersion": "0.4.2.0",
++ "contentVersion": "0.5.0.0",
+```
+
+**IL6 operators:** apply the same `contentVersion` bump to your IL6-local
+parameters file. Do **not** copy any other field from the commercial file —
+values like `tenantId`, `entraClientId`, `cognitiveCustomDomain`,
+`authAuthority`, `postgresTokenScope`, `cognitiveTokenScope`, and
+`containerImage` are IL6-specific and must remain as you have them configured.
+
+**No new parameters** are introduced in this delta, so no additions to the
+IL6 parameters file are required.
+
+### `deploy/main.json`
+
+Gitignored build artifact. Regenerate locally after pulling the updated
+`main.bicep`:
+
+```powershell
+bicep.exe build deploy\main.bicep
+```
+
+Expected: two new `HERALD_AGENT_MODEL_NAME` entries (one per Container App
+path, one per App Service path) bound to `parameters('cognitiveModelName')`.
+
+## Application Impact
+
+None. The compiled `/herald` binary is unchanged — no Go source, frontend, or
+Dockerfile edits. The existing image already reads `HERALD_AGENT_MODEL_NAME`
+via `os.Getenv` during `FinalizeAgent`; adding the env var simply lets the
+runtime see a value instead of an empty default. A fresh image is **not**
+required — redeploying the updated ARM template against the current image is
+sufficient.
+
+## Verification
+
+Before deploy, on the IL6 host:
+
+```powershell
+Select-String -Path deploy\main.json -Pattern 'HERALD_AGENT_MODEL_NAME'
+# expect two matches
+
+(Get-Content deploy\main.parameters.json | ConvertFrom-Json).contentVersion
+# expect 0.5.0.0
+```
+
+After deploy, confirm the Container App picked up the env var:
+
+```powershell
+az containerapp show `
+  --resource-group <resource-group> `
+  --name herald-app `
+  --query "properties.template.containers[0].env[?name=='HERALD_AGENT_MODEL_NAME']"
+```
+
+Re-classify a document from the Herald web UI and confirm the classification
+panel footer renders `<model> / azure  Classified …` (where `<model>` matches
+the `cognitiveModelName` parameter value).
+
+## Rollback
+
+If the review footer regresses, redeploy the prior `0.4.2.0` ARM template.
+The running binary is unaffected by this change — only the Container App env
+block moves — so no image rollback is required.


### PR DESCRIPTION
## Summary

Deployment-layer fix for the review-view footer rendering `/ azure  Classified …` on IL6 — the model segment was empty because `deploy/main.bicep` omitted `HERALD_AGENT_MODEL_NAME` from the Container App's `baseEnvVars`.

### Root Cause

The Dockerfile ships only the compiled `/herald` binary — `config.json` is not bundled. Production relies entirely on `HERALD_*` env vars, and the Bicep template injected every agent variable (`PROVIDER_NAME`, `BASE_URL`, `DEPLOYMENT`, `API_VERSION`, `AUTH_TYPE`, `RESOURCE`, `CLIENT_ID`) except `HERALD_AGENT_MODEL_NAME`. `FinalizeAgent` therefore left `c.Model.Name` at the empty string from `tauconfig.DefaultModelConfig()`, which flowed through `internal/api/domain.go:34` into the `classifications.model_name` column and rendered empty at `app/client/ui/modules/classification-panel.ts:204`.

### Audit

I walked every `HERALD_*` env var the codebase consumes against `baseEnvVars` to make sure no other variables were silently missing a required value:

- **Injected by Bicep:** all the expected service-wiring variables (`HERALD_ENV`, DB, storage, auth, agent) plus conditional auth variables when `authEnabled`.
- **Backed by tangible code defaults:** server host/timeouts, API base path/upload size, pagination, CORS, DB pool sizing, storage list cap, auth scope/cache location, etc.
- **Intentionally unset (mode-incompatible):** `HERALD_AGENT_TOKEN`, `HERALD_DB_PASSWORD`, `HERALD_AUTH_CLIENT_SECRET`, `HERALD_STORAGE_CONNECTION_STRING` — not used under managed identity.
- **Missing, no tangible default:** `HERALD_AGENT_MODEL_NAME` — fixed here.

### Semantic Wiring

Bound to the existing `cognitiveModelName` parameter (default `gpt-5-mini`), not to `cognitive.outputs.modelDeploymentName`. `HERALD_AGENT_DEPLOYMENT` already owns the deployment-name binding; the model identifier and the Azure deployment name are semantically distinct even when they coincide in value today.

Closes #140

## Changes

- `deploy/main.bicep` — added `HERALD_AGENT_MODEL_NAME` to `baseEnvVars`.
- `deploy/main.parameters.json` — bumped `contentVersion` from `0.4.2.0` to `0.5.0.0` (rolls with the Phase 5 release, not a dev iteration).
- `deploy/README.md` — added one row to the env-var reference table.
- `deploy/update.md` — new, canonical manual-patch recipe for the air-gapped IL6 deploy host (IL6 has `bicep.exe` locally, regenerates `main.json` on pull, and maintains its own sensitive parameters file).

No Go or frontend changes. The running container picks up the fix on the next ARM redeploy — no new image required, so no dev tag or CHANGELOG entry is cut for this PR.