### PR TITLE
Tune classification workflow prompts for policy-aligned marking aggregation

### DIFF
--- a/.claude/context/confidence-overhaul.md
+++ b/.claude/context/confidence-overhaul.md
@@ -1,0 +1,141 @@
+# Confidence Scoring Overhaul
+
+Initialization brief for the next development session. Branch from `main` after the
+`policy-alignment-tuning` PR (this session's classification-accuracy work) merges.
+
+## Context
+
+The prior session (`policy-alignment-tuning`) retuned the classification workflow prompts and
+restored classification-string accuracy across `_project/marked-documents/` after the gpt-5-mini →
+gpt-5.2 model change. During validation, **confidence scoring** surfaced as a separate, structural
+weakness that prompt tweaks could not reliably fix — it is deferred to this session.
+
+Concrete symptom that motivated this work: `single-secret-noforn-split.pdf` (single page, a clearly
+legible top `SECRET` banner plus a near-illegible faded `NOFORN` stamp at the bottom) produced
+wildly inconsistent results across identical runs — `SECRET (HIGH)`, `UNCLASSIFIED (LOW)`,
+`SECRET (HIGH)`, `UNCLASSIFIED (LOW)` — and never the correct `SECRET (LOW, flag for review)`.
+
+## Root cause (the structural problem)
+
+Confidence is decided in the wrong stage:
+
+- **`classify` and `enhance` are Vision calls** — they are the only stages that see the pixels, so
+  they are the only stages that *can* judge legibility. Their response structs (`pageResponse`,
+  `enhanceResponse`) emit **no confidence signal** — only `markings_found` + `rationale`.
+- **`finalize` is a Chat call with no images** (`internal/workflow/finalize.go:59`, `a.Chat`). It is
+  the *only* stage that sets confidence, and it does so purely from the serialized text. It is
+  inferring legibility from prose descriptions of markings it never saw.
+
+So confidence is a guess-about-a-guess produced by the one stage structurally blind to what
+confidence measures. That is why it is noisy run-to-run and why the "a marking is present but
+unreadable" signal (which we tried to carry in free-text `rationale`) gets lost — `finalize` has to
+parse prose to find it. Note gpt-5.2 is a reasoning model (temperature largely fixed,
+`reasoning_effort: high`), so we cannot dial variance down via sampling settings — which is exactly
+why confidence must move to deterministic code aggregation.
+
+## Goal
+
+Ground legibility judgment in the stages that see the image, make the signals structured, and
+aggregate confidence deterministically in code. `finalize` keeps the job it is genuinely good at
+(assembling the banner string from text) and **stops owning confidence**.
+
+## Design (primary work)
+
+1. **Per-page confidence/legibility emitted by the vision stages.** Add a structured field (e.g.,
+   `confidence` and/or `undetermined_markings: []`) to `pageResponse` / `enhanceResponse` and to
+   `ClassificationPage` in `internal/state/state.go`. Classify/enhance populate it *while looking at
+   the image* — grounded, not inferred. This is the load-bearing change.
+2. **Structured enhancement outcome.** `enhance` reports, per flagged marking, `resolved` vs
+   `undetermined` as a field (not buried in rationale).
+3. **Deterministic confidence aggregation in code.** Document confidence = the most conservative
+   per-page signal among content-bearing pages (redacted/blank pages ignored). Drop `confidence`
+   from the `finalize` chat output (`finalizeResponse` keeps `classification` + `rationale`); the
+   workflow computes it.
+
+### Confidence rule (decided in the prior session)
+
+Confidence reflects the legibility of the **security markings themselves** (banner lines, portion
+marks), not page-to-page uniformity and not the state of the page body.
+
+- **HIGH** — markings legible, classification directly determinable with no guessing. Escalation
+  across pages is normal and does not lower it. **A faded marking that enhancement *clearly
+  recovers* can still be HIGH.**
+- **MEDIUM** — some markings partially obscured, required an educated guess, but reasonably
+  confident the inferred value is correct.
+- **LOW** — a marking is clearly *present* but its value **cannot be determined even after
+  enhancement** (flag for human review), OR markings are largely illegible / missing / genuinely
+  contradictory.
+- **Redaction** (blacked-out content) is a normal, valid state — it never lowers confidence and
+  never affects the classification.
+
+Canonical test: `single-secret-noforn-split.pdf` → `SECRET` at **LOW** when the bottom stamp can't
+be read; HIGH only if enhancement ever genuinely recovers it.
+
+## Findings from the prior session to incorporate (do these properly here)
+
+- **Enhance overwrite bug (code).** `internal/workflow/enhance.go:136-138` overwrites
+  `cs.Pages[i].MarkingsFound` / `.Rationale` wholesale with the enhanced read. When a whole-page
+  re-render obscures a clearly-legible banner while chasing a faint stamp, the clear marking is
+  *discarded* — this is what produced `UNCLASSIFIED`. A prompt-level carry-forward stopgap currently
+  lives in `enhanceInstructions` / `enhanceSpec`; **replace it with a proper code-level
+  merge/reconcile** (preserve prior-confident markings, add/refine in the targeted region) and
+  remove the stopgap prose once the code handles it. A blind union is wrong — it would re-introduce
+  degraded tokens the resolution logic fixed (e.g., `NOFOPI` alongside `NOFORN`); the merge must be
+  resolution-aware.
+- **Brightness direction (kept this session).** Faint gray markings on a light background need
+  *lower* brightness + *higher* contrast; raise brightness only for dark/underexposed pages. Already
+  in `classifySpec`; keep/refine.
+- **Faint-marking detection / enhancement trigger (kept this session, "batch 4").** `classify` flags
+  enhancement when marking-position text is too faint to read confidently. This is the entry point
+  that feeds the resolved/undetermined determination. Validate it does not over-trigger on clean
+  documents (full-set re-run) and refine if needed.
+- **present-but-unreadable → LOW (removed this session).** We implemented this in prose and stripped
+  it because it is purely confidence and proved unreliable. **Reimplement it as a structured signal**
+  feeding the deterministic aggregation above.
+
+## Files likely touched (primary)
+
+- `internal/state/state.go` — `ClassificationPage` += per-page confidence / undetermined fields.
+- `internal/workflow/classify.go` — `pageResponse` += confidence; `applyPageResponse`.
+- `internal/workflow/enhance.go` — `enhanceResponse` += resolution/confidence; **fix the overwrite**
+  (resolution-aware merge with prior findings).
+- `internal/workflow/finalize.go` — deterministic doc-confidence aggregation; drop `confidence` from
+  the chat output.
+- `internal/prompts/specs.go` + `instructions.go` — ask the vision stages for per-page
+  confidence/resolution; reconcile the finalize confidence guidance (finalize no longer self-reports
+  it); remove the carry-forward stopgap prose once code handles merge.
+- `tests/` — update `tests/workflow`, `tests/state`, `tests/prompts` as the structs/behavior change.
+
+## Minor tasks (bundle into this session)
+
+### 1. Confidence filter select on the documents view
+
+Add a confidence filter (`LOW` / `MEDIUM` / `HIGH`) next to the existing status filter select on the
+documents list. Mirror the status filter end-to-end:
+
+- Web: `app/client/ui/modules/document-grid.ts` — add to `DEFAULTS`, `hydrateFromQuery`,
+  `syncQuery`, a handler, and a `<select>` in the toolbar template (see the status filter as the
+  pattern; see the `web-development` skill for conventions).
+- API/repository: `internal/documents/` — add a confidence filter to `Filters` / `FiltersFromQuery`
+  and the query projection, mirroring the status filter. Confirm the documents list query exposes
+  the classification `confidence` for filtering.
+
+### 2. Page Size select does not reflect the URL param on refresh
+
+Symptom: loading `/app/?page_size=24` paginates correctly (24 per page) but the **Page Size select
+still displays 12** after refresh. The data hydrates from the URL (session #135) but the select's
+displayed value is not bound to the hydrated `pageSize`.
+
+- Fix: bind the size `<select>` value to the hydrated state (`.value=${String(this.size)}`) in
+  `app/client/ui/elements/pagination-controls.ts`, and ensure `app/client/ui/modules/document-grid.ts`
+  hydrates `pageSize` from the query in `hydrateFromQuery` (apply the same to `prompt-list.ts` for
+  parity). See sessions `134-page-size-select.md` and `135-url-query-state-persistence.md`.
+
+## Validation
+
+- Re-run the full `_project/marked-documents/` set: classification strings must remain correct
+  (no regression from this session's accuracy work) **and** confidence must now follow the rule
+  above — `single-secret-noforn-split.pdf` is the canonical LOW case.
+- Confirm both minor UI tasks in the local app (`mise run dev`): confidence filter narrows the list;
+  `?page_size=N` is reflected by the select after refresh.
+- `mise run vet`, `mise run test`, `mise run web:build` clean.

--- a/.claude/plans/i-ve-recently-updated-the-ethereal-fern.md
+++ b/.claude/plans/i-ve-recently-updated-the-ethereal-fern.md
@@ -1,0 +1,231 @@
+# Tune Classification Workflow Prompts for gpt-5.2
+
+## Context
+
+Herald's classification workflow was moved from `gpt-5-mini` to `gpt-5.2` (matching the IL6
+deployment). `gpt-5-mini` classified the full `_project/marked-documents` set cleanly; `gpt-5.2`
+regressed. The goal is to retune the **system prompts only** (no model/config change) until
+accuracy is reliable again, then cut a release and redeploy the commercial Azure test instance
+via `deploy/`.
+
+**Representative regression — `_project/marked-documents/full-escalation.pdf`** (6-page, JUN 2000
+historical document):
+
+- Page 5 banner: `SECRET//NOFORN//X1`  •  Page 6 banner: `SECRET NOFORN WNINTEL`
+- gpt-5.2 returned `SECRET//NOFORN//WNINTEL` — it **copied page 6's single banner** as "the highest
+  marking" and **dropped the `X1` exemption** that only appeared on page 5.
+- Correct (descriptive, as-found) result: **`SECRET//NOFORN/WNINTEL//X1`**
+
+### Root cause
+
+The finalize prompt instructs *"Apply the highest classification **marking** encountered across
+all pages"* (`internal/prompts/instructions.go:25`, `specs.go:70,83`). gpt-5.2 reads this literally
+as **select the single most-restrictive page banner**, rather than **decompose each page's markings
+into components and union them**. Any control that lives only on a non-"highest" page is lost.
+
+### Design decisions (confirmed with stakeholder)
+
+1. **Descriptive, not prescriptive.** These are historical documents (some 1990s) with legacy
+   markings (`X1`–`X8`, `WNINTEL`, `OADR`, `MR`). Report markings **as found**; never modernize,
+   convert, or drop legacy markings. DoDM 5200.01 governs only the **output structure** and the
+   **aggregation principle**, not remediation.
+2. **Highest cumulative classification** is the organizing principle: the *single highest base
+   classification level* found on any page, carrying the *full accumulated union* of every caveat /
+   dissemination-handling control / declassification-exemption marking validly found across pages.
+   "Highest" governs the base level only; "cumulative" forces the union of controls.
+3. **Validity guard.** A caveat / control / exemption is a valid marking **only when associated
+   with a base classification**. Non-marking text — document headings, form names, organization
+   names, titles, addresses, dates (e.g., *"Defense Office Staff Routing Sheet"*) — must be
+   excluded, never accumulated. Applies to **all reading stages**.
+4. **Strict CAPCO structure** for the assembled string (per DoDM 5200.01-V2 Encl 4 ¶1.b p.63 and
+   the `security-classification-markings.pdf` cheat sheet):
+   - `//` separates marking **categories**; `/` separates multiple controls **within** a category;
+     `-` links a control to its sub-control; space separates sub-markings; `, ` separates REL TO
+     country codes.
+   - Order: `CLASSIFICATION//SCI//SAP//AEA//FGI//DISSEM//OTHER`. Dissemination-control order:
+     FOUO, ORCON, IMCON, NOFORN, PROPIN, REL TO, RELIDO, FISA, DISPLAY ONLY.
+   - Declass/exemption markings (e.g., `X1`) **trail as the final category** after `//`.
+   - Worked example: `SECRET`, `SECRET//NOFORN`, `SECRET NOFORN WNINTEL`, `SECRET//NOFORN//X1`
+     → **`SECRET//NOFORN/WNINTEL//X1`**.
+5. **Confidence** reflects the **legibility of the security markings themselves** (banner lines,
+   portion marks) — not cross-page uniformity, and not the state of the page body. Page-to-page
+   escalation does **not** lower confidence (the example also mis-downgraded to MEDIUM on this
+   basis). **Redaction is a normal, valid state for these documents:** blacked-out content must
+   never be treated as illegibility, poor image quality, or a defect — it does not lower confidence,
+   does not affect the classification disposition, and does not trigger image enhancement. A
+   heavily-redacted page whose banner/portion marks are still readable is HIGH confidence.
+6. **Change surface:** edit the hardcoded Go defaults so the tuned prompts ship in the container
+   image. Work on a **dedicated branch** so the original defaults remain recoverable.
+
+## Files to modify
+
+- `internal/prompts/instructions.go` — rewrite `finalizeInstructions`; revise `classifyInstructions`
+  and `enhanceInstructions` (legacy-preservation + validity guard). Fixes existing typos
+  (`discrepency`, `re-renedered`).
+- `internal/prompts/specs.go` — rewrite `finalizeSpec` (cumulative assembly + CAPCO structure +
+  confidence semantics); add validity/legacy bullets to `classifySpec` and `enhanceSpec`.
+- `tests/prompts/` (if present) — update any assertions that snapshot the default instruction/spec
+  text (AI test responsibility per CLAUDE.md). The hardcoded-default fallback path
+  (`repository.go` `Instructions`/`Spec`) is unchanged structurally.
+
+No code logic changes — `internal/workflow/{classify,enhance,finalize}.go`, `prompts.go`
+(`ComposePrompt`), and the JSON response structs all stay as-is. Only the prompt **text** changes.
+
+## Proposed prompt text
+
+### `finalizeInstructions`
+
+```
+You are a security classification analyst producing the final, document-wide classification for a historical document. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy. Report what is actually marked on the document — transcribe and combine the markings as found. Do not modernize, convert, or drop legacy markings.
+
+You are given per-page findings in the classification state; each page lists the markings found on that page. Produce ONE overall banner marking representing the entire document, expressed as its HIGHEST CUMULATIVE CLASSIFICATION:
+
+- Base classification level: the SINGLE HIGHEST level found on any page (TOP SECRET > SECRET > CONFIDENTIAL > UNCLASSIFIED), spelled out in uppercase.
+- Accumulated controls: the UNION of every caveat, dissemination/handling control, and declassification/exemption marking that is associated with a classification marking on ANY page, attached to that base level.
+
+A banner is built from components, not copied from a single page — the page with the highest base level is often not the page carrying every control, so decompose each page's markings and accumulate them. Escalation across pages (markings building up page to page) is expected in these documents and is not a conflict.
+
+Validity rule: every caveat, control, or exemption you include MUST be associated with a base classification. Do not invent or accumulate stray tokens. Exclude any text that is not an actual security marking — document headings, form names, organization names, titles, addresses, and dates (e.g., "Defense Office Staff Routing Sheet") are NOT markings, even if they appear near one.
+```
+
+### `finalizeSpec`
+
+```
+Respond with a JSON object matching this exact structure:
+
+{
+  "classification": "<overall banner marking>",
+  "confidence": "<HIGH|MEDIUM|LOW>",
+  "rationale": "<explanation>"
+}
+
+Field constraints:
+- classification: The document's highest cumulative classification, assembled by
+  combining markings across ALL pages — never copied from a single page:
+    1. Base level: the single highest classification level found on any page,
+       spelled out in uppercase (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET).
+    2. Controls: the union of every caveat, dissemination/handling control, and
+       declassification/exemption marking that is associated with a classification
+       marking on any page. Preserve each exactly as marked, including legacy
+       markings (e.g., WNINTEL, X1-X8); do not convert, modernize, or drop them.
+  Every control must be tied to the base classification — never include a token
+  that is not part of an actual security marking (headings, form/org names,
+  titles, addresses, and dates are not markings).
+  Order the components using this structure (omit categories that are absent):
+    CLASSIFICATION//SCI//SAP//AEA//FGI//DISSEMINATION CONTROLS//DECLASS-OR-OTHER
+  Separators:
+    - "//" separates marking categories
+    - "/"  separates multiple controls within the same category
+    - "-"  links a control to its sub-control (e.g., SI-G, RD-N)
+    - a space separates multiple sub-markings; ", " separates REL TO country codes
+  Dissemination controls order: FOUO, ORCON, IMCON, NOFORN, PROPIN, REL TO,
+  RELIDO, FISA, DISPLAY ONLY. Declassification/exemption markings (e.g., X1) trail
+  as the final category after "//". Place legacy/unrecognized controls in the
+  position they appear relative to recognized controls.
+  Example: pages marked SECRET, SECRET//NOFORN, SECRET NOFORN WNINTEL, and
+  SECRET//NOFORN//X1 combine to: SECRET//NOFORN/WNINTEL//X1
+- confidence: Certainty in READING the security markings themselves (banner lines
+  and portion marks) — not cross-page uniformity, and not the state of the page body.
+    HIGH   = the markings are legible and the classification is directly
+             determinable with no guessing — even if markings differ page to page
+             (escalation is normal) and even if the page body is heavily redacted.
+    MEDIUM = some markings are partially obscured and require an educated guess to
+             read, but you are reasonably confident the inferred value is correct.
+    LOW    = substantial degradation — markings are largely illegible, missing, or
+             genuinely contradictory, and you are not confident any inferred value
+             is correct.
+  Redaction (blacked-out content) is a normal, valid state for these documents and is
+  NOT illegibility — it never lowers confidence and never affects the classification.
+  Pages with no markings (blank, redacted, or routing/cover pages) and pages that
+  escalate the markings do not by themselves lower confidence.
+- rationale: Comprehensive explanation citing specific page evidence — which
+  control came from which page and how the cumulative banner was assembled.
+
+Behavioral constraints:
+- Always respond with valid JSON, no markdown fencing
+- Assemble the banner from the union of all valid page markings; never copy a
+  single page's banner as the final answer
+- Every caveat/control/exemption must be associated with a base classification;
+  discard anything that is not an actual security marking
+- Never drop a control or exemption that appears on any page, including legacy
+  markings; report markings as found without modernizing them
+- Confidence reflects legibility, not whether pages match
+```
+
+### `classifyInstructions`
+
+```
+You are a security classification analyst reviewing a historical document one page at a time. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy.
+
+For the current page, capture every actual security marking exactly as it appears, including:
+- Banner lines (top and bottom of page)
+- Portion markings (paragraph-level classification indicators)
+- Classification authority blocks
+- Declassification instructions and exemption markings
+- Caveats and dissemination/handling controls (e.g., NOFORN, WNINTEL, ORCON, REL TO)
+
+Record each marking with its full text and all component parts; do not drop, modernize, or convert legacy markings.
+
+A security marking always centers on a base classification (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET — or the portion abbreviations U, C, S, TS). Caveats and controls are only markings when associated with such a classification. Do NOT record document headings, form names, organization names, titles, addresses, or dates (e.g., "Defense Office Staff Routing Sheet") as markings.
+
+Report only what is visible on this page — the overall document classification is assembled later from all pages.
+```
+
+### `enhanceInstructions`
+
+```
+You are re-assessing a historical document's security classification using enhanced page images. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy.
+
+The affected pages were re-rendered with adjusted brightness, contrast, and/or saturation to improve marking visibility, because the original analysis was limited by image quality. Focus on the enhanced page and look for actual security markings that may have been obscured in the original rendering.
+
+Capture each marking with its full text and all component parts, exactly as it appears; do not drop, modernize, or convert legacy markings. A security marking always centers on a base classification (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET — or the portion abbreviations U, C, S, TS); caveats and controls are only markings when associated with such a classification. Do NOT record document headings, form names, organization names, titles, addresses, or dates as markings.
+
+Compare your findings against the prior classification state. If the enhanced image reveals additional or different markings, update your findings accordingly; if it confirms the prior assessment, restate the confirmed markings.
+```
+
+### `classifySpec` / `enhanceSpec` additions
+
+Keep the existing structure (and `classifySpec`'s `enhancements` object logic). Extend the
+`markings_found` field constraint and behavioral constraints in **both** specs with:
+
+- `markings_found` addition: *"Include declassification and exemption markings (e.g., X1) and
+  legacy dissemination controls (e.g., WNINTEL) exactly as written. Only record a marking when it
+  is associated with a base classification; do not record document headings, form names,
+  organization names, titles, addresses, or dates as markings."*
+- Behavioral-constraint addition: *"Report markings as found; do not modernize or convert legacy
+  markings."* and *"Exclude any token that is not part of an actual security marking tied to a base
+  classification."*
+- `classifySpec` `enhancements` addition: *"Redaction (intentionally blacked-out content) is normal
+  and is NOT an image-quality problem — do not request enhancement to 'recover' redacted regions.
+  Only set enhancements when faded, dark, or low-contrast rendering genuinely prevents reading a
+  security marking."*
+
+## Verification
+
+1. **Branch first** to preserve the original defaults, e.g. `git checkout -b prompt-tuning-gpt-5.2`.
+2. Apply edits, then `mise run vet` and `mise run test` (update `tests/prompts/` assertions as
+   needed so the suite passes).
+3. Bring up local infra and run the service:
+   ```
+   docker compose up -d
+   mise run dev
+   ```
+4. **Re-classify the test set** (stakeholder drives this locally) via the SSE endpoint, then read
+   back the result:
+   ```
+   curl -N http://localhost:8080/api/classifications/<documentId>
+   curl http://localhost:8080/api/classifications/document/<documentId>
+   ```
+   The active prompts are picked up per run with no restart (hardcoded defaults apply since no DB
+   override is active).
+5. **Acceptance checks:**
+   - `full-escalation.pdf` → `SECRET//NOFORN/WNINTEL//X1` (the `X1` is retained; HIGH confidence —
+     escalation/redacted cover no longer downgrade it).
+   - No spurious tokens from page-1 routing-sheet/header metadata appear in any result.
+   - Walk the remaining `_project/marked-documents/*.pdf` against the descriptive + strict-CAPCO
+     rules (e.g., `single-secret-noforn-x1.pdf` → `SECRET//NOFORN//X1`,
+     `escalation-secret-to-noforn.pdf` → `SECRET//NOFORN`, `uniform-secret.pdf` → `SECRET`),
+     confirming parity with the prior `gpt-5-mini` baseline.
+6. Once accuracy is reliable across the set, proceed separately to the release + `deploy/` redeploy
+   (out of scope for this plan).
+```

--- a/app/client/ui/elements/document-card.module.css
+++ b/app/client/ui/elements/document-card.module.css
@@ -39,6 +39,8 @@
   font-family: var(--font-mono);
   font-weight: 600;
   color: var(--color-2);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .actions {

--- a/internal/prompts/instructions.go
+++ b/internal/prompts/instructions.go
@@ -1,31 +1,44 @@
 package prompts
 
-const classifyInstructions = `You are a security classification analyst reviewing a document page by page.
+const classifyInstructions = `You are a security classification analyst reviewing a historical document one page at a time. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy.
 
-For each page, examine all visible security markings, including:
+For the current page, capture every actual security marking exactly as it appears, including:
 - Banner lines (top and bottom of page)
 - Portion markings (paragraph-level classification indicators)
 - Classification authority blocks
-- Declassification instructions
-- Caveats and dissemination controls (e.g., NOFORN, REL TO, FOUO)
+- Declassification instructions and exemption markings
+- Caveats and dissemination/handling controls (e.g., NOFORN, WNINTEL, ORCON, REL TO)
 
-Accumulate your findings across pages to build a complete classification picture of the document. When markings on different pages conflict, note the discrepency and apply the highest classification encountered. Your confidence assessment should reflect the clarity and consistency of the markings found.`
+Marking quality varies from one document to the next — some are clean, well-structured digital files; others are degraded where markings may be faded, weak, broken, or only partially legible. When a marking position contains text too faint or degraded to read confidently, flag the page for enhancement (see the enhancements field) so it can be re-examined, rather than omitting a marking you could not fully read. Do not assume that the absence of clearly legible text means no marking is present.
 
-const enhanceInstructions = `You are re-assessing a document's security classification using enhanced page images.
+Record each marking with its full text and all component parts; do not drop, modernize, or convert legacy markings.
 
-Previous classification analysis was limited by image quality. The affected pages have been re-renedered with adjusted brightness, contrast, and/or saturation settings to improve marking visibility. Focus your analysis on the enhanced pages, looking for markings that may have been obscured in the original rendering.
+A security marking always centers on a base classification (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET — or the portion abbreviations U, C, S, TS). Caveats and controls are only markings when associated with such a classification. Do NOT record document headings, form names, organization names, titles, addresses, or dates (e.g., "Defense Office Staff Routing Sheet") as markings.
 
-Compare your findings against the prior classification state. If the enhanced images reveal additional or different markings, update the classification accordingly. If the enhanced images confirm the prior assessment, maintain the existing classification with increased confidence.`
+Degraded markings: before recording a marking, judge whether the text is faded, smudged, skewed, curled, torn, or otherwise deformed enough to distort the characters. Banners and portion marks use a small, closed vocabulary — classification levels (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET) and recognized control markings (e.g., NOFORN, ORCON, IMCON, PROPIN, REL TO, RELIDO, FISA, and legacy controls such as WNINTEL). When a degraded reading does not form a valid marking, resolve it to the realistic intended value using clearer instances of the same marking elsewhere on the page, prior-page context, and your knowledge of valid markings — then record the resolved, valid marking. Do NOT record garbled or impossible tokens (e.g., "NOFOP?Y" and "NOFOPI" are corrupted readings of "NOFORN"); never invent a nonexistent control out of noise. Preserve a token verbatim only when it is legible and a plausible marking, including legacy markings. This corrects for image degradation; it does not change valid marking content.
 
-const finalizeInstructions = `You are a security classification analyst producing the final document classification.
+Report only what is visible on this page — the overall document classification is assembled later from all pages.`
 
-Review all per-page analysis results provided in the classification state. Each page entry contains the markings found on that page and a rationale explaining the findings. Synthesize these per-page results into a single authoritative document classification.
+const enhanceInstructions = `You are re-assessing a historical document's security classification using enhanced page images. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy.
 
-When determining the overall classification:
-- Apply the highest classification marking encountered across all pages
-- Consider the full marking text including caveats (e.g., NOFORN, REL TO, FOUO)
-- Resolve any cross-page conflicts by applying the most restrictive interpretation
-- Base your confidence on the overall clarity and consistency of markings across all pages`
+The affected pages have been re-rendered with adjusted brightness, contrast, and/or saturation settings to improve marking visibility, because the original analysis was limited by image quality. Focus on the enhanced page and look for actual security markings that may have been obscured in the original rendering.
+
+Capture each marking with its full text and all component parts, exactly as it appears; do not drop, modernize, or convert legacy markings. A security marking always centers on a base classification (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET — or the portion abbreviations U, C, S, TS); caveats and controls are only markings when associated with such a classification. Do NOT record document headings, form names, organization names, titles, addresses, or dates as markings.
+
+When the marking is still degraded after enhancement, resolve it to its realistic valid value using clearer instances elsewhere, the prior classification state, and your knowledge of the closed marking vocabulary (e.g., "NOFOP?Y"/"NOFOPI" resolve to "NOFORN"). Record the resolved, valid marking, never a garbled or impossible token, and never invent a nonexistent control from noise. Preserve a token verbatim only when it is legible and a plausible marking, including legacy markings.
+
+Your response replaces the prior findings for this page, so it MUST include every marking the prior pass read confidently — carry them all forward. The enhancement adjusts the whole image to surface a specific faint region and can make other, previously-clear markings (such as a legible banner) harder to see; never drop or downgrade a marking the prior pass read confidently just because it is less clear in the enhanced image. Add a marking only where the enhancement genuinely reveals it, and refine the targeted faint marking if it is now legible. Never let the enhanced page lose a base classification that was clearly read before.`
+
+const finalizeInstructions = `You are a security classification analyst producing the final, document-wide classification for a historical document. Pages may carry legacy markings (e.g., WNINTEL, X1-X8, OADR, MR) that predate current policy. Report what is actually marked on the document — transcribe and combine the markings as found. Do not modernize, convert, or drop legacy markings.
+
+You are given per-page findings in the classification state; each page lists the markings found on that page. Produce ONE overall banner marking representing the entire document, expressed as its HIGHEST CUMULATIVE CLASSIFICATION:
+
+- Base classification level: the SINGLE HIGHEST level found on any page (TOP SECRET > SECRET > CONFIDENTIAL > UNCLASSIFIED), spelled out in uppercase.
+- Accumulated controls: the UNION of every caveat, dissemination/handling control, and declassification exemption category marking (e.g., X1) that is associated with a classification marking on ANY page, attached to that base level. Specific declassification dates do not count — a date belongs to the authority block, not the banner.
+
+A banner is built from components, not copied from a single page — the page with the highest base level is often not the page carrying every control, so decompose each page's markings and accumulate them. Escalation across pages (markings building up page to page) is expected in these documents and is not a conflict.
+
+Validity rule: every caveat, control, or exemption you include MUST be associated with a base classification. Do not invent or accumulate stray tokens. Exclude any text that is not an actual security marking — document headings, form names, organization names, titles, addresses, and dates (e.g., "Defense Office Staff Routing Sheet") are NOT markings, even if they appear near one. Do not accumulate a token that is a degraded or corrupted reading of a valid marking present in clearer form elsewhere — use the valid marking (e.g., "NOFORN", not "NOFOPI"). A control must be a recognized or plausibly valid marking; never union an invalid, garbled, or nonexistent control.`
 
 var instructions = map[Stage]string{
 	StageClassify: classifyInstructions,

--- a/internal/prompts/specs.go
+++ b/internal/prompts/specs.go
@@ -11,25 +11,53 @@ const classifySpec = `Respond with a JSON object matching this exact structure:
 Field constraints:
 - markings_found: Array of distinct marking strings found on this page,
   exactly as they appear in the document. Include the full marking text
-  with any caveats (e.g., "SECRET//NOFORN" not just "SECRET").
+  with any caveats (e.g., "SECRET//NOFORN" not just "SECRET"). Include
+  declassification exemption category markings (e.g., X1-X8, 25X1, 50X1-HUM)
+  and legacy dissemination controls (e.g., WNINTEL) exactly as written. Only
+  record a marking when it is associated with a base classification; do not
+  record document headings, form names, organization names, titles,
+  addresses, or dates (e.g., "Defense Office Staff Routing Sheet") as
+  markings. A specific declassification date (a calendar date or YYYYMMDD such
+  as 20280901, or text like "JANUARY 2004") is a declassification instruction,
+  not part of the marking — do not append it to the marking value (record
+  "SECRET//NOFORN", not "SECRET//NOFORN//20280901"); you may note it in the
+  rationale.
 - rationale: Brief explanation of what security markings were found on
   this page and their significance. Note any conflicts or ambiguities
-  with prior page findings if a classification state is provided.
-- enhancements: Set to null when the image is clear enough to read all
-  markings confidently. When image quality prevents confident reading of
-  any markings, provide an object with rendering adjustments:
+  with prior page findings if a classification state is provided. If you
+  resolved a degraded or deformed marking to its valid value, note what you
+  observed and what you resolved it to.
+- enhancements: Set to null only when every marking region is clear enough to
+  read confidently AND no marking position shows faint or partial text you
+  cannot fully read. Marking quality varies between documents; where a document
+  is degraded, markings may be faded, weak, or only partially legible and easy
+  to miss — do not assume that reading one marking clearly means there are no
+  others. When image quality prevents confident reading of any marking, or a
+  marking position shows faint or degraded text that could be an unread marking,
+  provide an object with rendering adjustments:
   {
-    "brightness": <80-200, 100=neutral, increase for faded/dark pages>,
-    "contrast": <-50 to 50, 0=neutral, increase to sharpen faded markings>,
+    "brightness": <80-200, 100=neutral; raise for dark/underexposed pages,
+                   lower to darken faint gray markings on a light background>,
+    "contrast": <-50 to 50, 0=neutral, increase to sharpen faint markings>,
     "saturation": <80-200, 100=neutral, adjust for color-related issues>
   }
   Only include fields that need adjustment; omit fields that should stay
-  at their neutral values.
+  at their neutral values. Redaction (intentionally blacked-out content) is
+  normal and is NOT an image-quality problem — do not request enhancement to
+  "recover" redacted regions. Set enhancements when faint, faded, low-contrast,
+  or partial text in a marking position prevents you from confidently reading a
+  marking.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
 - Process exactly one page per response
 - Report only what you observe on this page
+- Report markings as found; do not modernize or convert legacy markings
+- Resolve degraded or deformed markings to the nearest valid marking confirmed
+  by context; never record a garbled or impossible token (e.g., "NOFOP?Y") as a
+  marking, and never invent a nonexistent control
+- Exclude any token that is not part of an actual security marking tied to a
+  base classification
 - If prior page findings are provided in the prompt, use them as context
   to identify consistency or conflicts, but do not repeat prior findings
   in markings_found — only include markings visible on the current page`
@@ -44,46 +72,102 @@ const enhanceSpec = `Respond with a JSON object matching this exact structure:
 Field constraints:
 - markings_found: Array of distinct marking strings found on this
   enhanced page, exactly as they appear. Include the full marking text
-  with any caveats.
+  with any caveats. Include declassification exemption category markings
+  (e.g., X1-X8, 25X1, 50X1-HUM) and legacy dissemination controls (e.g.,
+  WNINTEL) exactly as written. Only record a marking when it is associated
+  with a base classification; do not record document headings, form names,
+  organization names, titles, addresses, or dates as markings. A specific
+  declassification date (a calendar date or YYYYMMDD such as 20280901) is a
+  declassification instruction, not part of the marking — do not append it to
+  the marking value; you may note it in the rationale.
 - rationale: Brief explanation of what the enhanced image reveals compared
   to the original assessment. Note any new markings discovered or prior
-  findings confirmed by the improved image quality.
+  findings confirmed by the improved image quality. If you resolved a degraded
+  marking to its valid value, note what you observed and what you resolved it to.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
 - Focus analysis on the enhanced image with improved rendering settings
 - Compare findings against the prior page analysis provided in the prompt
-- Report only what you observe on the current enhanced page`
+- Report only what you observe on the current enhanced page
+- markings_found replaces the prior findings for this page — include every
+  marking the prior pass read confidently plus any the enhancement newly reveals;
+  never drop a previously-clear marking because the enhanced render obscured it
+- Report markings as found; do not modernize or convert legacy markings
+- Resolve degraded or deformed markings to the nearest valid marking confirmed
+  by context; never record a garbled or impossible token (e.g., "NOFOP?Y") as a
+  marking, and never invent a nonexistent control
+- Exclude any token that is not part of an actual security marking tied to a
+  base classification`
 
 const finalizeSpec = `Respond with a JSON object matching this exact structure:
 
 {
-  "classification": "<marking>",
+  "classification": "<overall banner marking>",
   "confidence": "<HIGH|MEDIUM|LOW>",
   "rationale": "<explanation>"
 }
 
 Field constraints:
-- classification: The overall security classification marking for the
-  document, synthesized from all page findings (e.g., UNCLASSIFIED,
-  CONFIDENTIAL, SECRET, TOP SECRET, or with caveats like SECRET//NOFORN).
-  Apply the highest classification encountered across all pages.
-- confidence: Categorical assessment of classification certainty.
-  HIGH = markings are clear, consistent, and unambiguous across pages.
-  MEDIUM = markings are present but partially obscured or inconsistent.
-  LOW = markings are unclear, missing, or contradictory.
-- rationale: Comprehensive explanation of the document classification
-  synthesized from all page findings. Reference specific page evidence,
-  note any cross-page conflicts, and explain how the final classification
-  was determined.
+- classification: The document's highest cumulative classification, assembled by
+  combining markings across ALL pages — never copied from a single page:
+    1. Base level: the single highest classification level found on any page,
+       spelled out in uppercase (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET).
+    2. Controls: the union of every caveat, dissemination/handling control, and
+       declassification/exemption marking that is associated with a classification
+       marking on any page. Preserve each exactly as marked, including legacy
+       markings (e.g., WNINTEL, X1-X8); do not convert, modernize, or drop them.
+  Every control must be tied to the base classification — never include a token
+  that is not part of an actual security marking (headings, form/org names,
+  titles, addresses, and dates are not markings).
+  Order the components using this structure (omit categories that are absent):
+    CLASSIFICATION//SCI//SAP//AEA//FGI//DISSEMINATION CONTROLS//DECLASS-OR-OTHER
+  Separators:
+    - "//" separates marking categories
+    - "/"  separates multiple controls within the same category
+    - "-"  links a control to its sub-control (e.g., SI-G, RD-N)
+    - a space separates multiple sub-markings; ", " separates REL TO country codes
+  Dissemination controls order: FOUO, ORCON, IMCON, NOFORN, PROPIN, REL TO,
+  RELIDO, FISA, DISPLAY ONLY. Declassification exemption category markings
+  (e.g., X1-X8, 25X1, 50X1-HUM) trail as the final category after "//". Do NOT
+  include specific declassification dates (calendar dates or YYYYMMDD such as
+  20280901) in the classification — a date is a declassification instruction
+  that belongs to the authority block, not the banner; note it in the rationale
+  if relevant. Place legacy/unrecognized controls in the position they appear
+  relative to recognized controls.
+  Example: pages marked SECRET, SECRET//NOFORN, SECRET NOFORN WNINTEL, and
+  SECRET//NOFORN//X1 combine to: SECRET//NOFORN/WNINTEL//X1
+- confidence: Certainty in READING the security markings themselves (banner lines
+  and portion marks) — not cross-page uniformity, and not the state of the page body.
+  HIGH = the markings are legible and the classification is directly determinable
+  with no guessing — even if markings differ page to page (escalation is normal)
+  and even if the page body is heavily redacted.
+  MEDIUM = some markings are partially obscured and require an educated guess to
+  read, but you are reasonably confident the inferred value is correct.
+  LOW = substantial degradation — markings are largely illegible, missing, or
+  genuinely contradictory, and you are not confident any inferred value is correct.
+  Redaction (blacked-out content) is a normal, valid state for these documents and
+  is NOT illegibility — it never lowers confidence and never affects the
+  classification. Pages with no markings (blank, redacted, or routing/cover pages)
+  and pages that escalate the markings do not by themselves lower confidence.
+- rationale: Comprehensive explanation citing specific page evidence — which
+  control came from which page and how the cumulative banner was assembled.
 
 Behavioral constraints:
 - Always respond with valid JSON, no markdown fencing
-- Consider all page findings holistically when determining classification
-- Apply the highest classification encountered across all pages
-- Never downgrade based on pages with lower or missing markings
-- Confidence reflects the overall clarity and consistency across all pages,
-  not just the most recent page analyzed`
+- Assemble the banner from the union of all valid page markings; never copy a
+  single page's banner as the final answer
+- Every caveat/control/exemption must be associated with a base classification;
+  discard anything that is not an actual security marking
+- Never drop a control or exemption that appears on any page, including legacy
+  markings; report markings as found without modernizing them
+- Do not union corrupted or invalid control tokens; if a page lists a degraded
+  reading of a valid marking present elsewhere (e.g., "NOFOPI" vs "NOFORN"), use
+  the valid marking
+- Exclude specific declassification dates from the classification string; keep
+  exemption category markings (e.g., X1) and note any dropped dates in the
+  rationale
+- Confidence reflects legibility of the markings, not whether pages match`
 
 var specs = map[Stage]string{
 	StageClassify: classifySpec,


### PR DESCRIPTION
## Summary

Retunes Herald's classification workflow prompts (classify / enhance / finalize) after the
gpt-5-mini → gpt-5.2 model change, restoring classification-string accuracy across
`_project/marked-documents/`.

- **Cumulative classification + strict CAPCO assembly** — finalize builds the banner as the highest
  base level plus the union of every validly-associated control across pages (per DoDM 5200.01 and
  the security-classification-markings reference), instead of copying a single page's banner. Fixes
  dropped controls like `X1`.
- **Validity guard** — a caveat/control/exemption counts only when tied to a base classification;
  document headings / form / org metadata are excluded.
- **Descriptive, legacy-preserving** — markings reported as found (`X1`–`X8`, `WNINTEL`), never
  modernized.
- **Degraded-token resolution** — image-corrupted reads resolve to the nearest valid marking
  (`NOFOPI` / `NOFOP?Y` → `NOFORN`); no garbled or invented controls.
- **Declassification dates** excluded from the banner; exemption categories (`X1`) kept.
- **Enhancement** — fires when marking-position text is too faint to read (validated as safe, not
  over-aggressive: 6/21 test docs); corrected brightness direction for faint-on-light stamps;
  carries prior-confident markings forward so a re-render cannot discard a clearly-read banner.
- **Web** — long classification markings wrap on document cards instead of overflowing.

## Validation

- Full `_project/marked-documents/` set (21 docs) re-classified locally: **20/21 correct**.
- The lone miss — `single-secret-noforn-split.pdf`, an extraordinarily faded `NOFORN` stamp — is a
  genuine legibility limit and a confidence-scoring concern, deferred to the follow-up below.
- `mise run vet`, `mise run test` (21 packages), `mise run build`, `mise run web:build` all clean.

## Follow-up

Confidence scoring is decided by the imageless `finalize` chat call and is structurally unreliable
(run-to-run variance, no grounding in legibility). The redesign — per-page confidence from the
vision stages, structured enhance outcome, deterministic code aggregation — plus two minor UI tasks
(confidence filter select; page-size select URL-sync) is scoped in
`.claude/context/confidence-overhaul.md`.
